### PR TITLE
WG-Charter-PB-Normative

### DIFF
--- a/charters/wot-wg-2016.html
+++ b/charters/wot-wg-2016.html
@@ -299,9 +299,9 @@
         <div id="informative">
           <h3>Informative Specifications</h3>
           <dl>
-            <dt id="wot-bindings" class="spec"><a href="#">WoT Protocol Bindings</a></dt>
+            <dt id="wot-bindings" class="spec"><a href="#">WoT Binding Templates</a></dt>
             <dd>
-              <p>This specification defines bindings from the Web of Things to some common protocols and encodings.</p>
+              <p>This specification defines binding templates from the Web of Things to some common protocols and encodings.</p>
 
               <p class="draft-status"><b>Draft state:</b> discussion and implementation experience in the Web of Things Interest Group</p>
 

--- a/charters/wot-wg-2016.html
+++ b/charters/wot-wg-2016.html
@@ -251,9 +251,12 @@
       <section id="deliverables">
         <h2>Deliverables</h2>
 
-        <p>More detailed milestones and updated publication schedules are available on the <a href="https://www.w3.org/WoT/WG/wiki/PubStatus">group publication status page</a>.</p>
+        <p>More detailed milestones and updated publication schedules are available on the 
+          <a href="https://www.w3.org/WoT/WG/wiki/PubStatus">group publication status page</a>.</p>
 
-        <p><i>Draft state</i> indicates the state of the deliverable at the time of the charter approval. <i>Expected completion</i> indicates when the deliverable is projected to become a Recommendation, or otherwise reach a stable state.</p>
+        <p><i>Draft state</i> indicates the state of the deliverable at the time of the charter approval. 
+          <i>Expected completion</i> indicates when the deliverable is projected to become a Recommendation, 
+          or otherwise reach a stable state.</p>
 
         <div id="normative">
           <h3>Normative Specifications</h3>
@@ -290,7 +293,12 @@
               <p class="milestone"><b>First Public Working Draft:</b> 4 months after charter commencement</p>
               <p class="milestone"><b>Expected completion:</b> 22 months after charter commencement </p>
             </dd>
+          </dl>
+        </div>
 
+        <div id="informative">
+          <h3>Informative Specifications</h3>
+          <dl>
             <dt id="wot-bindings" class="spec"><a href="#">WoT Protocol Bindings</a></dt>
             <dd>
               <p>This specification defines bindings from the Web of Things to some common protocols and encodings.</p>


### PR DESCRIPTION
Make the protocol bindings deliverable informative rather than normative, as discussed.