### PR TITLE
adds support for semantic types in exposedthing

### DIFF
--- a/current-practices/wot-practices.html
+++ b/current-practices/wot-practices.html
@@ -2156,15 +2156,20 @@ to CoAP requests to RS. </li>
 					</p>
 
 					<pre class="idl">
+						interface SemanticType {
+							attribute DOMString name;
+							attribute DOMString context;
+						};
+
 						interface ExposedThing {
 								readonly attribute DOMString name;
 							    Promise&lt;any&gt; invokeAction(DOMString actionName, any parameter);
 							    Promise&lt;any&gt; setProperty(DOMString propertyName, any newValue);
 							    Promise&lt;any&gt; getProperty(DOMString propertyName);
 								Promise&lt;any&gt; emitEvent(DOMString eventName, any payload);
-								ExposedThing addEvent(DOMString eventName, object payloadType);
-								ExposedThing addAction(DOMString actionName, object inputType, object outputType);
-								ExposedThing addProperty(DOMString propertyName, object contentType);
+								ExposedThing addEvent(DOMString eventName, object payloadType, optional SemanticType[] semanticType);
+								ExposedThing addAction(DOMString actionName, object inputType, object outputType, optional SemanticType[] semanticType);
+								ExposedThing addProperty(DOMString propertyName, object contentType, optional SemanticType[] semanticType);
 								ExposedThing onInvokeAction(DOMString actionName, ActionHandler callback);
 								ExposedThing onUpdateProperty(DOMString propertyName, PropertyChangeListener callback);
 								ExposedThing addListener(DOMString eventName, ThingEventListener listener);

--- a/scripting/proposals/typescript-definitions/index.d.ts
+++ b/scripting/proposals/typescript-definitions/index.d.ts
@@ -157,7 +157,7 @@ export interface DynamicThing extends ExposedThing {
     /**
      * declare a new eventsource for the thing
      */
-    addEvent(eventName: string): DynamicThing
+    addEvent(eventName: string, semanticType? : SemanticType[]): DynamicThing
 
     /**
      * remove a property from the thing
@@ -180,6 +180,10 @@ export interface DynamicThing extends ExposedThing {
  * To be discussed: simple form based on default context?
  */
 declare class SemanticType {
+
+    /** name / identifier */
     public name : string;
+
+    /** the context, e.g. URI for JSON-LD*/
     public context : string;
 }

--- a/scripting/proposals/typescript-definitions/index.d.ts
+++ b/scripting/proposals/typescript-definitions/index.d.ts
@@ -144,7 +144,7 @@ export interface DynamicThing extends ExposedThing {
      * @param propertyName Name of the property
      * @param valueType type specification of the value (JSON schema) 
      */
-    addProperty(propertyName: string, valueType: Object): DynamicThing
+    addProperty(propertyName: string, valueType: Object, semanticType? : SemanticType[]): DynamicThing
 
     /**
      * declare a new action for the thing
@@ -152,7 +152,7 @@ export interface DynamicThing extends ExposedThing {
      * @param inputType type specification of the parameter (optional, JSON schema)
      * @param outputType type specification of the return value (optional, JSON schema)
      */
-    addAction(actionName: string, inputType?: Object, outputType?: Object): DynamicThing
+    addAction(actionName: string, inputType?: Object, outputType?: Object, semanticType? : SemanticType[]): DynamicThing
 
     /**
      * declare a new eventsource for the thing
@@ -173,4 +173,13 @@ export interface DynamicThing extends ExposedThing {
      * remove an event from the thing
      */
     removeEvent(eventName: string): boolean
+}
+
+/**
+ * Semantic type for an interaction, eqiv. to the TD entries
+ * To be discussed: simple form based on default context?
+ */
+declare class SemanticType {
+    public name : string;
+    public context : string;
 }


### PR DESCRIPTION
as discussed in the scripting call on 23rd Feb 2017, I added an optional parameter to the add[Action|Property|Event] methods to enable a basic and backwards-compatible way of specifying semantic types for actions, properties and events.

Note: deeper explanation is missing yet - will be added after API rework on February F2F