### PR TITLE
[wg-charter] add end date

### DIFF
--- a/charters/wot-wg-2016.html
+++ b/charters/wot-wg-2016.html
@@ -107,7 +107,7 @@
               End date
             </th>
             <td>
-              <i class="todo">[dd monthname yyyy]</i>
+              31 December 2018 (same end date as the IG)
             </td>
           </tr>
 <!--


### PR DESCRIPTION
According to the discussion during today's IG call (https://www.w3.org/2016/08/03-wot-minutes.html), I've just created a branch to add "31 December 2018" as the end date for the proposed WoT WG.