### PR TITLE
Leading text in 2.1of WG Charter

### DIFF
--- a/charters/wot-wg-2016.html
+++ b/charters/wot-wg-2016.html
@@ -193,6 +193,8 @@
 
 <h3>Thing Descriptions</h3>
 
+<p>Thing Descriptions are Metadata for describing thing. The Working Group will seek to specify:</p>
+
 <ul>
 <li><p>A Linked Data vocabulary for describing things in terms of the data and interaction  models they expose to applications. This will cover thing lifecycles, datatypes, including streams, integrity constraints, and provision for early and late binding. This cross domain vocabulary will be designed for use in combination with vocabularies for domain specific semantics and metadata. Consideration will be given to the means for describing the stability of data models and metadata, and how they evolve over time. This is needed to manage interdependencies, and is analogous to the role of metadata for package management in the Linux operating system.</p></li>
 


### PR DESCRIPTION
In 2.1 Thing Descriptions, Leading text is missing. The definition of Thing Descriptions is also necessary.