### PR TITLE
Initial WoT Security TF Documentation

### DIFF
--- a/TF-Security/Charter.md
+++ b/TF-Security/Charter.md
@@ -35,16 +35,19 @@ The WoT Security Task Force is responsible for:
     * Onboarding
     * Provisioning
     * Compromise Recovery
+    * Updates
+    * Decommissioning
+    * Ownership Transfer
 * Security Test Plans for Specifications
 * Suggested Test Plans for Implementations
 * Security Compliance Test Suite
 
 # Deliverables
-The WoT Security Task Force will not produce recommendation-track deliverables but will produce Working Group Notes on security in conformance with the [scope](#scope) of this document.  This will include specification reviews, use case reviews and security test plans.
+The WoT Security Task Force will not produce recommendation-track deliverables but will produce Working Group Notes on security in conformance with the [scope](#scope) of this document.  This will include specification reviews, use case reviews and security test plans.  Security test plans will focus on adversarial testing as opposed to functional testing.
 
-In addition to these documents, the Security Task Force will establish and continually evolve a compliance test suite.
+In addition to these documents, the Security Task Force will establish and continually evolve a compliance test suite based on the security test plans.
 
-# Relationships to External Groups
+# Relationships to Groups External To WoT
 This task force will need to work with a number of different groups both within and without W3C to be successful.  Within W3C, this task force will need to work with:
 
 * [W3C Security Activity](https://www.w3.org/Security/)
@@ -54,22 +57,30 @@ This task force will need to work with a number of different groups both within 
 * [Automotive WG](https://www.w3.org/auto/wg/)
 * [Web Security IG](https://www.w3.org/2011/07/security-ig-charter.html)
 * [Web Application Security WG](https://www.w3.org/2011/webappsec/)
+* [Devices & Sensors WG](https://www.w3.org/2009/dap/)
 
-Additionally, this task force will work with security experts from any external organization that is defined in the WoT WG charter.
+Additionally, this task force will work with security experts from any external organization that is defined in the WoT WG charter. These will potentially include representatives from:
+
+* [IETF](http://ietf.org)
+* [OWASP](https://www.owasp.org)
 
 # Participation
-Participation by security experts from any W3C group is welcome.  They must meet the [good standing requirements](Good Standing requirements) of the W3C Process.  Additionally, recognized external experts will also be welcomed.
+Participation by security experts from any W3C group is welcome.  They must meet the [good standing requirements](Good Standing requirements) of the W3C Process.  Additionally, this task force will work with security experts from any external organization for which a liaison has been established by the WG.
 
 # Communication
-The WoT Security TF will primairly conduct its work on the public mail list TBD.
+The WoT Security TF will primarily conduct its work on the public mail list TBD.
 
-The group will use the Web of Things Working Groupo home page to provide updated public information about its activities.
+The group will use the Web of Things Working Group home page to provide updated public information about its activities.
 
-Information about the group (deliverables, participants, face-to-face meetings, teleconfrences, etc.) is available from the Web of Things Working Group home page.
+Information about the group (deliverables, participants, face-to-face meetings, teleconferences, etc.) is available from the Web of Things Working Group home page.
 
 # Decision Policy
 As Explained in the Process Document ([section 3.3](https://www.w3.org/Consortium/Process/policies#Consensus)), this group will seek to make decisions when there is consensus.  In cases where there is a need to formally produce a group resolution about a particular issue, its Chair will put a question about the issue to the group and gather responses (including any formal objections); then, after due consideration of all the responses, the Chair will record a group resolution (possibly after a formal vote and also along with responding to any formal objections).
 
+# Patent Policy
+Participants in the WoT Security Task Force are obligated to comply with W3C patent-disclosure policy as outlined out in [Section 6](http://www.w3.org/Consortium/Patent-Policy/#sec-Disclosure) of the W3C Patent Policy document. Although the Indic Text Layout Task Force is not chartered to produce Recommendation-track documents that themselves require patent disclosure, participants in the group are nevertheless obligated to comply with W3C patent-disclosure policy for any Recommendation-track specifications that they review or comment on.
+
+For more information about disclosure obligations for this group, please see the W3C Patent [Policy Implementation](https://www.w3.org/2004/01/pp-impl/).
 # About This Charter
 This charter for the Task Force within the Web of Things WG has been created according to [section 6.2](https://www.w3.org/Consortium/Process/groups#GAGeneral) of the [Process Document](https://www.w3.org/Consortium/Process).  In the event of a conflict between this document or the provisions of any charter and the W3C Process, the W3C Process shall take precedence
 

--- a/TF-Security/Charter.md
+++ b/TF-Security/Charter.md
@@ -1,0 +1,80 @@
+
+# Web of Things Security Task Force Charter
+The mission of this task force at the highest level is to ensure everything that the W3C WoT WG produces is secure by default.  Incidents such as [Mirai](https://en.wikipedia.org/wiki/Mirai_(malware)) reinforce the need to ensure security up front.
+
+## Task Force Details
+
+**End Date:** Coincident with WoT WG
+
+**Confidentiality:** Proceedings are [public](https://www.w3.org/2005/10/Process-20051014/comm.html#confidentiality-levels).
+
+**Initial Chair:** Ryan Ware
+
+**Initial Team Contact:** Dave Raggett
+
+**Meeting Schedule:** TBD
+
+
+## Table of Contents
+1. [Scope](#scope)
+2. [Deliverables](#deliverables)
+3. [Relationships to External Groups](#relationships-to-external-groups)
+4. [Participation](#participation)
+5. [Communication](#communication)
+6. [About This Charter](#about-this-charter)
+
+# Scope
+The WoT Security Task Force is responsible for:
+
+* Review of WoT related specifications for specific security relevant properties.  These include areas related to:
+    * Authentication
+    * Authorization
+    * Encryption
+    * Auditing
+* Review of use cases including:
+    * Onboarding
+    * Provisioning
+    * Compromise Recovery
+* Security Test Plans for Specifications
+* Suggested Test Plans for Implementations
+* Security Compliance Test Suite
+
+# Deliverables
+The WoT Security Task Force will not produce recommendation-track deliverables but will produce Working Group Notes on security in conformance with the [scope](#scope) of this document.  This will include specification reviews, use case reviews and security test plans.
+
+In addition to these documents, the Security Task Force will establish and continually evolve a compliance test suite.
+
+# Relationships to External Groups
+This task force will need to work with a number of different groups both within and without W3C to be successful.  Within W3C, this task force will need to work with:
+
+* [W3C Security Activity](https://www.w3.org/Security/)
+* Web of Things WG
+* [Web of Things IG](https://www.w3.org/WoT/IG/)
+* [Web of Things CG](https://www.w3.org/community/wot/)
+* [Automotive WG](https://www.w3.org/auto/wg/)
+* [Web Security IG](https://www.w3.org/2011/07/security-ig-charter.html)
+* [Web Application Security WG](https://www.w3.org/2011/webappsec/)
+
+Additionally, this task force will work with security experts from any external organization that is defined in the WoT WG charter.
+
+# Participation
+Participation by security experts from any W3C group is welcome.  They must meet the [good standing requirements](Good Standing requirements) of the W3C Process.  Additionally, recognized external experts will also be welcomed.
+
+# Communication
+The WoT Security TF will primairly conduct its work on the public mail list TBD.
+
+The group will use the Web of Things Working Groupo home page to provide updated public information about its activities.
+
+Information about the group (deliverables, participants, face-to-face meetings, teleconfrences, etc.) is available from the Web of Things Working Group home page.
+
+# Decision Policy
+As Explained in the Process Document ([section 3.3](https://www.w3.org/Consortium/Process/policies#Consensus)), this group will seek to make decisions when there is consensus.  In cases where there is a need to formally produce a group resolution about a particular issue, its Chair will put a question about the issue to the group and gather responses (including any formal objections); then, after due consideration of all the responses, the Chair will record a group resolution (possibly after a formal vote and also along with responding to any formal objections).
+
+# About This Charter
+This charter for the Task Force within the Web of Things WG has been created according to [section 6.2](https://www.w3.org/Consortium/Process/groups#GAGeneral) of the [Process Document](https://www.w3.org/Consortium/Process).  In the event of a conflict between this document or the provisions of any charter and the W3C Process, the W3C Process shall take precedence
+
+---
+Charter author: Ryan Ware
+
+Copyright© 2016 W3C ® (MIT , ERCIM , Keio), All Rights Reserved.
+

--- a/TF-Security/README.md
+++ b/TF-Security/README.md
@@ -1,0 +1,4 @@
+# Interest Group on the Web of Things
+Github repository of the task force on Security
+
+Please find contributions to discuss security for WoT


### PR DESCRIPTION
This is the initial WoT Security TF Documentation.  This includes:

* README.md - A standard readme file.
* Charter.md - An initial proposed charter for the TF in markdown.