### PR TITLE
Alternative text for abstract emphasizing reuse

### DIFF
--- a/charters/wot-white-paper-2016.html
+++ b/charters/wot-white-paper-2016.html
@@ -115,7 +115,7 @@
 
       <p class="issue"><i>Comments are welcome on the <a href="mailto:public-wot-ig@w3.org?subject=[White%20Paper]%20your%20comment">Web of Things Interest Group public email list</a></i></p>
 
-      <p id="abstract">The Web of Things seeks to counter the fragmentation of the IoT through standardized Web technologies (e.g., metadata and APIs) that enable easy integration across IoT platforms and application domains. This will reduce costs for developing and deploying IoT services through the global reach of Web standards, enable open markets of services, and unleash the power of the network effect.</p>
+      <p id="abstract">The Web of Things seeks to counter the fragmentation of the IoT by using and extending existing, standardized Web technologies (e.g., metadata and APIs) in order to enable easy integration across IoT platforms and application domains.  Extending existing web standards will reduce costs for developing and deploying IoT services through the global reach of these standards, enable open markets of services, and unleash the power of the network effect.</p>
       
       <p id="interop"><img src="platform-interoperation2.png" alt="metadata as basis for platform interoperation" /><br />Metadata enables different IoT platforms to interoperate and form part of the Web of Things</p>
       


### PR DESCRIPTION
Alternative text for abstract emphasizing that web technologies will be reused as much as possible.   I did not feel this was clear enough in the original abstract.   However, this abstract also notes that we need to extend these standards where necessary.

Here is a summary with changed words highlighted:
OLD:
The Web of Things seeks to counter the fragmentation of the IoT through standardized Web technologies (e.g., metadata and APIs) that enable easy integration across IoT platforms and application domains. This will reduce costs for developing and deploying IoT services through the global reach of Web standards, enable open markets of services, and unleash the power of the network effect.

NEW:
The Web of Things seeks to counter the fragmentation of the IoT **by using and extending existing,** standardized Web technologies (e.g., metadata and APIs) **in order to** enable easy integration across IoT platforms and application domains.  **Extending existing web standards** will reduce costs for developing and deploying IoT services through the global reach of these standards, enable open markets of services, and unleash the power of the network effect.  
