### PR TITLE
Proposal for a WoT Ontology

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,8 @@ after_success:
   - cp -R charters/ page/
   - mkdir -p page/proposals/explicit-bindings
   - cp  proposals/explicit-bindings/abstract-transfer-layer.html page/proposals/explicit-bindings/abstract-transfer-layer.html
+  - cp  proposals/ontology/ire-extended.owl page/ire-extended.owl
+  - cp  proposals/ontology/wot.owl page/wot.owl
   - cd page
   - echo "https://${GH_TOKEN}:@github.com" > .git/credentials
   - git add wot-ucr.html
@@ -29,5 +31,7 @@ after_success:
   - git add architecture/
   - git add charters/
   - git add proposals/explicit-bindings/abstract-transfer-layer.html
+  - git add ire-extended.owl
+  - git add wot.owl
   - if [[ $TRAVIS_PULL_REQUEST == 'false' ]]; then git diff-index --quiet --cached HEAD || git commit -m"automated commit from Travis CI"; fi
   - if [[ $TRAVIS_PULL_REQUEST == 'false' ]]; then git push https://github.com/w3c/wot.git gh-pages; fi

--- a/proposals/ontology/README.md
+++ b/proposals/ontology/README.md
@@ -1,0 +1,29 @@
+# An Ontology for WoT
+
+This proposal for a WoT ontology mostly defines five concepts:
+- __Thing Description__ - Semantic resource formally describing a unique WoT
+Thing that a software agent can interact with. Examples of WoT Things include
+building rooms, manufactured products, mechanical systems but also digital
+control devices, i.e. any real-world entity without a priori restriction.
+- __Interaction__ - Web resource of arbitrary content format acting as a digital
+proxy for any real-world entity that is not already digital information. Such
+entities can be physical quantities like temperature or pressure, natural
+phenomena like raise of temperature or object motion, arbitrary states like
+on/off, etc.
+- __Property__ - Time-independent real-world entity that is neither an Action,
+nor an Event. For instance, physical quantities (temperature, pressure,
+brigthness...) are Properties.
+- __Action__ - Real-world entity characterizing particular time intervals,
+possibly influencing some Properties. Non-immediate natural phenomena (e.g.
+heating) or functionalities provided by a cyber-physical system (open, close,
+switch, toggle...) are Actions.
+- __Event__ - Real-world entity characterizing particular instants, possibly
+related to some Properties. State changes or sensor measurements are Events.
+
+For a formal definition of these concepts, see
+http://w3c.github.io/wot/proposals/ontology/wot.owl. It is based on the IRE
+(Identifier/Resource/Entity) ontology. See
+
+> Presutti, V., & Gangemi, A. (2010). Identity of Resources and Entities on the Web. In M. Lytras, & A. Sheth (Eds.) Progressive Concepts for Semantic Web Evolution: Applications and Developments (pp. 123-147). Hershey, PA: Information Science Reference. doi:10.4018/978-1-60566-992-2.ch007
+
+More details to be published in a workshop paper.

--- a/proposals/ontology/README.md
+++ b/proposals/ontology/README.md
@@ -9,7 +9,7 @@ control devices, i.e. any real-world entity without a priori restriction.
 proxy for any real-world entity that is not already digital information. Such
 entities can be physical quantities like temperature or pressure, natural
 phenomena like raise of temperature or object motion, arbitrary states like
-on/off, etc.
+on/off, etc.
 - __Property__ - Time-independent real-world entity that is neither an Action,
 nor an Event. For instance, physical quantities (temperature, pressure,
 brigthness...) are Properties.

--- a/proposals/ontology/ire-extended.owl
+++ b/proposals/ontology/ire-extended.owl
@@ -1,0 +1,362 @@
+<?xml version="1.0"?>
+
+
+<!DOCTYPE rdf:RDF [
+    <!ENTITY owl "http://www.w3.org/2002/07/owl#" >
+    <!ENTITY xsd "http://www.w3.org/2001/XMLSchema#" >
+    <!ENTITY skos "http://www.w3.org/2004/02/skos/core#" >
+    <!ENTITY daml "http://www.daml.org/2001/03/daml+oil#" >
+    <!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#" >
+    <!ENTITY DUL "http://www.ontologydesignpatterns.org/ont/dul/DUL.owl#" >
+    <!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#" >
+    <!ENTITY KCO "http://www.loa-cnr.it/ontologies/KCO/KCO.owl#" >
+    <!ENTITY dol "http://www.loa-cnr.it/ontologies/DOLCE-Lite.owl#" >
+    <!ENTITY edns "http://www.loa-cnr.it/ontologies/ExtendedDnS.owl#" >
+    <!ENTITY inf "http://www.loa-cnr.it/ontologies/InformationObjects.owl#" >
+]>
+
+
+<rdf:RDF xmlns="http://w3c.github.io/wot/proposals/ontology/ire-extended.owl#"
+     xml:base="http://w3c.github.io/wot/proposals/ontology/ire-extended.owl"
+     xmlns:DUL="http://www.ontologydesignpatterns.org/ont/dul/DUL.owl#"
+     xmlns:dol="http://www.loa-cnr.it/ontologies/DOLCE-Lite.owl#"
+     xmlns:inf="http://www.loa-cnr.it/ontologies/InformationObjects.owl#"
+     xmlns:daml="http://www.daml.org/2001/03/daml+oil#"
+     xmlns:edns="http://www.loa-cnr.it/ontologies/ExtendedDnS.owl#"
+     xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+     xmlns:owl="http://www.w3.org/2002/07/owl#"
+     xmlns:xsd="http://www.w3.org/2001/XMLSchema#"
+     xmlns:KCO="http://www.loa-cnr.it/ontologies/KCO/KCO.owl#"
+     xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+     xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+    <owl:Ontology rdf:about="http://w3c.github.io/wot/proposals/ontology/ire-extended.owl">
+        <owl:versionInfo rdf:datatype="&xsd;float">0.7</owl:versionInfo>
+        <rdfs:comment rdf:datatype="&xsd;string">Original version: http://www.loa-cnr.it/ontologies/IRE/IRE.owl</rdfs:comment>
+        <owl:imports rdf:resource="http://www.ontologydesignpatterns.org/ont/dul/DUL.owl"/>
+    </owl:Ontology>
+
+
+
+    <!--
+    ///////////////////////////////////////////////////////////////////////////////////////
+    //
+    // Annotation properties
+    //
+    ///////////////////////////////////////////////////////////////////////////////////////
+     -->
+
+
+
+
+    <!-- http://www.w3.org/2004/02/skos/core#closeMatch -->
+
+    <owl:AnnotationProperty rdf:about="&skos;closeMatch"/>
+
+
+
+    <!--
+    ///////////////////////////////////////////////////////////////////////////////////////
+    //
+    // Datatypes
+    //
+    ///////////////////////////////////////////////////////////////////////////////////////
+     -->
+
+
+
+
+    <!-- http://www.w3.org/2001/XMLSchema#anyURI -->
+
+    <rdfs:Datatype rdf:about="&xsd;anyURI"/>
+
+
+
+    <!-- http://www.w3.org/2001/XMLSchema#string -->
+
+    <rdfs:Datatype rdf:about="&xsd;string"/>
+
+
+
+    <!--
+    ///////////////////////////////////////////////////////////////////////////////////////
+    //
+    // Object Properties
+    //
+    ///////////////////////////////////////////////////////////////////////////////////////
+     -->
+
+
+
+
+    <!-- http://w3c.github.io/wot/proposals/ontology/ire-extended.owl#approximateProxyFor -->
+
+    <owl:ObjectProperty rdf:about="http://w3c.github.io/wot/proposals/ontology/ire-extended.owl#approximateProxyFor">
+        <rdfs:domain rdf:resource="http://w3c.github.io/wot/proposals/ontology/ire-extended.owl#WebResource"/>
+        <rdfs:subPropertyOf rdf:resource="http://w3c.github.io/wot/proposals/ontology/ire-extended.owl#proxyFor"/>
+    </owl:ObjectProperty>
+
+
+
+    <!-- http://w3c.github.io/wot/proposals/ontology/ire-extended.owl#exactProxyFor -->
+
+    <owl:ObjectProperty rdf:about="http://w3c.github.io/wot/proposals/ontology/ire-extended.owl#exactProxyFor">
+        <rdfs:subPropertyOf rdf:resource="http://w3c.github.io/wot/proposals/ontology/ire-extended.owl#proxyFor"/>
+    </owl:ObjectProperty>
+
+
+
+    <!-- http://w3c.github.io/wot/proposals/ontology/ire-extended.owl#formalExactProxyFor -->
+
+    <owl:ObjectProperty rdf:about="http://w3c.github.io/wot/proposals/ontology/ire-extended.owl#formalExactProxyFor">
+        <rdfs:domain rdf:resource="http://w3c.github.io/wot/proposals/ontology/ire-extended.owl#SemanticResource"/>
+        <rdfs:subPropertyOf rdf:resource="http://w3c.github.io/wot/proposals/ontology/ire-extended.owl#exactProxyFor"/>
+        <rdfs:subPropertyOf rdf:resource="http://w3c.github.io/wot/proposals/ontology/ire-extended.owl#proxyFor"/>
+    </owl:ObjectProperty>
+
+
+
+    <!-- http://w3c.github.io/wot/proposals/ontology/ire-extended.owl#hasWebLocation -->
+
+    <owl:ObjectProperty rdf:about="http://w3c.github.io/wot/proposals/ontology/ire-extended.owl#hasWebLocation">
+        <rdfs:range rdf:resource="http://w3c.github.io/wot/proposals/ontology/ire-extended.owl#AbstractWebLocation"/>
+        <rdfs:domain rdf:resource="http://w3c.github.io/wot/proposals/ontology/ire-extended.owl#WebResource"/>
+    </owl:ObjectProperty>
+
+
+
+    <!-- http://w3c.github.io/wot/proposals/ontology/ire-extended.owl#informalExactProxyFor -->
+
+    <owl:ObjectProperty rdf:about="http://w3c.github.io/wot/proposals/ontology/ire-extended.owl#informalExactProxyFor">
+        <rdfs:domain rdf:resource="http://w3c.github.io/wot/proposals/ontology/ire-extended.owl#Resource"/>
+        <rdfs:subPropertyOf rdf:resource="http://w3c.github.io/wot/proposals/ontology/ire-extended.owl#exactProxyFor"/>
+        <rdfs:subPropertyOf rdf:resource="http://w3c.github.io/wot/proposals/ontology/ire-extended.owl#proxyFor"/>
+    </owl:ObjectProperty>
+
+
+
+    <!-- http://w3c.github.io/wot/proposals/ontology/ire-extended.owl#nonResolvableProxyFor -->
+
+    <owl:ObjectProperty rdf:about="http://w3c.github.io/wot/proposals/ontology/ire-extended.owl#nonResolvableProxyFor">
+        <rdfs:subPropertyOf rdf:resource="http://w3c.github.io/wot/proposals/ontology/ire-extended.owl#proxyFor"/>
+    </owl:ObjectProperty>
+
+
+
+    <!-- http://w3c.github.io/wot/proposals/ontology/ire-extended.owl#proxyFor -->
+
+    <owl:ObjectProperty rdf:about="http://w3c.github.io/wot/proposals/ontology/ire-extended.owl#proxyFor">
+        <rdfs:domain rdf:resource="http://w3c.github.io/wot/proposals/ontology/ire-extended.owl#Resource"/>
+        <rdfs:range rdf:resource="&DUL;Entity"/>
+    </owl:ObjectProperty>
+
+
+
+    <!-- http://w3c.github.io/wot/proposals/ontology/ire-extended.owl#resolvableProxyFor -->
+
+    <owl:ObjectProperty rdf:about="http://w3c.github.io/wot/proposals/ontology/ire-extended.owl#resolvableProxyFor">
+        <rdfs:subPropertyOf rdf:resource="http://w3c.github.io/wot/proposals/ontology/ire-extended.owl#proxyFor"/>
+    </owl:ObjectProperty>
+
+
+
+    <!-- http://w3c.github.io/wot/proposals/ontology/ire-extended.owl#webLocationOf -->
+
+    <owl:ObjectProperty rdf:about="http://w3c.github.io/wot/proposals/ontology/ire-extended.owl#webLocationOf">
+        <rdfs:domain rdf:resource="http://w3c.github.io/wot/proposals/ontology/ire-extended.owl#AbstractWebLocation"/>
+        <rdfs:range rdf:resource="http://w3c.github.io/wot/proposals/ontology/ire-extended.owl#WebResource"/>
+        <owl:inverseOf rdf:resource="http://w3c.github.io/wot/proposals/ontology/ire-extended.owl#hasWebLocation"/>
+    </owl:ObjectProperty>
+
+
+
+    <!-- http://www.ontologydesignpatterns.org/ont/dul/DUL.owl#isAbout -->
+
+    <owl:ObjectProperty rdf:about="&DUL;isAbout"/>
+
+
+
+    <!-- http://www.ontologydesignpatterns.org/ont/dul/DUL.owl#isReferenceOf -->
+
+    <owl:ObjectProperty rdf:about="&DUL;isReferenceOf"/>
+
+
+
+    <!-- http://www.ontologydesignpatterns.org/ont/dul/DUL.owl#realizes -->
+
+    <owl:ObjectProperty rdf:about="&DUL;realizes"/>
+
+
+
+    <!--
+    ///////////////////////////////////////////////////////////////////////////////////////
+    //
+    // Data properties
+    //
+    ///////////////////////////////////////////////////////////////////////////////////////
+     -->
+
+
+
+
+    <!-- http://w3c.github.io/wot/proposals/ontology/ire-extended.owl#hasIdentifier -->
+
+    <owl:DatatypeProperty rdf:about="http://w3c.github.io/wot/proposals/ontology/ire-extended.owl#hasIdentifier">
+        <rdf:type rdf:resource="&owl;FunctionalProperty"/>
+        <rdfs:domain rdf:resource="&DUL;SpaceRegion"/>
+        <rdfs:range rdf:resource="&xsd;string"/>
+    </owl:DatatypeProperty>
+
+
+
+    <!-- http://w3c.github.io/wot/proposals/ontology/ire-extended.owl#hasURI -->
+
+    <owl:DatatypeProperty rdf:about="http://w3c.github.io/wot/proposals/ontology/ire-extended.owl#hasURI">
+        <rdf:type rdf:resource="&owl;FunctionalProperty"/>
+        <rdfs:domain rdf:resource="http://w3c.github.io/wot/proposals/ontology/ire-extended.owl#AbstractWebLocation"/>
+        <rdfs:range rdf:resource="&xsd;anyURI"/>
+    </owl:DatatypeProperty>
+
+
+
+    <!--
+    ///////////////////////////////////////////////////////////////////////////////////////
+    //
+    // Classes
+    //
+    ///////////////////////////////////////////////////////////////////////////////////////
+     -->
+
+
+
+
+    <!-- http://w3c.github.io/wot/proposals/ontology/ire-extended.owl#AbstractWebLocation -->
+
+    <owl:Class rdf:about="http://w3c.github.io/wot/proposals/ontology/ire-extended.owl#AbstractWebLocation">
+        <rdfs:subClassOf rdf:resource="&DUL;SpaceRegion"/>
+    </owl:Class>
+
+
+
+    <!-- http://w3c.github.io/wot/proposals/ontology/ire-extended.owl#ProxyResource -->
+
+    <owl:Class rdf:about="http://w3c.github.io/wot/proposals/ontology/ire-extended.owl#ProxyResource">
+        <owl:equivalentClass>
+            <owl:Class>
+                <owl:intersectionOf rdf:parseType="Collection">
+                    <rdf:Description rdf:about="http://w3c.github.io/wot/proposals/ontology/ire-extended.owl#WebResource"/>
+                    <owl:Restriction>
+                        <owl:onProperty rdf:resource="http://w3c.github.io/wot/proposals/ontology/ire-extended.owl#proxyFor"/>
+                        <owl:someValuesFrom rdf:resource="&DUL;Entity"/>
+                    </owl:Restriction>
+                </owl:intersectionOf>
+            </owl:Class>
+        </owl:equivalentClass>
+        <rdfs:subClassOf rdf:resource="http://w3c.github.io/wot/proposals/ontology/ire-extended.owl#WebResource"/>
+    </owl:Class>
+
+
+
+    <!-- http://w3c.github.io/wot/proposals/ontology/ire-extended.owl#ResolutionMethod -->
+
+    <owl:Class rdf:about="http://w3c.github.io/wot/proposals/ontology/ire-extended.owl#ResolutionMethod">
+        <rdfs:subClassOf rdf:resource="&DUL;Method"/>
+    </owl:Class>
+
+
+
+    <!-- http://w3c.github.io/wot/proposals/ontology/ire-extended.owl#Resource -->
+
+    <owl:Class rdf:about="http://w3c.github.io/wot/proposals/ontology/ire-extended.owl#Resource">
+        <rdfs:subClassOf rdf:resource="&DUL;InformationRealization"/>
+        <rdfs:comment rdf:datatype="&xsd;string">A computational object that might be seen as a proxy for some entity.
+Possible: a resource can enter a resolution method.</rdfs:comment>
+    </owl:Class>
+
+
+
+    <!-- http://w3c.github.io/wot/proposals/ontology/ire-extended.owl#SemanticResource -->
+
+    <owl:Class rdf:about="http://w3c.github.io/wot/proposals/ontology/ire-extended.owl#SemanticResource">
+        <owl:equivalentClass>
+            <owl:Class>
+                <owl:intersectionOf rdf:parseType="Collection">
+                    <rdf:Description rdf:about="http://w3c.github.io/wot/proposals/ontology/ire-extended.owl#ProxyResource"/>
+                    <owl:Restriction>
+                        <owl:onProperty rdf:resource="http://w3c.github.io/wot/proposals/ontology/ire-extended.owl#formalExactProxyFor"/>
+                        <owl:onClass rdf:resource="&DUL;Entity"/>
+                        <owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
+                    </owl:Restriction>
+                </owl:intersectionOf>
+            </owl:Class>
+        </owl:equivalentClass>
+        <rdfs:subClassOf rdf:resource="http://w3c.github.io/wot/proposals/ontology/ire-extended.owl#ProxyResource"/>
+    </owl:Class>
+
+
+
+    <!-- http://w3c.github.io/wot/proposals/ontology/ire-extended.owl#WebResource -->
+
+    <owl:Class rdf:about="http://w3c.github.io/wot/proposals/ontology/ire-extended.owl#WebResource">
+        <owl:equivalentClass>
+            <owl:Class>
+                <owl:intersectionOf rdf:parseType="Collection">
+                    <rdf:Description rdf:about="http://w3c.github.io/wot/proposals/ontology/ire-extended.owl#Resource"/>
+                    <owl:Class>
+                        <owl:unionOf rdf:parseType="Collection">
+                            <owl:Restriction>
+                                <owl:onProperty rdf:resource="http://w3c.github.io/wot/proposals/ontology/ire-extended.owl#approximateProxyFor"/>
+                                <owl:onClass rdf:resource="&DUL;Entity"/>
+                                <owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">2</owl:minQualifiedCardinality>
+                            </owl:Restriction>
+                            <owl:Restriction>
+                                <owl:onProperty rdf:resource="http://w3c.github.io/wot/proposals/ontology/ire-extended.owl#exactProxyFor"/>
+                                <owl:onClass rdf:resource="&DUL;Entity"/>
+                                <owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
+                            </owl:Restriction>
+                        </owl:unionOf>
+                    </owl:Class>
+                    <owl:Restriction>
+                        <owl:onProperty rdf:resource="http://w3c.github.io/wot/proposals/ontology/ire-extended.owl#hasWebLocation"/>
+                        <owl:someValuesFrom rdf:resource="http://w3c.github.io/wot/proposals/ontology/ire-extended.owl#AbstractWebLocation"/>
+                    </owl:Restriction>
+                </owl:intersectionOf>
+            </owl:Class>
+        </owl:equivalentClass>
+        <rdfs:subClassOf rdf:resource="http://w3c.github.io/wot/proposals/ontology/ire-extended.owl#Resource"/>
+        <skos:closeMatch rdf:resource="http://www.w3.org/ns/hydra/core#Resource"/>
+    </owl:Class>
+
+
+
+    <!-- http://www.ontologydesignpatterns.org/ont/dul/DUL.owl#Entity -->
+
+    <owl:Class rdf:about="&DUL;Entity"/>
+
+
+
+    <!-- http://www.ontologydesignpatterns.org/ont/dul/DUL.owl#InformationObject -->
+
+    <owl:Class rdf:about="&DUL;InformationObject"/>
+
+
+
+    <!-- http://www.ontologydesignpatterns.org/ont/dul/DUL.owl#InformationRealization -->
+
+    <owl:Class rdf:about="&DUL;InformationRealization"/>
+
+
+
+    <!-- http://www.ontologydesignpatterns.org/ont/dul/DUL.owl#Method -->
+
+    <owl:Class rdf:about="&DUL;Method"/>
+
+
+
+    <!-- http://www.ontologydesignpatterns.org/ont/dul/DUL.owl#SpaceRegion -->
+
+    <owl:Class rdf:about="&DUL;SpaceRegion"/>
+</rdf:RDF>
+
+
+
+<!-- Generated by the OWL API (version 3.4.2) http://owlapi.sourceforge.net -->

--- a/proposals/ontology/ire-extended.owl
+++ b/proposals/ontology/ire-extended.owl
@@ -5,39 +5,39 @@
     <!ENTITY owl "http://www.w3.org/2002/07/owl#" >
     <!ENTITY xsd "http://www.w3.org/2001/XMLSchema#" >
     <!ENTITY skos "http://www.w3.org/2004/02/skos/core#" >
-    <!ENTITY daml "http://www.daml.org/2001/03/daml+oil#" >
     <!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#" >
-    <!ENTITY DUL "http://www.ontologydesignpatterns.org/ont/dul/DUL.owl#" >
+    <!ENTITY daml "http://www.daml.org/2001/03/daml+oil#" >
     <!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#" >
     <!ENTITY KCO "http://www.loa-cnr.it/ontologies/KCO/KCO.owl#" >
     <!ENTITY dol "http://www.loa-cnr.it/ontologies/DOLCE-Lite.owl#" >
     <!ENTITY edns "http://www.loa-cnr.it/ontologies/ExtendedDnS.owl#" >
+    <!ENTITY DUL "http://www.ontologydesignpatterns.org/ont/dul/DUL.owl#" >
     <!ENTITY inf "http://www.loa-cnr.it/ontologies/InformationObjects.owl#" >
 ]>
 
 
-<rdf:RDF xmlns="http://w3c.github.io/wot/proposals/ontology/ire-extended.owl#"
-     xml:base="http://w3c.github.io/wot/proposals/ontology/ire-extended.owl"
-     xmlns:DUL="http://www.ontologydesignpatterns.org/ont/dul/DUL.owl#"
-     xmlns:dol="http://www.loa-cnr.it/ontologies/DOLCE-Lite.owl#"
+<rdf:RDF xmlns="http://w3c.github.io/wot/ire-extended.owl#"
+     xml:base="http://w3c.github.io/wot/ire-extended.owl"
      xmlns:inf="http://www.loa-cnr.it/ontologies/InformationObjects.owl#"
-     xmlns:daml="http://www.daml.org/2001/03/daml+oil#"
-     xmlns:edns="http://www.loa-cnr.it/ontologies/ExtendedDnS.owl#"
-     xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+     xmlns:dol="http://www.loa-cnr.it/ontologies/DOLCE-Lite.owl#"
      xmlns:owl="http://www.w3.org/2002/07/owl#"
      xmlns:xsd="http://www.w3.org/2001/XMLSchema#"
-     xmlns:KCO="http://www.loa-cnr.it/ontologies/KCO/KCO.owl#"
+     xmlns:skos="http://www.w3.org/2004/02/skos/core#"
+     xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+     xmlns:edns="http://www.loa-cnr.it/ontologies/ExtendedDnS.owl#"
+     xmlns:daml="http://www.daml.org/2001/03/daml+oil#"
      xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-     xmlns:skos="http://www.w3.org/2004/02/skos/core#">
-    <owl:Ontology rdf:about="http://w3c.github.io/wot/proposals/ontology/ire-extended.owl">
+     xmlns:KCO="http://www.loa-cnr.it/ontologies/KCO/KCO.owl#"
+     xmlns:DUL="http://www.ontologydesignpatterns.org/ont/dul/DUL.owl#">
+    <owl:Ontology rdf:about="http://w3c.github.io/wot/ire-extended.owl">
         <owl:versionInfo rdf:datatype="&xsd;float">0.7</owl:versionInfo>
         <rdfs:comment rdf:datatype="&xsd;string">Original version: http://www.loa-cnr.it/ontologies/IRE/IRE.owl</rdfs:comment>
         <owl:imports rdf:resource="http://www.ontologydesignpatterns.org/ont/dul/DUL.owl"/>
     </owl:Ontology>
+    
 
 
-
-    <!--
+    <!-- 
     ///////////////////////////////////////////////////////////////////////////////////////
     //
     // Annotation properties
@@ -45,16 +45,16 @@
     ///////////////////////////////////////////////////////////////////////////////////////
      -->
 
-
+    
 
 
     <!-- http://www.w3.org/2004/02/skos/core#closeMatch -->
 
     <owl:AnnotationProperty rdf:about="&skos;closeMatch"/>
+    
 
 
-
-    <!--
+    <!-- 
     ///////////////////////////////////////////////////////////////////////////////////////
     //
     // Datatypes
@@ -62,22 +62,22 @@
     ///////////////////////////////////////////////////////////////////////////////////////
      -->
 
-
+    
 
 
     <!-- http://www.w3.org/2001/XMLSchema#anyURI -->
 
     <rdfs:Datatype rdf:about="&xsd;anyURI"/>
-
+    
 
 
     <!-- http://www.w3.org/2001/XMLSchema#string -->
 
     <rdfs:Datatype rdf:about="&xsd;string"/>
+    
 
 
-
-    <!--
+    <!-- 
     ///////////////////////////////////////////////////////////////////////////////////////
     //
     // Object Properties
@@ -85,109 +85,109 @@
     ///////////////////////////////////////////////////////////////////////////////////////
      -->
 
+    
 
 
+    <!-- http://w3c.github.io/wot/ire-extended.owl#approximateProxyFor -->
 
-    <!-- http://w3c.github.io/wot/proposals/ontology/ire-extended.owl#approximateProxyFor -->
-
-    <owl:ObjectProperty rdf:about="http://w3c.github.io/wot/proposals/ontology/ire-extended.owl#approximateProxyFor">
-        <rdfs:domain rdf:resource="http://w3c.github.io/wot/proposals/ontology/ire-extended.owl#WebResource"/>
-        <rdfs:subPropertyOf rdf:resource="http://w3c.github.io/wot/proposals/ontology/ire-extended.owl#proxyFor"/>
+    <owl:ObjectProperty rdf:about="http://w3c.github.io/wot/ire-extended.owl#approximateProxyFor">
+        <rdfs:domain rdf:resource="http://w3c.github.io/wot/ire-extended.owl#WebResource"/>
+        <rdfs:subPropertyOf rdf:resource="http://w3c.github.io/wot/ire-extended.owl#proxyFor"/>
     </owl:ObjectProperty>
+    
 
 
+    <!-- http://w3c.github.io/wot/ire-extended.owl#exactProxyFor -->
 
-    <!-- http://w3c.github.io/wot/proposals/ontology/ire-extended.owl#exactProxyFor -->
-
-    <owl:ObjectProperty rdf:about="http://w3c.github.io/wot/proposals/ontology/ire-extended.owl#exactProxyFor">
-        <rdfs:subPropertyOf rdf:resource="http://w3c.github.io/wot/proposals/ontology/ire-extended.owl#proxyFor"/>
+    <owl:ObjectProperty rdf:about="http://w3c.github.io/wot/ire-extended.owl#exactProxyFor">
+        <rdfs:subPropertyOf rdf:resource="http://w3c.github.io/wot/ire-extended.owl#proxyFor"/>
     </owl:ObjectProperty>
+    
 
 
+    <!-- http://w3c.github.io/wot/ire-extended.owl#formalExactProxyFor -->
 
-    <!-- http://w3c.github.io/wot/proposals/ontology/ire-extended.owl#formalExactProxyFor -->
-
-    <owl:ObjectProperty rdf:about="http://w3c.github.io/wot/proposals/ontology/ire-extended.owl#formalExactProxyFor">
-        <rdfs:domain rdf:resource="http://w3c.github.io/wot/proposals/ontology/ire-extended.owl#SemanticResource"/>
-        <rdfs:subPropertyOf rdf:resource="http://w3c.github.io/wot/proposals/ontology/ire-extended.owl#exactProxyFor"/>
-        <rdfs:subPropertyOf rdf:resource="http://w3c.github.io/wot/proposals/ontology/ire-extended.owl#proxyFor"/>
+    <owl:ObjectProperty rdf:about="http://w3c.github.io/wot/ire-extended.owl#formalExactProxyFor">
+        <rdfs:domain rdf:resource="http://w3c.github.io/wot/ire-extended.owl#SemanticResource"/>
+        <rdfs:subPropertyOf rdf:resource="http://w3c.github.io/wot/ire-extended.owl#exactProxyFor"/>
+        <rdfs:subPropertyOf rdf:resource="http://w3c.github.io/wot/ire-extended.owl#proxyFor"/>
     </owl:ObjectProperty>
+    
 
 
+    <!-- http://w3c.github.io/wot/ire-extended.owl#hasWebLocation -->
 
-    <!-- http://w3c.github.io/wot/proposals/ontology/ire-extended.owl#hasWebLocation -->
-
-    <owl:ObjectProperty rdf:about="http://w3c.github.io/wot/proposals/ontology/ire-extended.owl#hasWebLocation">
-        <rdfs:range rdf:resource="http://w3c.github.io/wot/proposals/ontology/ire-extended.owl#AbstractWebLocation"/>
-        <rdfs:domain rdf:resource="http://w3c.github.io/wot/proposals/ontology/ire-extended.owl#WebResource"/>
+    <owl:ObjectProperty rdf:about="http://w3c.github.io/wot/ire-extended.owl#hasWebLocation">
+        <rdfs:range rdf:resource="http://w3c.github.io/wot/ire-extended.owl#AbstractWebLocation"/>
+        <rdfs:domain rdf:resource="http://w3c.github.io/wot/ire-extended.owl#WebResource"/>
     </owl:ObjectProperty>
+    
 
 
+    <!-- http://w3c.github.io/wot/ire-extended.owl#informalExactProxyFor -->
 
-    <!-- http://w3c.github.io/wot/proposals/ontology/ire-extended.owl#informalExactProxyFor -->
-
-    <owl:ObjectProperty rdf:about="http://w3c.github.io/wot/proposals/ontology/ire-extended.owl#informalExactProxyFor">
-        <rdfs:domain rdf:resource="http://w3c.github.io/wot/proposals/ontology/ire-extended.owl#Resource"/>
-        <rdfs:subPropertyOf rdf:resource="http://w3c.github.io/wot/proposals/ontology/ire-extended.owl#exactProxyFor"/>
-        <rdfs:subPropertyOf rdf:resource="http://w3c.github.io/wot/proposals/ontology/ire-extended.owl#proxyFor"/>
+    <owl:ObjectProperty rdf:about="http://w3c.github.io/wot/ire-extended.owl#informalExactProxyFor">
+        <rdfs:domain rdf:resource="http://w3c.github.io/wot/ire-extended.owl#Resource"/>
+        <rdfs:subPropertyOf rdf:resource="http://w3c.github.io/wot/ire-extended.owl#exactProxyFor"/>
+        <rdfs:subPropertyOf rdf:resource="http://w3c.github.io/wot/ire-extended.owl#proxyFor"/>
     </owl:ObjectProperty>
+    
 
 
+    <!-- http://w3c.github.io/wot/ire-extended.owl#nonResolvableProxyFor -->
 
-    <!-- http://w3c.github.io/wot/proposals/ontology/ire-extended.owl#nonResolvableProxyFor -->
-
-    <owl:ObjectProperty rdf:about="http://w3c.github.io/wot/proposals/ontology/ire-extended.owl#nonResolvableProxyFor">
-        <rdfs:subPropertyOf rdf:resource="http://w3c.github.io/wot/proposals/ontology/ire-extended.owl#proxyFor"/>
+    <owl:ObjectProperty rdf:about="http://w3c.github.io/wot/ire-extended.owl#nonResolvableProxyFor">
+        <rdfs:subPropertyOf rdf:resource="http://w3c.github.io/wot/ire-extended.owl#proxyFor"/>
     </owl:ObjectProperty>
+    
 
 
+    <!-- http://w3c.github.io/wot/ire-extended.owl#proxyFor -->
 
-    <!-- http://w3c.github.io/wot/proposals/ontology/ire-extended.owl#proxyFor -->
-
-    <owl:ObjectProperty rdf:about="http://w3c.github.io/wot/proposals/ontology/ire-extended.owl#proxyFor">
-        <rdfs:domain rdf:resource="http://w3c.github.io/wot/proposals/ontology/ire-extended.owl#Resource"/>
+    <owl:ObjectProperty rdf:about="http://w3c.github.io/wot/ire-extended.owl#proxyFor">
+        <rdfs:domain rdf:resource="http://w3c.github.io/wot/ire-extended.owl#Resource"/>
         <rdfs:range rdf:resource="&DUL;Entity"/>
     </owl:ObjectProperty>
+    
 
 
+    <!-- http://w3c.github.io/wot/ire-extended.owl#resolvableProxyFor -->
 
-    <!-- http://w3c.github.io/wot/proposals/ontology/ire-extended.owl#resolvableProxyFor -->
-
-    <owl:ObjectProperty rdf:about="http://w3c.github.io/wot/proposals/ontology/ire-extended.owl#resolvableProxyFor">
-        <rdfs:subPropertyOf rdf:resource="http://w3c.github.io/wot/proposals/ontology/ire-extended.owl#proxyFor"/>
+    <owl:ObjectProperty rdf:about="http://w3c.github.io/wot/ire-extended.owl#resolvableProxyFor">
+        <rdfs:subPropertyOf rdf:resource="http://w3c.github.io/wot/ire-extended.owl#proxyFor"/>
     </owl:ObjectProperty>
+    
 
 
+    <!-- http://w3c.github.io/wot/ire-extended.owl#webLocationOf -->
 
-    <!-- http://w3c.github.io/wot/proposals/ontology/ire-extended.owl#webLocationOf -->
-
-    <owl:ObjectProperty rdf:about="http://w3c.github.io/wot/proposals/ontology/ire-extended.owl#webLocationOf">
-        <rdfs:domain rdf:resource="http://w3c.github.io/wot/proposals/ontology/ire-extended.owl#AbstractWebLocation"/>
-        <rdfs:range rdf:resource="http://w3c.github.io/wot/proposals/ontology/ire-extended.owl#WebResource"/>
-        <owl:inverseOf rdf:resource="http://w3c.github.io/wot/proposals/ontology/ire-extended.owl#hasWebLocation"/>
+    <owl:ObjectProperty rdf:about="http://w3c.github.io/wot/ire-extended.owl#webLocationOf">
+        <rdfs:domain rdf:resource="http://w3c.github.io/wot/ire-extended.owl#AbstractWebLocation"/>
+        <rdfs:range rdf:resource="http://w3c.github.io/wot/ire-extended.owl#WebResource"/>
+        <owl:inverseOf rdf:resource="http://w3c.github.io/wot/ire-extended.owl#hasWebLocation"/>
     </owl:ObjectProperty>
-
+    
 
 
     <!-- http://www.ontologydesignpatterns.org/ont/dul/DUL.owl#isAbout -->
 
     <owl:ObjectProperty rdf:about="&DUL;isAbout"/>
-
+    
 
 
     <!-- http://www.ontologydesignpatterns.org/ont/dul/DUL.owl#isReferenceOf -->
 
     <owl:ObjectProperty rdf:about="&DUL;isReferenceOf"/>
-
+    
 
 
     <!-- http://www.ontologydesignpatterns.org/ont/dul/DUL.owl#realizes -->
 
     <owl:ObjectProperty rdf:about="&DUL;realizes"/>
+    
 
 
-
-    <!--
+    <!-- 
     ///////////////////////////////////////////////////////////////////////////////////////
     //
     // Data properties
@@ -195,30 +195,30 @@
     ///////////////////////////////////////////////////////////////////////////////////////
      -->
 
+    
 
 
+    <!-- http://w3c.github.io/wot/ire-extended.owl#hasIdentifier -->
 
-    <!-- http://w3c.github.io/wot/proposals/ontology/ire-extended.owl#hasIdentifier -->
-
-    <owl:DatatypeProperty rdf:about="http://w3c.github.io/wot/proposals/ontology/ire-extended.owl#hasIdentifier">
+    <owl:DatatypeProperty rdf:about="http://w3c.github.io/wot/ire-extended.owl#hasIdentifier">
         <rdf:type rdf:resource="&owl;FunctionalProperty"/>
         <rdfs:domain rdf:resource="&DUL;SpaceRegion"/>
         <rdfs:range rdf:resource="&xsd;string"/>
     </owl:DatatypeProperty>
+    
 
 
+    <!-- http://w3c.github.io/wot/ire-extended.owl#hasURI -->
 
-    <!-- http://w3c.github.io/wot/proposals/ontology/ire-extended.owl#hasURI -->
-
-    <owl:DatatypeProperty rdf:about="http://w3c.github.io/wot/proposals/ontology/ire-extended.owl#hasURI">
+    <owl:DatatypeProperty rdf:about="http://w3c.github.io/wot/ire-extended.owl#hasURI">
         <rdf:type rdf:resource="&owl;FunctionalProperty"/>
-        <rdfs:domain rdf:resource="http://w3c.github.io/wot/proposals/ontology/ire-extended.owl#AbstractWebLocation"/>
+        <rdfs:domain rdf:resource="http://w3c.github.io/wot/ire-extended.owl#AbstractWebLocation"/>
         <rdfs:range rdf:resource="&xsd;anyURI"/>
     </owl:DatatypeProperty>
+    
 
 
-
-    <!--
+    <!-- 
     ///////////////////////////////////////////////////////////////////////////////////////
     //
     // Classes
@@ -226,130 +226,130 @@
     ///////////////////////////////////////////////////////////////////////////////////////
      -->
 
+    
 
 
+    <!-- http://w3c.github.io/wot/ire-extended.owl#AbstractWebLocation -->
 
-    <!-- http://w3c.github.io/wot/proposals/ontology/ire-extended.owl#AbstractWebLocation -->
-
-    <owl:Class rdf:about="http://w3c.github.io/wot/proposals/ontology/ire-extended.owl#AbstractWebLocation">
+    <owl:Class rdf:about="http://w3c.github.io/wot/ire-extended.owl#AbstractWebLocation">
         <rdfs:subClassOf rdf:resource="&DUL;SpaceRegion"/>
     </owl:Class>
+    
 
 
+    <!-- http://w3c.github.io/wot/ire-extended.owl#ProxyResource -->
 
-    <!-- http://w3c.github.io/wot/proposals/ontology/ire-extended.owl#ProxyResource -->
-
-    <owl:Class rdf:about="http://w3c.github.io/wot/proposals/ontology/ire-extended.owl#ProxyResource">
+    <owl:Class rdf:about="http://w3c.github.io/wot/ire-extended.owl#ProxyResource">
         <owl:equivalentClass>
             <owl:Class>
                 <owl:intersectionOf rdf:parseType="Collection">
-                    <rdf:Description rdf:about="http://w3c.github.io/wot/proposals/ontology/ire-extended.owl#WebResource"/>
+                    <rdf:Description rdf:about="http://w3c.github.io/wot/ire-extended.owl#WebResource"/>
                     <owl:Restriction>
-                        <owl:onProperty rdf:resource="http://w3c.github.io/wot/proposals/ontology/ire-extended.owl#proxyFor"/>
+                        <owl:onProperty rdf:resource="http://w3c.github.io/wot/ire-extended.owl#proxyFor"/>
                         <owl:someValuesFrom rdf:resource="&DUL;Entity"/>
                     </owl:Restriction>
                 </owl:intersectionOf>
             </owl:Class>
         </owl:equivalentClass>
-        <rdfs:subClassOf rdf:resource="http://w3c.github.io/wot/proposals/ontology/ire-extended.owl#WebResource"/>
+        <rdfs:subClassOf rdf:resource="http://w3c.github.io/wot/ire-extended.owl#WebResource"/>
     </owl:Class>
+    
 
 
+    <!-- http://w3c.github.io/wot/ire-extended.owl#ResolutionMethod -->
 
-    <!-- http://w3c.github.io/wot/proposals/ontology/ire-extended.owl#ResolutionMethod -->
-
-    <owl:Class rdf:about="http://w3c.github.io/wot/proposals/ontology/ire-extended.owl#ResolutionMethod">
+    <owl:Class rdf:about="http://w3c.github.io/wot/ire-extended.owl#ResolutionMethod">
         <rdfs:subClassOf rdf:resource="&DUL;Method"/>
     </owl:Class>
+    
 
 
+    <!-- http://w3c.github.io/wot/ire-extended.owl#Resource -->
 
-    <!-- http://w3c.github.io/wot/proposals/ontology/ire-extended.owl#Resource -->
-
-    <owl:Class rdf:about="http://w3c.github.io/wot/proposals/ontology/ire-extended.owl#Resource">
+    <owl:Class rdf:about="http://w3c.github.io/wot/ire-extended.owl#Resource">
         <rdfs:subClassOf rdf:resource="&DUL;InformationRealization"/>
         <rdfs:comment rdf:datatype="&xsd;string">A computational object that might be seen as a proxy for some entity.
 Possible: a resource can enter a resolution method.</rdfs:comment>
     </owl:Class>
+    
 
 
+    <!-- http://w3c.github.io/wot/ire-extended.owl#SemanticResource -->
 
-    <!-- http://w3c.github.io/wot/proposals/ontology/ire-extended.owl#SemanticResource -->
-
-    <owl:Class rdf:about="http://w3c.github.io/wot/proposals/ontology/ire-extended.owl#SemanticResource">
+    <owl:Class rdf:about="http://w3c.github.io/wot/ire-extended.owl#SemanticResource">
         <owl:equivalentClass>
             <owl:Class>
                 <owl:intersectionOf rdf:parseType="Collection">
-                    <rdf:Description rdf:about="http://w3c.github.io/wot/proposals/ontology/ire-extended.owl#ProxyResource"/>
+                    <rdf:Description rdf:about="http://w3c.github.io/wot/ire-extended.owl#ProxyResource"/>
                     <owl:Restriction>
-                        <owl:onProperty rdf:resource="http://w3c.github.io/wot/proposals/ontology/ire-extended.owl#formalExactProxyFor"/>
+                        <owl:onProperty rdf:resource="http://w3c.github.io/wot/ire-extended.owl#formalExactProxyFor"/>
                         <owl:onClass rdf:resource="&DUL;Entity"/>
                         <owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
                     </owl:Restriction>
                 </owl:intersectionOf>
             </owl:Class>
         </owl:equivalentClass>
-        <rdfs:subClassOf rdf:resource="http://w3c.github.io/wot/proposals/ontology/ire-extended.owl#ProxyResource"/>
+        <rdfs:subClassOf rdf:resource="http://w3c.github.io/wot/ire-extended.owl#ProxyResource"/>
     </owl:Class>
+    
 
 
+    <!-- http://w3c.github.io/wot/ire-extended.owl#WebResource -->
 
-    <!-- http://w3c.github.io/wot/proposals/ontology/ire-extended.owl#WebResource -->
-
-    <owl:Class rdf:about="http://w3c.github.io/wot/proposals/ontology/ire-extended.owl#WebResource">
+    <owl:Class rdf:about="http://w3c.github.io/wot/ire-extended.owl#WebResource">
         <owl:equivalentClass>
             <owl:Class>
                 <owl:intersectionOf rdf:parseType="Collection">
-                    <rdf:Description rdf:about="http://w3c.github.io/wot/proposals/ontology/ire-extended.owl#Resource"/>
+                    <rdf:Description rdf:about="http://w3c.github.io/wot/ire-extended.owl#Resource"/>
                     <owl:Class>
                         <owl:unionOf rdf:parseType="Collection">
                             <owl:Restriction>
-                                <owl:onProperty rdf:resource="http://w3c.github.io/wot/proposals/ontology/ire-extended.owl#approximateProxyFor"/>
+                                <owl:onProperty rdf:resource="http://w3c.github.io/wot/ire-extended.owl#approximateProxyFor"/>
                                 <owl:onClass rdf:resource="&DUL;Entity"/>
                                 <owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">2</owl:minQualifiedCardinality>
                             </owl:Restriction>
                             <owl:Restriction>
-                                <owl:onProperty rdf:resource="http://w3c.github.io/wot/proposals/ontology/ire-extended.owl#exactProxyFor"/>
+                                <owl:onProperty rdf:resource="http://w3c.github.io/wot/ire-extended.owl#exactProxyFor"/>
                                 <owl:onClass rdf:resource="&DUL;Entity"/>
                                 <owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
                             </owl:Restriction>
                         </owl:unionOf>
                     </owl:Class>
                     <owl:Restriction>
-                        <owl:onProperty rdf:resource="http://w3c.github.io/wot/proposals/ontology/ire-extended.owl#hasWebLocation"/>
-                        <owl:someValuesFrom rdf:resource="http://w3c.github.io/wot/proposals/ontology/ire-extended.owl#AbstractWebLocation"/>
+                        <owl:onProperty rdf:resource="http://w3c.github.io/wot/ire-extended.owl#hasWebLocation"/>
+                        <owl:someValuesFrom rdf:resource="http://w3c.github.io/wot/ire-extended.owl#AbstractWebLocation"/>
                     </owl:Restriction>
                 </owl:intersectionOf>
             </owl:Class>
         </owl:equivalentClass>
-        <rdfs:subClassOf rdf:resource="http://w3c.github.io/wot/proposals/ontology/ire-extended.owl#Resource"/>
+        <rdfs:subClassOf rdf:resource="http://w3c.github.io/wot/ire-extended.owl#Resource"/>
         <skos:closeMatch rdf:resource="http://www.w3.org/ns/hydra/core#Resource"/>
     </owl:Class>
-
+    
 
 
     <!-- http://www.ontologydesignpatterns.org/ont/dul/DUL.owl#Entity -->
 
     <owl:Class rdf:about="&DUL;Entity"/>
-
+    
 
 
     <!-- http://www.ontologydesignpatterns.org/ont/dul/DUL.owl#InformationObject -->
 
     <owl:Class rdf:about="&DUL;InformationObject"/>
-
+    
 
 
     <!-- http://www.ontologydesignpatterns.org/ont/dul/DUL.owl#InformationRealization -->
 
     <owl:Class rdf:about="&DUL;InformationRealization"/>
-
+    
 
 
     <!-- http://www.ontologydesignpatterns.org/ont/dul/DUL.owl#Method -->
 
     <owl:Class rdf:about="&DUL;Method"/>
-
+    
 
 
     <!-- http://www.ontologydesignpatterns.org/ont/dul/DUL.owl#SpaceRegion -->
@@ -359,4 +359,5 @@ Possible: a resource can enter a resolution method.</rdfs:comment>
 
 
 
-<!-- Generated by the OWL API (version 3.4.2) http://owlapi.sourceforge.net -->
+<!-- Generated by the OWL API (version 3.5.0) http://owlapi.sourceforge.net -->
+

--- a/proposals/ontology/wot.owl
+++ b/proposals/ontology/wot.owl
@@ -3,23 +3,21 @@
 
 <!DOCTYPE rdf:RDF [
     <!ENTITY owl "http://www.w3.org/2002/07/owl#" >
+    <!ENTITY wot2 "http://w3c.github.io/wot/wot.owl#" >
     <!ENTITY xsd "http://www.w3.org/2001/XMLSchema#" >
-    <!ENTITY wot "http://w3c.github.io/wot/wot.owl#" >
     <!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#" >
     <!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#" >
-    <!ENTITY wot2 "http://w3c.github.io/wot/proposals/ontology/wot.owl#" >
 ]>
 
 
 <rdf:RDF xmlns="http://www.w3c.org/wot/td#"
      xml:base="http://www.w3c.org/wot/td"
-     xmlns:wot="http://w3c.github.io/wot/wot.owl#"
-     xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
-     xmlns:wot2="http://w3c.github.io/wot/proposals/ontology/wot.owl#"
+     xmlns:wot2="http://w3c.github.io/wot/wot.owl#"
+     xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
      xmlns:owl="http://www.w3.org/2002/07/owl#"
      xmlns:xsd="http://www.w3.org/2001/XMLSchema#"
-     xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
-    <owl:Ontology rdf:about="http://w3c.github.io/wot/proposals/ontology/wot.owl">
+     xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">
+    <owl:Ontology rdf:about="http://w3c.github.io/wot/wot.owl">
         <owl:versionInfo rdf:datatype="&xsd;decimal">2.1</owl:versionInfo>
         <created rdf:datatype="&xsd;string">2015-08-14</created>
         <title rdf:datatype="&xsd;string">Thing Description Model</title>
@@ -43,31 +41,31 @@
     
 
 
-    <!-- http://w3c.github.io/wot/proposals/ontology/wot.owl#created -->
+    <!-- http://w3c.github.io/wot/wot.owl#created -->
 
     <owl:AnnotationProperty rdf:about="&wot2;created"/>
     
 
 
-    <!-- http://w3c.github.io/wot/proposals/ontology/wot.owl#creator -->
+    <!-- http://w3c.github.io/wot/wot.owl#creator -->
 
     <owl:AnnotationProperty rdf:about="&wot2;creator"/>
     
 
 
-    <!-- http://w3c.github.io/wot/proposals/ontology/wot.owl#identifier -->
+    <!-- http://w3c.github.io/wot/wot.owl#identifier -->
 
     <owl:AnnotationProperty rdf:about="&wot2;identifier"/>
     
 
 
-    <!-- http://w3c.github.io/wot/proposals/ontology/wot.owl#modified -->
+    <!-- http://w3c.github.io/wot/wot.owl#modified -->
 
     <owl:AnnotationProperty rdf:about="&wot2;modified"/>
     
 
 
-    <!-- http://w3c.github.io/wot/proposals/ontology/wot.owl#title -->
+    <!-- http://w3c.github.io/wot/wot.owl#title -->
 
     <owl:AnnotationProperty rdf:about="&wot2;title"/>
     
@@ -96,7 +94,7 @@
     
 
 
-    <!-- http://w3c.github.io/wot/proposals/ontology/wot.owl#dependsOn -->
+    <!-- http://w3c.github.io/wot/wot.owl#dependsOn -->
 
     <owl:ObjectProperty rdf:about="&wot2;dependsOn">
         <rdfs:subPropertyOf rdf:resource="&wot2;isAssociatedTo"/>
@@ -104,7 +102,7 @@
     
 
 
-    <!-- http://w3c.github.io/wot/proposals/ontology/wot.owl#forProperty -->
+    <!-- http://w3c.github.io/wot/wot.owl#forProperty -->
 
     <owl:ObjectProperty rdf:about="&wot2;forProperty">
         <rdfs:range rdf:resource="&wot2;Property"/>
@@ -120,7 +118,7 @@
     
 
 
-    <!-- http://w3c.github.io/wot/proposals/ontology/wot.owl#hasAction -->
+    <!-- http://w3c.github.io/wot/wot.owl#hasAction -->
 
     <owl:ObjectProperty rdf:about="&wot2;hasAction">
         <rdfs:range rdf:resource="&wot2;Action"/>
@@ -130,7 +128,7 @@
     
 
 
-    <!-- http://w3c.github.io/wot/proposals/ontology/wot.owl#hasEvent -->
+    <!-- http://w3c.github.io/wot/wot.owl#hasEvent -->
 
     <owl:ObjectProperty rdf:about="&wot2;hasEvent">
         <rdfs:range rdf:resource="&wot2;Event"/>
@@ -140,7 +138,7 @@
     
 
 
-    <!-- http://w3c.github.io/wot/proposals/ontology/wot.owl#hasInput -->
+    <!-- http://w3c.github.io/wot/wot.owl#hasInput -->
 
     <owl:ObjectProperty rdf:about="&wot2;hasInput">
         <rdfs:domain rdf:resource="&wot2;Action"/>
@@ -148,7 +146,7 @@
     
 
 
-    <!-- http://w3c.github.io/wot/proposals/ontology/wot.owl#hasInteraction -->
+    <!-- http://w3c.github.io/wot/wot.owl#hasInteraction -->
 
     <owl:ObjectProperty rdf:about="&wot2;hasInteraction">
         <rdfs:range rdf:resource="&wot2;Interaction"/>
@@ -156,7 +154,7 @@
     
 
 
-    <!-- http://w3c.github.io/wot/proposals/ontology/wot.owl#hasOutput -->
+    <!-- http://w3c.github.io/wot/wot.owl#hasOutput -->
 
     <owl:ObjectProperty rdf:about="&wot2;hasOutput">
         <rdfs:domain rdf:resource="&wot2;Action"/>
@@ -164,7 +162,7 @@
     
 
 
-    <!-- http://w3c.github.io/wot/proposals/ontology/wot.owl#hasProperty -->
+    <!-- http://w3c.github.io/wot/wot.owl#hasProperty -->
 
     <owl:ObjectProperty rdf:about="&wot2;hasProperty">
         <rdfs:range rdf:resource="&wot2;Property"/>
@@ -174,7 +172,7 @@
     
 
 
-    <!-- http://w3c.github.io/wot/proposals/ontology/wot.owl#hasThingDescription -->
+    <!-- http://w3c.github.io/wot/wot.owl#hasThingDescription -->
 
     <owl:ObjectProperty rdf:about="&wot2;hasThingDescription">
         <owl:inverseOf rdf:resource="&wot2;isThingDescriptionOf"/>
@@ -182,7 +180,7 @@
     
 
 
-    <!-- http://w3c.github.io/wot/proposals/ontology/wot.owl#hasValueType -->
+    <!-- http://w3c.github.io/wot/wot.owl#hasValueType -->
 
     <owl:ObjectProperty rdf:about="&wot2;hasValueType">
         <rdfs:domain>
@@ -197,16 +195,16 @@
     
 
 
-    <!-- http://w3c.github.io/wot/proposals/ontology/wot.owl#isAssociatedTo -->
+    <!-- http://w3c.github.io/wot/wot.owl#isAssociatedTo -->
 
     <owl:ObjectProperty rdf:about="&wot2;isAssociatedTo">
-        <rdfs:domain rdf:resource="&wot2;Thing"/>
         <rdfs:range rdf:resource="&wot2;Thing"/>
+        <rdfs:domain rdf:resource="&wot2;Thing"/>
     </owl:ObjectProperty>
     
 
 
-    <!-- http://w3c.github.io/wot/proposals/ontology/wot.owl#isChildOf -->
+    <!-- http://w3c.github.io/wot/wot.owl#isChildOf -->
 
     <owl:ObjectProperty rdf:about="&wot2;isChildOf">
         <rdfs:subPropertyOf rdf:resource="&wot2;isAssociatedTo"/>
@@ -214,7 +212,7 @@
     
 
 
-    <!-- http://w3c.github.io/wot/proposals/ontology/wot.owl#isInteractionOf -->
+    <!-- http://w3c.github.io/wot/wot.owl#isInteractionOf -->
 
     <owl:ObjectProperty rdf:about="&wot2;isInteractionOf">
         <rdfs:subPropertyOf rdf:resource="http://w3c.github.io/wot/ire-extended.owl#informalExactProxyFor"/>
@@ -223,7 +221,7 @@
     
 
 
-    <!-- http://w3c.github.io/wot/proposals/ontology/wot.owl#isParentOf -->
+    <!-- http://w3c.github.io/wot/wot.owl#isParentOf -->
 
     <owl:ObjectProperty rdf:about="&wot2;isParentOf">
         <rdfs:subPropertyOf rdf:resource="&wot2;isAssociatedTo"/>
@@ -231,11 +229,17 @@
     
 
 
-    <!-- http://w3c.github.io/wot/proposals/ontology/wot.owl#isThingDescriptionOf -->
+    <!-- http://w3c.github.io/wot/wot.owl#isThingDescriptionOf -->
 
     <owl:ObjectProperty rdf:about="&wot2;isThingDescriptionOf">
         <rdfs:subPropertyOf rdf:resource="http://w3c.github.io/wot/ire-extended.owl#formalExactProxyFor"/>
     </owl:ObjectProperty>
+    
+
+
+    <!-- http://www.ontologydesignpatterns.org/ont/dul/DUL.owl#hasConstituent -->
+
+    <owl:ObjectProperty rdf:about="http://www.ontologydesignpatterns.org/ont/dul/DUL.owl#hasConstituent"/>
     
 
 
@@ -250,7 +254,7 @@
     
 
 
-    <!-- http://w3c.github.io/wot/proposals/ontology/wot.owl#hasName -->
+    <!-- http://w3c.github.io/wot/wot.owl#hasName -->
 
     <owl:DatatypeProperty rdf:about="&wot2;hasName">
         <rdfs:range rdf:resource="&xsd;string"/>
@@ -268,7 +272,7 @@
     
 
 
-    <!-- http://w3c.github.io/wot/proposals/ontology/wot.owl#hasPriority -->
+    <!-- http://w3c.github.io/wot/wot.owl#hasPriority -->
 
     <owl:DatatypeProperty rdf:about="&wot2;hasPriority">
         <rdfs:comment>In case of more than one protocol binding, defines an order to suggest which protocol(s) should be used in priority.</rdfs:comment>
@@ -277,7 +281,7 @@
     
 
 
-    <!-- http://w3c.github.io/wot/proposals/ontology/wot.owl#hasStability -->
+    <!-- http://w3c.github.io/wot/wot.owl#hasStability -->
 
     <owl:DatatypeProperty rdf:about="&wot2;hasStability">
         <rdfs:comment>Characterizes how often the property likely changes. Expressed in ms.</rdfs:comment>
@@ -287,7 +291,7 @@
     
 
 
-    <!-- http://w3c.github.io/wot/proposals/ontology/wot.owl#isWritable -->
+    <!-- http://w3c.github.io/wot/wot.owl#isWritable -->
 
     <owl:DatatypeProperty rdf:about="&wot2;isWritable">
         <rdfs:domain rdf:resource="&wot2;Property"/>
@@ -296,13 +300,13 @@
     
 
 
-    <!-- http://w3c.github.io/wot/proposals/ontology/wot.owl#supportsEncoding -->
+    <!-- http://w3c.github.io/wot/wot.owl#supportsEncoding -->
 
     <owl:DatatypeProperty rdf:about="&wot2;supportsEncoding"/>
     
 
 
-    <!-- http://w3c.github.io/wot/proposals/ontology/wot.owl#supportsSecurity -->
+    <!-- http://w3c.github.io/wot/wot.owl#supportsSecurity -->
 
     <owl:DatatypeProperty rdf:about="&wot2;supportsSecurity"/>
     
@@ -331,15 +335,15 @@
     
 
 
-    <!-- http://w3c.github.io/wot/proposals/ontology/wot.owl#Action -->
+    <!-- http://w3c.github.io/wot/wot.owl#Action -->
 
     <owl:Class rdf:about="&wot2;Action">
         <owl:equivalentClass>
             <owl:Class>
                 <owl:intersectionOf rdf:parseType="Collection">
-                    <rdf:Description rdf:about="http://www.loa-cnr.it/ontologies/DUL.owl#Abstract"/>
+                    <rdf:Description rdf:about="http://www.ontologydesignpatterns.org/ont/dul/DUL.owl#Abstract"/>
                     <owl:Restriction>
-                        <owl:onProperty rdf:resource="http://www.loa-cnr.it/ontologies/DUL.owl#hasConstituent"/>
+                        <owl:onProperty rdf:resource="http://www.ontologydesignpatterns.org/ont/dul/DUL.owl#hasConstituent"/>
                         <owl:allValuesFrom rdf:resource="http://www.w3.org/2006/time#Interval"/>
                     </owl:Restriction>
                 </owl:intersectionOf>
@@ -347,37 +351,36 @@
         </owl:equivalentClass>
         <owl:disjointWith rdf:resource="&wot2;Event"/>
         <owl:disjointWith rdf:resource="&wot2;Property"/>
-        <rdfs:comment>Real-world entity characterizing particular time intervals, possibly influencing some Properties. Non-immediate natural phenomena (e.g. heating) or functionalities provided by a cyber-physical system (open, close, switch, toggle. . . ) are Actions.</rdfs:comment>
+        <rdfs:comment xml:lang="en">Real-world entity characterizing particular time intervals, possibly influencing some Properties. Non-immediate natural phenomena (e.g. heating) or functionalities provided by a cyber-physical system (open, close, switch, toggle...) are Actions.</rdfs:comment>
     </owl:Class>
     
 
 
-    <!-- http://w3c.github.io/wot/proposals/ontology/wot.owl#Event -->
+    <!-- http://w3c.github.io/wot/wot.owl#Event -->
 
     <owl:Class rdf:about="&wot2;Event">
         <owl:equivalentClass>
             <owl:Class>
                 <owl:intersectionOf rdf:parseType="Collection">
-                    <rdf:Description rdf:about="http://www.loa-cnr.it/ontologies/DUL.owl#Abstract"/>
+                    <rdf:Description rdf:about="http://www.ontologydesignpatterns.org/ont/dul/DUL.owl#Abstract"/>
                     <owl:Restriction>
-                        <owl:onProperty rdf:resource="http://www.loa-cnr.it/ontologies/DUL.owl#hasConstituent"/>
+                        <owl:onProperty rdf:resource="http://www.ontologydesignpatterns.org/ont/dul/DUL.owl#hasConstituent"/>
                         <owl:allValuesFrom rdf:resource="http://www.w3.org/2006/time#Instant"/>
                     </owl:Restriction>
                 </owl:intersectionOf>
             </owl:Class>
         </owl:equivalentClass>
         <owl:disjointWith rdf:resource="&wot2;Property"/>
-        <rdfs:comment>Real-world entity characterizing particular instants, possibly related to some Properties. State changes or sensor measurements are
-Events.</rdfs:comment>
+        <rdfs:comment xml:lang="en">Real-world entity characterizing particular instants, possibly related to some Properties. State changes or sensor measurements are Events.</rdfs:comment>
     </owl:Class>
     
 
 
-    <!-- http://w3c.github.io/wot/proposals/ontology/wot.owl#Interaction -->
+    <!-- http://w3c.github.io/wot/wot.owl#Interaction -->
 
     <owl:Class rdf:about="&wot2;Interaction">
-        <rdfs:label>WoT Resource</rdfs:label>
         <rdfs:label>Interaction</rdfs:label>
+        <rdfs:label>WoT Resource</rdfs:label>
         <owl:equivalentClass>
             <owl:Class>
                 <owl:intersectionOf rdf:parseType="Collection">
@@ -387,9 +390,9 @@ Events.</rdfs:comment>
                         <owl:allValuesFrom>
                             <owl:Class>
                                 <owl:intersectionOf rdf:parseType="Collection">
-                                    <rdf:Description rdf:about="http://www.loa-cnr.it/ontologies/DUL.owl#Entity"/>
+                                    <rdf:Description rdf:about="http://www.ontologydesignpatterns.org/ont/dul/DUL.owl#Entity"/>
                                     <owl:Class>
-                                        <owl:complementOf rdf:resource="http://www.loa-cnr.it/ontologies/DUL.owl#InformationEntity"/>
+                                        <owl:complementOf rdf:resource="http://www.ontologydesignpatterns.org/ont/dul/DUL.owl#InformationEntity"/>
                                     </owl:Class>
                                 </owl:intersectionOf>
                             </owl:Class>
@@ -399,21 +402,21 @@ Events.</rdfs:comment>
             </owl:Class>
         </owl:equivalentClass>
         <rdfs:subClassOf rdf:resource="http://w3c.github.io/wot/ire-extended.owl#ProxyResource"/>
-        <rdfs:comment>Web resource of arbitrary content format acting as a digital proxy for any real-world entity that is not already digital information. Such entities can be physical quantities like temperature or pressure, natural phenomena like raise of temperature or object motion, arbitrary states like on/off, etc.</rdfs:comment>
+        <rdfs:comment xml:lang="en">Web resource of arbitrary content format acting as a digital proxy for any real-world entity that is not already digital information. Such entities can be physical quantities like temperature or pressure, natural phenomena like raise of temperature or object motion, arbitrary states like on/off, etc.</rdfs:comment>
     </owl:Class>
     
 
 
-    <!-- http://w3c.github.io/wot/proposals/ontology/wot.owl#Property -->
+    <!-- http://w3c.github.io/wot/wot.owl#Property -->
 
     <owl:Class rdf:about="&wot2;Property">
-        <rdfs:subClassOf rdf:resource="http://www.loa-cnr.it/ontologies/DUL.owl#Entity"/>
-        <rdfs:comment>Time-independent real-world entity that is neither an Action, nor an Event. For instance, physical quantities (temperature, pressure, brigthness. . . ) are Properties.</rdfs:comment>
+        <rdfs:subClassOf rdf:resource="http://www.ontologydesignpatterns.org/ont/dul/DUL.owl#Entity"/>
+        <rdfs:comment xml:lang="en">Time-independent real-world entity that is neither an Action, nor an Event. For instance, physical quantities (temperature, pressure, brigthness...) are Properties.</rdfs:comment>
     </owl:Class>
     
 
 
-    <!-- http://w3c.github.io/wot/proposals/ontology/wot.owl#PropertyChangedEvent -->
+    <!-- http://w3c.github.io/wot/wot.owl#PropertyChangedEvent -->
 
     <owl:Class rdf:about="&wot2;PropertyChangedEvent">
         <rdfs:subClassOf rdf:resource="&wot2;Event"/>
@@ -421,15 +424,15 @@ Events.</rdfs:comment>
     
 
 
-    <!-- http://w3c.github.io/wot/proposals/ontology/wot.owl#Thing -->
+    <!-- http://w3c.github.io/wot/wot.owl#Thing -->
 
     <owl:Class rdf:about="&wot2;Thing">
-        <rdfs:subClassOf rdf:resource="http://www.loa-cnr.it/ontologies/DUL.owl#Entity"/>
+        <rdfs:subClassOf rdf:resource="http://www.ontologydesignpatterns.org/ont/dul/DUL.owl#Entity"/>
     </owl:Class>
     
 
 
-    <!-- http://w3c.github.io/wot/proposals/ontology/wot.owl#ThingDescription -->
+    <!-- http://w3c.github.io/wot/wot.owl#ThingDescription -->
 
     <owl:Class rdf:about="&wot2;ThingDescription">
         <owl:equivalentClass>
@@ -444,16 +447,34 @@ Events.</rdfs:comment>
                 </owl:intersectionOf>
             </owl:Class>
         </owl:equivalentClass>
-        <rdfs:comment>Semantic resource formally describing a unique WoT Thing that a software agent can interact with. Examples of WoT Things include building rooms, manufactured products, mechanical systems but also digital control devices, i.e. any real-world entity without a priori restriction.</rdfs:comment>
+        <rdfs:comment xml:lang="en">Semantic resource formally describing a unique WoT Thing that a software agent can interact with. Examples of WoT Things include building rooms, manufactured products, mechanical systems but also digital control devices, i.e. any real-world entity without a priori restriction.</rdfs:comment>
     </owl:Class>
     
 
 
-    <!-- http://w3c.github.io/wot/proposals/ontology/wot.owl#UpdatePropertyAction -->
+    <!-- http://w3c.github.io/wot/wot.owl#UpdatePropertyAction -->
 
     <owl:Class rdf:about="&wot2;UpdatePropertyAction">
         <rdfs:subClassOf rdf:resource="&wot2;Action"/>
     </owl:Class>
+    
+
+
+    <!-- http://www.ontologydesignpatterns.org/ont/dul/DUL.owl#Abstract -->
+
+    <owl:Class rdf:about="http://www.ontologydesignpatterns.org/ont/dul/DUL.owl#Abstract"/>
+    
+
+
+    <!-- http://www.ontologydesignpatterns.org/ont/dul/DUL.owl#Entity -->
+
+    <owl:Class rdf:about="http://www.ontologydesignpatterns.org/ont/dul/DUL.owl#Entity"/>
+    
+
+
+    <!-- http://www.ontologydesignpatterns.org/ont/dul/DUL.owl#InformationEntity -->
+
+    <owl:Class rdf:about="http://www.ontologydesignpatterns.org/ont/dul/DUL.owl#InformationEntity"/>
     
 
 
@@ -470,5 +491,5 @@ Events.</rdfs:comment>
 
 
 
-<!-- Generated by the OWL API (version 3.4.2) http://owlapi.sourceforge.net -->
+<!-- Generated by the OWL API (version 3.5.0) http://owlapi.sourceforge.net -->
 

--- a/proposals/ontology/wot.owl
+++ b/proposals/ontology/wot.owl
@@ -1,0 +1,474 @@
+<?xml version="1.0"?>
+
+
+<!DOCTYPE rdf:RDF [
+    <!ENTITY owl "http://www.w3.org/2002/07/owl#" >
+    <!ENTITY xsd "http://www.w3.org/2001/XMLSchema#" >
+    <!ENTITY wot "http://w3c.github.io/wot/wot.owl#" >
+    <!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#" >
+    <!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#" >
+    <!ENTITY wot2 "http://w3c.github.io/wot/proposals/ontology/wot.owl#" >
+]>
+
+
+<rdf:RDF xmlns="http://www.w3c.org/wot/td#"
+     xml:base="http://www.w3c.org/wot/td"
+     xmlns:wot="http://w3c.github.io/wot/wot.owl#"
+     xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+     xmlns:wot2="http://w3c.github.io/wot/proposals/ontology/wot.owl#"
+     xmlns:owl="http://www.w3.org/2002/07/owl#"
+     xmlns:xsd="http://www.w3.org/2001/XMLSchema#"
+     xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+    <owl:Ontology rdf:about="http://w3c.github.io/wot/proposals/ontology/wot.owl">
+        <owl:versionInfo rdf:datatype="&xsd;decimal">2.1</owl:versionInfo>
+        <created rdf:datatype="&xsd;string">2015-08-14</created>
+        <title rdf:datatype="&xsd;string">Thing Description Model</title>
+        <rdfs:comment rdf:datatype="&xsd;string">This ontology describes Things as specified by the Thing Description Model.</rdfs:comment>
+        <creator rdf:datatype="&xsd;string">W3C Web of Things Interest Group</creator>
+        <identifier rdf:datatype="&xsd;anyURI">http://www.w3c.org/wot/td</identifier>
+        <owl:imports rdf:resource="http://w3c.github.io/wot/ire-extended.owl"/>
+        <owl:imports rdf:resource="http://www.w3.org/2006/time"/>
+    </owl:Ontology>
+    
+
+
+    <!-- 
+    ///////////////////////////////////////////////////////////////////////////////////////
+    //
+    // Annotation properties
+    //
+    ///////////////////////////////////////////////////////////////////////////////////////
+     -->
+
+    
+
+
+    <!-- http://w3c.github.io/wot/proposals/ontology/wot.owl#created -->
+
+    <owl:AnnotationProperty rdf:about="&wot2;created"/>
+    
+
+
+    <!-- http://w3c.github.io/wot/proposals/ontology/wot.owl#creator -->
+
+    <owl:AnnotationProperty rdf:about="&wot2;creator"/>
+    
+
+
+    <!-- http://w3c.github.io/wot/proposals/ontology/wot.owl#identifier -->
+
+    <owl:AnnotationProperty rdf:about="&wot2;identifier"/>
+    
+
+
+    <!-- http://w3c.github.io/wot/proposals/ontology/wot.owl#modified -->
+
+    <owl:AnnotationProperty rdf:about="&wot2;modified"/>
+    
+
+
+    <!-- http://w3c.github.io/wot/proposals/ontology/wot.owl#title -->
+
+    <owl:AnnotationProperty rdf:about="&wot2;title"/>
+    
+
+
+    <!-- 
+    ///////////////////////////////////////////////////////////////////////////////////////
+    //
+    // Object Properties
+    //
+    ///////////////////////////////////////////////////////////////////////////////////////
+     -->
+
+    
+
+
+    <!-- http://w3c.github.io/wot/ire-extended.owl#formalExactProxyFor -->
+
+    <owl:ObjectProperty rdf:about="http://w3c.github.io/wot/ire-extended.owl#formalExactProxyFor"/>
+    
+
+
+    <!-- http://w3c.github.io/wot/ire-extended.owl#informalExactProxyFor -->
+
+    <owl:ObjectProperty rdf:about="http://w3c.github.io/wot/ire-extended.owl#informalExactProxyFor"/>
+    
+
+
+    <!-- http://w3c.github.io/wot/proposals/ontology/wot.owl#dependsOn -->
+
+    <owl:ObjectProperty rdf:about="&wot2;dependsOn">
+        <rdfs:subPropertyOf rdf:resource="&wot2;isAssociatedTo"/>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- http://w3c.github.io/wot/proposals/ontology/wot.owl#forProperty -->
+
+    <owl:ObjectProperty rdf:about="&wot2;forProperty">
+        <rdfs:range rdf:resource="&wot2;Property"/>
+        <rdfs:domain>
+            <owl:Class>
+                <owl:unionOf rdf:parseType="Collection">
+                    <rdf:Description rdf:about="&wot2;Action"/>
+                    <rdf:Description rdf:about="&wot2;Event"/>
+                </owl:unionOf>
+            </owl:Class>
+        </rdfs:domain>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- http://w3c.github.io/wot/proposals/ontology/wot.owl#hasAction -->
+
+    <owl:ObjectProperty rdf:about="&wot2;hasAction">
+        <rdfs:range rdf:resource="&wot2;Action"/>
+        <rdfs:domain rdf:resource="&wot2;Thing"/>
+        <rdfs:subPropertyOf rdf:resource="&owl;topObjectProperty"/>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- http://w3c.github.io/wot/proposals/ontology/wot.owl#hasEvent -->
+
+    <owl:ObjectProperty rdf:about="&wot2;hasEvent">
+        <rdfs:range rdf:resource="&wot2;Event"/>
+        <rdfs:domain rdf:resource="&wot2;Thing"/>
+        <rdfs:subPropertyOf rdf:resource="&owl;topObjectProperty"/>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- http://w3c.github.io/wot/proposals/ontology/wot.owl#hasInput -->
+
+    <owl:ObjectProperty rdf:about="&wot2;hasInput">
+        <rdfs:domain rdf:resource="&wot2;Action"/>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- http://w3c.github.io/wot/proposals/ontology/wot.owl#hasInteraction -->
+
+    <owl:ObjectProperty rdf:about="&wot2;hasInteraction">
+        <rdfs:range rdf:resource="&wot2;Interaction"/>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- http://w3c.github.io/wot/proposals/ontology/wot.owl#hasOutput -->
+
+    <owl:ObjectProperty rdf:about="&wot2;hasOutput">
+        <rdfs:domain rdf:resource="&wot2;Action"/>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- http://w3c.github.io/wot/proposals/ontology/wot.owl#hasProperty -->
+
+    <owl:ObjectProperty rdf:about="&wot2;hasProperty">
+        <rdfs:range rdf:resource="&wot2;Property"/>
+        <rdfs:domain rdf:resource="&wot2;Thing"/>
+        <rdfs:subPropertyOf rdf:resource="&owl;topObjectProperty"/>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- http://w3c.github.io/wot/proposals/ontology/wot.owl#hasThingDescription -->
+
+    <owl:ObjectProperty rdf:about="&wot2;hasThingDescription">
+        <owl:inverseOf rdf:resource="&wot2;isThingDescriptionOf"/>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- http://w3c.github.io/wot/proposals/ontology/wot.owl#hasValueType -->
+
+    <owl:ObjectProperty rdf:about="&wot2;hasValueType">
+        <rdfs:domain>
+            <owl:Class>
+                <owl:unionOf rdf:parseType="Collection">
+                    <rdf:Description rdf:about="&wot2;Event"/>
+                    <rdf:Description rdf:about="&wot2;Property"/>
+                </owl:unionOf>
+            </owl:Class>
+        </rdfs:domain>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- http://w3c.github.io/wot/proposals/ontology/wot.owl#isAssociatedTo -->
+
+    <owl:ObjectProperty rdf:about="&wot2;isAssociatedTo">
+        <rdfs:domain rdf:resource="&wot2;Thing"/>
+        <rdfs:range rdf:resource="&wot2;Thing"/>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- http://w3c.github.io/wot/proposals/ontology/wot.owl#isChildOf -->
+
+    <owl:ObjectProperty rdf:about="&wot2;isChildOf">
+        <rdfs:subPropertyOf rdf:resource="&wot2;isAssociatedTo"/>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- http://w3c.github.io/wot/proposals/ontology/wot.owl#isInteractionOf -->
+
+    <owl:ObjectProperty rdf:about="&wot2;isInteractionOf">
+        <rdfs:subPropertyOf rdf:resource="http://w3c.github.io/wot/ire-extended.owl#informalExactProxyFor"/>
+        <owl:inverseOf rdf:resource="&wot2;hasInteraction"/>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- http://w3c.github.io/wot/proposals/ontology/wot.owl#isParentOf -->
+
+    <owl:ObjectProperty rdf:about="&wot2;isParentOf">
+        <rdfs:subPropertyOf rdf:resource="&wot2;isAssociatedTo"/>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- http://w3c.github.io/wot/proposals/ontology/wot.owl#isThingDescriptionOf -->
+
+    <owl:ObjectProperty rdf:about="&wot2;isThingDescriptionOf">
+        <rdfs:subPropertyOf rdf:resource="http://w3c.github.io/wot/ire-extended.owl#formalExactProxyFor"/>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- 
+    ///////////////////////////////////////////////////////////////////////////////////////
+    //
+    // Data properties
+    //
+    ///////////////////////////////////////////////////////////////////////////////////////
+     -->
+
+    
+
+
+    <!-- http://w3c.github.io/wot/proposals/ontology/wot.owl#hasName -->
+
+    <owl:DatatypeProperty rdf:about="&wot2;hasName">
+        <rdfs:range rdf:resource="&xsd;string"/>
+        <rdfs:domain>
+            <owl:Class>
+                <owl:unionOf rdf:parseType="Collection">
+                    <rdf:Description rdf:about="&wot2;Action"/>
+                    <rdf:Description rdf:about="&wot2;Event"/>
+                    <rdf:Description rdf:about="&wot2;Property"/>
+                    <rdf:Description rdf:about="&wot2;Thing"/>
+                </owl:unionOf>
+            </owl:Class>
+        </rdfs:domain>
+    </owl:DatatypeProperty>
+    
+
+
+    <!-- http://w3c.github.io/wot/proposals/ontology/wot.owl#hasPriority -->
+
+    <owl:DatatypeProperty rdf:about="&wot2;hasPriority">
+        <rdfs:comment>In case of more than one protocol binding, defines an order to suggest which protocol(s) should be used in priority.</rdfs:comment>
+        <rdfs:range rdf:resource="&xsd;integer"/>
+    </owl:DatatypeProperty>
+    
+
+
+    <!-- http://w3c.github.io/wot/proposals/ontology/wot.owl#hasStability -->
+
+    <owl:DatatypeProperty rdf:about="&wot2;hasStability">
+        <rdfs:comment>Characterizes how often the property likely changes. Expressed in ms.</rdfs:comment>
+        <rdfs:domain rdf:resource="&wot2;Property"/>
+        <rdfs:range rdf:resource="&xsd;decimal"/>
+    </owl:DatatypeProperty>
+    
+
+
+    <!-- http://w3c.github.io/wot/proposals/ontology/wot.owl#isWritable -->
+
+    <owl:DatatypeProperty rdf:about="&wot2;isWritable">
+        <rdfs:domain rdf:resource="&wot2;Property"/>
+        <rdfs:range rdf:resource="&xsd;boolean"/>
+    </owl:DatatypeProperty>
+    
+
+
+    <!-- http://w3c.github.io/wot/proposals/ontology/wot.owl#supportsEncoding -->
+
+    <owl:DatatypeProperty rdf:about="&wot2;supportsEncoding"/>
+    
+
+
+    <!-- http://w3c.github.io/wot/proposals/ontology/wot.owl#supportsSecurity -->
+
+    <owl:DatatypeProperty rdf:about="&wot2;supportsSecurity"/>
+    
+
+
+    <!-- 
+    ///////////////////////////////////////////////////////////////////////////////////////
+    //
+    // Classes
+    //
+    ///////////////////////////////////////////////////////////////////////////////////////
+     -->
+
+    
+
+
+    <!-- http://w3c.github.io/wot/ire-extended.owl#ProxyResource -->
+
+    <owl:Class rdf:about="http://w3c.github.io/wot/ire-extended.owl#ProxyResource"/>
+    
+
+
+    <!-- http://w3c.github.io/wot/ire-extended.owl#SemanticResource -->
+
+    <owl:Class rdf:about="http://w3c.github.io/wot/ire-extended.owl#SemanticResource"/>
+    
+
+
+    <!-- http://w3c.github.io/wot/proposals/ontology/wot.owl#Action -->
+
+    <owl:Class rdf:about="&wot2;Action">
+        <owl:equivalentClass>
+            <owl:Class>
+                <owl:intersectionOf rdf:parseType="Collection">
+                    <rdf:Description rdf:about="http://www.loa-cnr.it/ontologies/DUL.owl#Abstract"/>
+                    <owl:Restriction>
+                        <owl:onProperty rdf:resource="http://www.loa-cnr.it/ontologies/DUL.owl#hasConstituent"/>
+                        <owl:allValuesFrom rdf:resource="http://www.w3.org/2006/time#Interval"/>
+                    </owl:Restriction>
+                </owl:intersectionOf>
+            </owl:Class>
+        </owl:equivalentClass>
+        <owl:disjointWith rdf:resource="&wot2;Event"/>
+        <owl:disjointWith rdf:resource="&wot2;Property"/>
+        <rdfs:comment>Real-world entity characterizing particular time intervals, possibly influencing some Properties. Non-immediate natural phenomena (e.g. heating) or functionalities provided by a cyber-physical system (open, close, switch, toggle. . . ) are Actions.</rdfs:comment>
+    </owl:Class>
+    
+
+
+    <!-- http://w3c.github.io/wot/proposals/ontology/wot.owl#Event -->
+
+    <owl:Class rdf:about="&wot2;Event">
+        <owl:equivalentClass>
+            <owl:Class>
+                <owl:intersectionOf rdf:parseType="Collection">
+                    <rdf:Description rdf:about="http://www.loa-cnr.it/ontologies/DUL.owl#Abstract"/>
+                    <owl:Restriction>
+                        <owl:onProperty rdf:resource="http://www.loa-cnr.it/ontologies/DUL.owl#hasConstituent"/>
+                        <owl:allValuesFrom rdf:resource="http://www.w3.org/2006/time#Instant"/>
+                    </owl:Restriction>
+                </owl:intersectionOf>
+            </owl:Class>
+        </owl:equivalentClass>
+        <owl:disjointWith rdf:resource="&wot2;Property"/>
+        <rdfs:comment>Real-world entity characterizing particular instants, possibly related to some Properties. State changes or sensor measurements are
+Events.</rdfs:comment>
+    </owl:Class>
+    
+
+
+    <!-- http://w3c.github.io/wot/proposals/ontology/wot.owl#Interaction -->
+
+    <owl:Class rdf:about="&wot2;Interaction">
+        <rdfs:label>WoT Resource</rdfs:label>
+        <rdfs:label>Interaction</rdfs:label>
+        <owl:equivalentClass>
+            <owl:Class>
+                <owl:intersectionOf rdf:parseType="Collection">
+                    <rdf:Description rdf:about="http://w3c.github.io/wot/ire-extended.owl#ProxyResource"/>
+                    <owl:Restriction>
+                        <owl:onProperty rdf:resource="http://w3c.github.io/wot/ire-extended.owl#informalExactProxyFor"/>
+                        <owl:allValuesFrom>
+                            <owl:Class>
+                                <owl:intersectionOf rdf:parseType="Collection">
+                                    <rdf:Description rdf:about="http://www.loa-cnr.it/ontologies/DUL.owl#Entity"/>
+                                    <owl:Class>
+                                        <owl:complementOf rdf:resource="http://www.loa-cnr.it/ontologies/DUL.owl#InformationEntity"/>
+                                    </owl:Class>
+                                </owl:intersectionOf>
+                            </owl:Class>
+                        </owl:allValuesFrom>
+                    </owl:Restriction>
+                </owl:intersectionOf>
+            </owl:Class>
+        </owl:equivalentClass>
+        <rdfs:subClassOf rdf:resource="http://w3c.github.io/wot/ire-extended.owl#ProxyResource"/>
+        <rdfs:comment>Web resource of arbitrary content format acting as a digital proxy for any real-world entity that is not already digital information. Such entities can be physical quantities like temperature or pressure, natural phenomena like raise of temperature or object motion, arbitrary states like on/off, etc.</rdfs:comment>
+    </owl:Class>
+    
+
+
+    <!-- http://w3c.github.io/wot/proposals/ontology/wot.owl#Property -->
+
+    <owl:Class rdf:about="&wot2;Property">
+        <rdfs:subClassOf rdf:resource="http://www.loa-cnr.it/ontologies/DUL.owl#Entity"/>
+        <rdfs:comment>Time-independent real-world entity that is neither an Action, nor an Event. For instance, physical quantities (temperature, pressure, brigthness. . . ) are Properties.</rdfs:comment>
+    </owl:Class>
+    
+
+
+    <!-- http://w3c.github.io/wot/proposals/ontology/wot.owl#PropertyChangedEvent -->
+
+    <owl:Class rdf:about="&wot2;PropertyChangedEvent">
+        <rdfs:subClassOf rdf:resource="&wot2;Event"/>
+    </owl:Class>
+    
+
+
+    <!-- http://w3c.github.io/wot/proposals/ontology/wot.owl#Thing -->
+
+    <owl:Class rdf:about="&wot2;Thing">
+        <rdfs:subClassOf rdf:resource="http://www.loa-cnr.it/ontologies/DUL.owl#Entity"/>
+    </owl:Class>
+    
+
+
+    <!-- http://w3c.github.io/wot/proposals/ontology/wot.owl#ThingDescription -->
+
+    <owl:Class rdf:about="&wot2;ThingDescription">
+        <owl:equivalentClass>
+            <owl:Class>
+                <owl:intersectionOf rdf:parseType="Collection">
+                    <rdf:Description rdf:about="http://w3c.github.io/wot/ire-extended.owl#SemanticResource"/>
+                    <owl:Restriction>
+                        <owl:onProperty rdf:resource="http://w3c.github.io/wot/ire-extended.owl#formalExactProxyFor"/>
+                        <owl:onClass rdf:resource="&wot2;Thing"/>
+                        <owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
+                    </owl:Restriction>
+                </owl:intersectionOf>
+            </owl:Class>
+        </owl:equivalentClass>
+        <rdfs:comment>Semantic resource formally describing a unique WoT Thing that a software agent can interact with. Examples of WoT Things include building rooms, manufactured products, mechanical systems but also digital control devices, i.e. any real-world entity without a priori restriction.</rdfs:comment>
+    </owl:Class>
+    
+
+
+    <!-- http://w3c.github.io/wot/proposals/ontology/wot.owl#UpdatePropertyAction -->
+
+    <owl:Class rdf:about="&wot2;UpdatePropertyAction">
+        <rdfs:subClassOf rdf:resource="&wot2;Action"/>
+    </owl:Class>
+    
+
+
+    <!-- http://www.w3.org/2006/time#Instant -->
+
+    <owl:Class rdf:about="http://www.w3.org/2006/time#Instant"/>
+    
+
+
+    <!-- http://www.w3.org/2006/time#Interval -->
+
+    <owl:Class rdf:about="http://www.w3.org/2006/time#Interval"/>
+</rdf:RDF>
+
+
+
+<!-- Generated by the OWL API (version 3.4.2) http://owlapi.sourceforge.net -->
+


### PR DESCRIPTION
Proposal for more detailed semantics regarding TDs. Includes an ontology for WoT and import.

Ontologies should be dereferenceable, that's why I updated the travis script to copy them to `gh-pages`. I placed them under the root, so that their URI remains short and doesn't need to be changed wherever the original file is moved in the `master` branch.