### PR TITLE
Corrected Example 14 and 15 to use @type to indicate the interaction type

### DIFF
--- a/current-practices/wot-practices.html
+++ b/current-practices/wot-practices.html
@@ -669,7 +669,7 @@ to CoAP requests to RS. </li>
 					<pre class="example" title="Data Only">
                         {
                           "@context": ["http://w3c.github.io/wot/w3c-wot-td-context.jsonld"],
-                          "@type": "Thing",
+                          "@type": [ "Thing" ],
                           "name": "MyTemperatureThing",
                           "interaction": [
                             {
@@ -707,7 +707,7 @@ to CoAP requests to RS. </li>
 						"@context": ["http://w3c.github.io/wot/w3c-wot-td-context.jsonld",
 									 <span style="font-weight: bold; background-color: lightgrey;">{ "sensor": "http://example.org/sensors#" }</span>
 									],
-						  "@type": "Thing",
+						  "@type": [ "Thing" ],
 						  "name": "MyTemperatureThing",
 						  "interaction": [
 						    {
@@ -738,7 +738,7 @@ to CoAP requests to RS. </li>
 								"http://w3c.github.io/wot/w3c-wot-td-context.jsonld",
 								{ "actuator": "http://example.org/actuator#" }
 							],
-							"@type": "Thing",
+							"@type": [ "Thing" ],
 							"name": "MyLEDThing",
 							"base": "coap://myled.example.com:5683/",
 							"security": {
@@ -2521,7 +2521,7 @@ to CoAP requests to RS. </li>
 				<pre class="example">
 {
 	"@context": ["http://w3c.github.io/wot/w3c-wot-td-context.jsonld"],
-	"@type": "Thing",
+	"@type": [ "Thing" ],
 	"name": "TestThing",
 	"interaction": [{
 		"@type": ["Property"],

--- a/current-practices/wot-practices.html
+++ b/current-practices/wot-practices.html
@@ -1160,22 +1160,22 @@ to CoAP requests to RS. </li>
 					<pre class="example">
 						{
 							...
-						  "properties": [
+						  "interaction": [
+							...
 						    {
-									...
+						      "@type": ["Property"],
 						      "name": "temperature",
 						      "valueType": { "type": "number" },
 									...
-						    }
-						  ]
+						    },
 							...
-						  "events": [
 						    {
-									...
+						      "@type": ["Event"],
 						      "name": "criticalCondition",
 						      "valueType": { "type": "string" },
 									...
 						    }
+							...
 						  ]
 							...
 						}
@@ -1187,18 +1187,19 @@ to CoAP requests to RS. </li>
 					<pre class="example">
 						{
 							...
-						  "actions": [
+						  "interaction": [
+							...
 						    {
-									...
+						      "@type": ["Action"],
 						      "name": "fadeIn",
 						      "inputData": {
 						        "valueType": { "type": "number" },
 						        "actuator:unit": "actuator:ms"
 						      },
 						      "outputData":{ "type": "boolean" },
-						      
 									...
 						    }
+							...
 						  ]
 							...
 						}
@@ -1573,7 +1574,7 @@ to CoAP requests to RS. </li>
 							               "https://w3c.github.io/wot/w3c-wot-common-context.jsonld"],
 							  "@type": "Sensor",
 							  "name": "myTempSensor",
-							 "base" : "coap:///www.example.com:5683/temp/",
+							  "base" : "coap:///www.example.com:5683/temp/",
 							  "interaction": [
 							    {
 							      "@id": "val",


### PR DESCRIPTION
Corrected Example 14 and 15 to use @type to indicate the interaction type (i.e. Property, Action or Event)