### PR TITLE
Update WG-Charter-PB-Sec

### DIFF
--- a/charters/wot-wg-2016.html
+++ b/charters/wot-wg-2016.html
@@ -208,20 +208,47 @@
 
         <h3>Bindings to Common Platforms and Protocols</h3>
 
-        <p>To enable interoperability, the Working Group will seek to define standard bindings to common platforms and protocols in close collaboration with the industry alliances and standards development organizations responsible for these. This includes definition of mappings from the interactions at the Thing Layer to:</p>
+        <p>While the Thing Description will provide general mechanisms to describe arbitrary protocols,
+          to enable interoperability, 
+          the Working Group will define standard bindings for common protocols.
+          These standard bindings will be created in close collaboration with the industry alliances 
+          and standards development organizations responsible for these. 
+          This includes definition of mappings from the interactions at the Thing Layer to:</p>
 
         <ul>
           <li>Transfer layer communication patterns such as push, pull, pub-sub, bi-directional messaging, etc.</li>
-          <li>Specific protocols at the transfer layer, e.g., REST-based protocols such as HTTP and CoAP, pub-sub protocols such as MQTT, and raw channel-based protocols such as WebSockets</li>
+          <li>Specific protocols at the transfer layer, 
+            e.g., 
+            REST-based protocols such as HTTP and CoAP, 
+            pub-sub protocols such as MQTT, 
+            and raw channel-based protocols such as WebSockets</li>
         </ul>
         
-        <p>The Web of Things has a multi-protocol architecture and bindings to both IP and non-IP transports (e.g., Bluetooth Low Energy) may be defined.</p>
+        <p>The Web of Things has a multi-protocol architecture and bindings to both IP and non-IP transports 
+          (e.g., Bluetooth Low Energy) may be defined.</p>
         
-        <p>Support for secure communications will initially focus on transport-level security (e.g., TLS and DTLS), but also object security is considered where relevant. This task will utilize 3rd party defined security frameworks and protocols including their extension points. The profiling of their usage is in scope of this task. The specification of own (new from scratch) frameworks is out-of-scope.</p>
+        <p>Support for secure communications will initially focus on transport-level security 
+          (e.g., TLS and DTLS), 
+          but also object security may also be considered where relevant. 
+          This task will utilize 3rd party defined security frameworks and protocols including their extension points. 
+          The profiling of their usage is in scope of this task. 
+          The specification of own (new from scratch) frameworks is out-of-scope.</p>
+        
+        <p>This deliverable is informative by nature since the intended capabilities 
+          of the Thing Description could be used to describe any protocol, even common ones, from first principles.
+          However, interoperability will be enhanced by providing and encouraging the use of 
+          standard bindings for common protocols when possible.
+        </p>
         
         <h3>Cross-cutting Security and Privacy</h3>
 
-        <p>The mechanisms for security and privacy must be cross-cutting over the descriptions, scripting APIs, and bindings. Thus, they are detailed within the corresponding building blocks above.</p>
+        <p>The mechanisms for security and privacy must be cross-cutting over the descriptions, scripting APIs, and bindings. 
+          Thus, they have already been discussed within the corresponding building blocks above.</p>
+        <p>However, in order to enhance the security of WoT systems, we will also generate and implement a security testing
+          plan which will include adversarial testing of the proposed standards and its implementations.  
+          We will only recommend an implementation of the proposed standards for use in production once it has 
+          passed such testing.
+        </p>
 
         <div id="section-out-of-scope">
           <h3 id="out-of-scope">Out of Scope</h3>

--- a/charters/wot-wg-2016.html
+++ b/charters/wot-wg-2016.html
@@ -206,12 +206,12 @@
         <p>Where practical, APIs will be defined in ways that are independent of the choice of programming languages. The scope includes APIs for User Agents/browsers as well as APIs for faceless applications in a runtime environment such as node.js. The underlying assumptions and contracts between the runtime environment and the application (e.g., security policies and callback signatures) will be well-defined.</p>
 
 
-        <h3>Bindings to Common Platforms and Protocols</h3>
+        <h3>Binding Templates</h3>
 
         <p>While the Thing Description will provide general mechanisms to describe arbitrary protocols,
           to enable interoperability, 
-          the Working Group will define standard bindings for common protocols.
-          These standard bindings will be created in close collaboration with the industry alliances 
+          the Working Group will define standard binding templates for common protocols.
+          These standard binding templates will be created in close collaboration with the industry alliances 
           and standards development organizations responsible for these. 
           This includes definition of mappings from the interactions at the Thing Layer to:</p>
 
@@ -227,25 +227,22 @@
         <p>The Web of Things has a multi-protocol architecture and bindings to both IP and non-IP transports 
           (e.g., Bluetooth Low Energy) may be defined.</p>
         
-        <p>Support for secure communications will initially focus on transport-level security 
-          (e.g., TLS and DTLS), 
-          but also object security may also be considered where relevant. 
-          This task will utilize 3rd party defined security frameworks and protocols including their extension points. 
-          The profiling of their usage is in scope of this task. 
-          The specification of own (new from scratch) frameworks is out-of-scope.</p>
+        <p>Support for secure communications will be included, as defined by the Security and Privacy deliverable.</p>
         
-        <p>This deliverable is informative by nature since the intended capabilities 
+        <p>The Binding Templates deliverable is informative by nature since the intended capabilities 
           of the Thing Description could be used to describe any protocol, even common ones, from first principles.
           However, interoperability will be enhanced by providing and encouraging the use of 
-          standard bindings for common protocols when possible.
+          standard binding templates for common protocols when possible.
         </p>
         
-        <h3>Cross-cutting Security and Privacy</h3>
+        <h3>Security and Privacy</h3>
 
         <p>The mechanisms for security and privacy must be cross-cutting over the descriptions, scripting APIs, and bindings. 
-          Thus, they have already been discussed within the corresponding building blocks above.</p>
-        <p>However, in order to enhance the security of WoT systems, we will also generate and implement a security testing
-          plan which will include adversarial testing of the proposed standards and its implementations.  
+         The Thing Description and the Scripting API will support both transport and object security using best practices,
+          and the Binding Templates will support the use of appropriate security for the protocols they map to.
+        </p>
+        <p>In order to enhance the security of WoT systems, we will also generate and implement a security testing
+          plan which will include both functional and adversarial testing of the proposed standards and its implementations.  
           We will only recommend an implementation of the proposed standards for use in production once it has 
           passed such testing.
         </p>
@@ -259,7 +256,8 @@
             <dt>Application- and domain-specific metadata vocabularies</dt>
             <dd>The Working Group is restricted to work on cross-domain vocabularies.</dd>
             <dt>APIs and security frameworks specific to particular platforms external to the W3C</dt>
-            <dd>The scope of the Working Group is restricted to APIs and security frameworks that are applicable across platforms.</dd>
+            <dd>The scope of the Working Group is restricted to APIs and security frameworks that are applicable across platforms.
+            We will not define new security mechanisms but will use existing mechanisms and best practices.</dd>
             <dt>Modification of protocols</dt>
             <dd>If during work on protocol bindings, it becomes apparent that changes are needed to protocols, the Web of Things Working Group will rely on the organization responsible for the protocol to make the changes. It is out of scope for the Working Group to standardize such changes itself.</dd>
           </dl>


### PR DESCRIPTION
Updates to protocol bindings (stating that they are meant to codify common protocols but that the Thing Description still will have ways to specify arbitrary protocols) and security (adding a statement about testing, including adversarial testing).