### PR TITLE
Clarification of IF point in 2.3 of WG Charter

### DIFF
--- a/charters/wot-wg-2016.html
+++ b/charters/wot-wg-2016.html
@@ -232,7 +232,7 @@
 
 <h3>Bindings to Common Platforms and Protocols</h3>
 
-<p>To enable interoperability, the Working Group will seek to define standard bindings to common platforms and protocols in close collaboration with the industry alliances and standards development organizations responsible for these. This includes definition of mappings from the ”interactions" (actions, properties, events etc.) at the application layer, via abstract messages at the thing layer, to:</p>
+<p>To enable interoperability, the Working Group will seek to define standard bindings to common platforms and protocols which the server exposes to clients or other servers, in close collaboration with the industry alliances and standards development organizations responsible for these. This includes definition of mappings from the ”interactions" (actions, properties, events etc.) at the application layer, via abstract messages at the thing layer, to:</p>
 
 <ul>
   <li><p>Transfer layer communication patterns, push, pull, pub-sub, bi-directional messaging, etc.</p></li>


### PR DESCRIPTION
In 2.3 Bindings to Common Platforms and Protocols, it is unclear which interface is subject to this bindings, so an explanation is added.