### PR TITLE
Proposed Add to terminology section

### DIFF
--- a/landscape.html
+++ b/landscape.html
@@ -44,11 +44,13 @@
       <p>
        This document uses the following terms defined elsewhere:
       </p>
-  <dl>
-    <dt><dfn title="HTTPServer" id="HTTPServer">HTTP Server</dfn></dt><dd>
-     An application program that accepts connections in order to service HTTP requests by sending back HTTP responses [[!di-gloss]]
-    </dd>
 	<dl>
+	<dt><dfn title="CoAP" id="CoAP">CoAP</dfn></dt><dd>
+	Acronym for Constrained Application Protocol [[!rfc7252]]
+	</dd>
+        <dt><dfn title="HTTPServer" id="HTTPServer">HTTP Server</dfn></dt><dd>
+            An application program that accepts connections in order to service HTTP requests by sending back HTTP responses [[!di-gloss]]
+         </dd>
 	 <dt><dfn title="iot" id="dfn-iot">Internet of things (IoT)</dfn></dt><dd>
 		A global infrastructure for the information society, enabling advanced services by interconnecting (physical and virtual) things based on existing and evolving interoperable information and communication technologies.  [ITU-T Y.2060]
 	 </dd>

--- a/landscape.html
+++ b/landscape.html
@@ -57,6 +57,9 @@
 	 <dt><dfn title="iri" id="dfn-iri">IRI</dfn></dt><dd>
 	 Acronym for Internationalized Resource Identifier. An IRI is a sequence of characters from the Universal Character Set (Unicode/ISO 10646) [[rfc3987]]	
 	 </dd>
+	 <dt><dfn title="json" id="json">JSON</dfn></dt><dd>
+	 Acronym for JavaScript Object Notation [[!RFC4627]] [[ECMA-404]]	
+	 </dd>
 	 <dt><dfn title="resource" id="dfn-resource">Resource</dfn></dt><dd>
 	 Anything that might be identified by a URI or IRI [[!webarch]]
  	</dd>

--- a/landscape.html
+++ b/landscape.html
@@ -22,10 +22,10 @@
                  value: "Master branch on GitHub",
                  href: "https://github.com/w3c/wot/blob/master/tech-landscape/landscape.html"
                }, {
-                value: 'File a bug.',
+                value: 'File a bug',
                 href: 'https://github.com/w3c/wot/issues'
                }, {
-                value: 'Commit history.',
+                value: 'Commit history',
                 href: 'https://github.com/w3c/wot/commits/gh-pages'
                }
               ]

--- a/landscape.html
+++ b/landscape.html
@@ -21,6 +21,12 @@
                {
                  value: "Master branch on GitHub",
                  href: "https://github.com/w3c/wot/blob/master/tech-landscape/landscape.html"
+               }, {
+                value: 'File a bug.',
+                href: 'https://github.com/w3c/wot/issues'
+               }, {
+                value: 'Commit history.',
+                href: 'https://github.com/w3c/wot/commits/gh-pages'
                }
               ]
             }

--- a/landscape.html
+++ b/landscape.html
@@ -39,6 +39,52 @@
         This is a template to capture the inputs from the wiki into a deliverable format.
       </p>
     </section>
+    <section>    	
+	<h2>Terminology</h2>
+      <p>
+       This document uses the following terms defined elsewhere:
+      </p>
+  <dl>
+    <dt><dfn title="HTTPServer" id="HTTPServer">HTTP Server</dfn></dt><dd>
+     An application program that accepts connections in order to service HTTP requests by sending back HTTP responses [[!di-gloss]]
+    </dd>
+	<dl>
+	 <dt><dfn title="iot" id="dfn-iot">Internet of things (IoT)</dfn></dt><dd>
+		A global infrastructure for the information society, enabling advanced services by interconnecting (physical and virtual) things based on existing and evolving interoperable information and communication technologies.  [ITU-T Y.2060]
+	 </dd>
+	 <dt><dfn title="iri" id="dfn-iri">IRI</dfn></dt><dd>
+	 Acronym for Internationalized Resource Identifier. An IRI is a sequence of characters from the Universal Character Set (Unicode/ISO 10646) [[rfc3987]]	
+	 </dd>
+	 <dt><dfn title="resource" id="dfn-resource">Resource</dfn></dt><dd>
+	 Anything that might be identified by a URI or IRI [[!webarch]]
+ 	</dd>
+	 <dt><dfn title="thing" id="dfn-thing">Thing</dfn></dt><dd>
+	With regard to the Internet of things, this is an object of the physical world (physical things) or the information world (virtual things), which is capable of being identified and integrated into communication networks.  [ITU-T Y.2060]
+	 </dd>
+	 <dt><dfn title="Thing Description" id="thing-description">Thing Description</dfn></dt><dd>
+	 Description about a thing - interfaces, data and aspects of a Thing 
+	 </dd>
+	 <dt><dfn title="URI" id="dfn-URI">URI</dfn></dt><dd>
+	Acronym for Uniform Resource Identifier. A simple and extensible means for identifying a resource. [[!rfc3986]]
+	</dd>
+	 <dt><dfn title="user agent" id="dfn-UA">User Agent</dfn></dt><dd>
+	 One type of Web agent; a piece of software acting on behalf of a person. Browsers are examples of user agents, as are web robots that automatically traverse the web collecting information. [[di-gloss]] [[webarch]]
+	</dd>
+	<dt><dfn titile="web agent" id="dfn-WA">Web agent</dfn></dt><dd>
+	A person or a piece of software acting on the information space on behalf of a person, entity, or process. [[!webarch]]	
+	</dd>
+	 <dt><dfn title="web of tings" id="dfn-wot">Web of Things (WoT)</dfn></dt><dd>
+	A way to realize the IoT where (physical and virtual) things are connected and controlled through the World Wide Web.  [ITU-T Y.2063]
+	</dd>
+	<dt><dfn title="WoT Client" id="dfn-wot-client">WoT Client</dfn></dt><dd>
+	a logical entity that accesses an WoT Resource on an WoT Server	
+	</dd>
+	 <dt><dfn title="WWW" id="dfn-WWW">World Wide Web</dfn></dt><dd>
+	An information space in which the items of interest, referred to as resources, are identified by global identifiers called Uniform Resource Identifiers (URI). [[!webarch]]
+	</dd>
+	</dL>
+	</section>
+	
     <section>
       <h2>Tech landscape for Thing description</h2>
       <section>


### PR DESCRIPTION
I'd like to propose change the landscape document on gh-pages. 

Anyone can access it directly via this link - https://w3c.github.io/wot/landscape.html 
