### PR TITLE
add APA WG to "4. Coordination" section

### DIFF
--- a/charters/wot-wg-2016.html
+++ b/charters/wot-wg-2016.html
@@ -395,6 +395,8 @@
           <dl>
             <dt><a href="https://www.w3.org/WoT/IG/">Web of Things Interest Group</a></dt>
             <dd>The Web of Things Interest Group provides a forum for discussion of use cases and requirements, for investigation of areas that need further study before transfer to the standardization track, and for outreach and collaboration with industry alliances and standards development organizations. The Web of Things Working Group may ask the Interest Group to look into issues that are found to be insufficiently mature for immediate standardization, The Interest Group will take the lead on work on testing, e.g., organization of PlugFest events, test frameworks, and joint work with other organizations on interoperability testing.</dd>
+            <dt><a href="https://www.w3.org/WAI/APA/">Accessible Platform Architectures Working Group</a></dt>
+            <dd>For coordination on impacts of Web of Things technologies on accessibility to users with disabilities.</dd>
             <dt><a href="http://www.w3.org/2009/dap/">Device and Sensors Working Group</a></dt>
             <dd>For coordination on APIs for sensors and actuators.</dd>
             <dt><a href="http://www.w3.org/XML/EXI/">Efficient XML Interchange Working Group</a></dt>


### PR DESCRIPTION
got a comment from W3M to add the Accessibility Platform Architecture WG to the list of groups to coordinate with.