### PR TITLE
add plugfest framework diagram

### DIFF
--- a/plugfest/2018-prague/preparation.md
+++ b/plugfest/2018-prague/preparation.md
@@ -56,7 +56,7 @@ Notes: The following contents has been just copied from Barlingame table. Please
 
 ## 2.3 Servients from plugfest participants ( diagram )
 
-TBD
+![Basic framework for PlurFests using Fujitsu's proxies](images/20180228-plugfest.png)
 
 # 3 Plugfest scenarios
 


### PR DESCRIPTION
adding the diagram of the PlugFest framework including all the expected Application Servients, Device Servients and Fujitsu's proxies.

Please note that I've added Eurecom's application based on the discussion during the PlugFest call on Feb. 21st. Also I changed the direction of the diagram by rotating it by 90 degrees so that we can easily add additional servients.

The SVG source of the diagram isalso  available at:
  https://github.com/w3c/wot/blob/master/plugfest/2018-prague/images/20180228-plugfest.svg

Kazuyuki