### PR TITLE
add TDs of Local simulator on VLAN2

### DIFF
--- a/plugfest/2018-sept-online/TDs/Panasonic/Local_simulator_on_VLAN2/PanaSimAirConditioner1.jsonld
+++ b/plugfest/2018-sept-online/TDs/Panasonic/Local_simulator_on_VLAN2/PanaSimAirConditioner1.jsonld
@@ -1,0 +1,126 @@
+{
+  "@context": [
+    "https://w3c.github.io/wot/w3c-wot-td-context.jsonld",
+    "https://w3c.github.io/wot/w3c-wot-common-context.jsonld",
+    {
+      "iot": "http://iotschema.org/"
+    }
+  ],
+  "@type": "Thing",
+  "name": "PanaSimAirConditioner1",
+  "id": "p-wot:PanaSimAirConditioner1",
+  "base": "http://10.8.2.5/wot/things/PanaSimAirConditioner1/",
+  "security": [
+    {
+      "scheme": "bearer",
+      "format": "jwt",
+      "alg": "ES256",
+      "authorizationUrl": "https://w3c.p-wot.com:8443/auth"
+    }
+  ],
+  "properties": {
+    "power": {
+      "label": "power",
+      "type": "boolean",
+      "writable": true,
+      "observable": true,
+      "forms": [
+        {
+          "href": "power",
+          "mediaType": "application/json"
+        },
+        {
+          "href": "http://10.8.2.5:8003/poll/PanaSimAirConditioner1/power",
+          "mediaType": "application/json",
+          "subProtocol": "LongPoll",
+          "rel": "observeProperty"
+        },
+        {
+          "href": "ws://10.8.2.5:8003/wot/things/PanaSimAirConditioner1/power",
+          "mediaType": "application/json",
+          "rel": "observeProperty"
+        }
+      ]
+    },
+    "operationMode": {
+      "label": "operationMode",
+      "type": "string",
+      "enum": [
+        "Auto",
+        "Cooling",
+        "Heating",
+        "Dehumidifying",
+        "Blast"
+      ],
+      "writable": true,
+      "observable": true,
+      "forms": [
+        {
+          "href": "operationMode",
+          "mediaType": "application/json"
+        },
+        {
+          "href": "http://10.8.2.5:8003/poll/PanaSimAirConditioner1/operationMode",
+          "mediaType": "application/json",
+          "subProtocol": "LongPoll",
+          "rel": "observeProperty"
+        },
+        {
+          "href": "ws://10.8.2.5:8003/wot/things/PanaSimAirConditioner1/operationMode",
+          "mediaType": "application/json",
+          "rel": "observeProperty"
+        }
+      ]
+    },
+    "desiredTemp": {
+      "label": "desiredTemp",
+      "type": "number",
+      "minimum": 16,
+      "maximum": 30,
+      "writable": true,
+      "observable": true,
+      "forms": [
+        {
+          "href": "desiredTemp",
+          "mediaType": "application/json"
+        },
+        {
+          "href": "http://10.8.2.5:8003/poll/PanaSimAirConditioner1/desiredTemp",
+          "mediaType": "application/json",
+          "subProtocol": "LongPoll",
+          "rel": "observeProperty"
+        },
+        {
+          "href": "ws://10.8.2.5:8003/wot/things/PanaSimAirConditioner1/desiredTemp",
+          "mediaType": "application/json",
+          "rel": "observeProperty"
+        }
+      ]
+    },
+    "windVolumeLevel": {
+      "label": "windVolumeLevel",
+      "type": "number",
+      "minimum": 1,
+      "maximum": 3,
+      "writable": true,
+      "observable": true,
+      "forms": [
+        {
+          "href": "windVolumeLevel",
+          "mediaType": "application/json"
+        },
+        {
+          "href": "http://10.8.2.5:8003/poll/PanaSimAirConditioner1/windVolumeLevel",
+          "mediaType": "application/json",
+          "subProtocol": "LongPoll",
+          "rel": "observeProperty"
+        },
+        {
+          "href": "ws://10.8.2.5:8003/wot/things/PanaSimAirConditioner1/windVolumeLevel",
+          "mediaType": "application/json",
+          "rel": "observeProperty"
+        }
+      ]
+    }
+  }
+}

--- a/plugfest/2018-sept-online/TDs/Panasonic/Local_simulator_on_VLAN2/PanaSimCleaner1.jsonld
+++ b/plugfest/2018-sept-online/TDs/Panasonic/Local_simulator_on_VLAN2/PanaSimCleaner1.jsonld
@@ -1,0 +1,83 @@
+{
+  "@context": [
+    "https://w3c.github.io/wot/w3c-wot-td-context.jsonld",
+    "https://w3c.github.io/wot/w3c-wot-common-context.jsonld",
+    {
+      "iot": "http://iotschema.org/"
+    }
+  ],
+  "@type": "Thing",
+  "name": "PanaSimCleaner1",
+  "id": "p-wot:PanaSimCleaner1",
+  "base": "http://10.8.2.5/wot/things/PanaSimCleaner1/",
+  "security": [
+    {
+      "scheme": "bearer",
+      "format": "jwt",
+      "alg": "ES256",
+      "authorizationUrl": "https://w3c.p-wot.com:8443/auth"
+    }
+  ],
+  "properties": {
+    "power": {
+      "@type": "iot:SwitchToggle",
+      "label": "power",
+      "type": "boolean",
+      "writable": false,
+      "observable": false,
+      "forms": [
+        {
+          "href": "power",
+          "mediaType": "application/json"
+        }
+      ]
+    }
+  },
+  "actions": {
+    "operationPower": {
+      "label": "operationPower",
+      "forms": [
+        {
+          "href": "action/operationPower",
+          "mediaType": "application/json"
+        }
+      ]
+    },
+    "turnRight": {
+      "label": "turnRight",
+      "forms": [
+        {
+          "href": "action/turnRight",
+          "mediaType": "application/json"
+        }
+      ]
+    },
+    "turnLeft": {
+      "label": "turnLeft",
+      "forms": [
+        {
+          "href": "action/turnLeft",
+          "mediaType": "application/json"
+        }
+      ]
+    },
+    "goStraight": {
+      "label": "goStraight",
+      "forms": [
+        {
+          "href": "action/goStraight",
+          "mediaType": "application/json"
+        }
+      ]
+    },
+    "goHome": {
+      "name": "goHome",
+      "forms": [
+        {
+          "href": "action/goHome",
+          "mediaType": "application/json"
+        }
+      ]
+    }
+  }
+}

--- a/plugfest/2018-sept-online/TDs/Panasonic/Local_simulator_on_VLAN2/PanaSimDrone1.jsonld
+++ b/plugfest/2018-sept-online/TDs/Panasonic/Local_simulator_on_VLAN2/PanaSimDrone1.jsonld
@@ -1,0 +1,92 @@
+{
+  "@context": [
+    "https://w3c.github.io/wot/w3c-wot-td-context.jsonld",
+    "https://w3c.github.io/wot/w3c-wot-common-context.jsonld",
+    {
+      "iot": "http://iotschema.org/"
+    }
+  ],
+  "@type": "Thing",
+  "name": "PanaSimDrone1",
+  "id": "p-wot:PanaSimDrone1",
+  "base": "http://10.8.2.5/wot/things/PanaSimDrone1/",
+  "security": [
+    {
+      "scheme": "bearer",
+      "format": "jwt",
+      "alg": "ES256",
+      "authorizationUrl": "https://w3c.p-wot.com:8443/auth"
+    }
+  ],
+  "properties": {
+    "power": {
+      "@type": "iot:SwitchToggle",
+      "label": "power",
+      "type": "boolean",
+      "writable": false,
+      "observable": false,
+      "forms": [
+        {
+          "href": "power",
+          "mediaType": "application/json"
+        }
+      ]
+    }
+  },
+  "actions": {
+    "up": {
+      "label": "up",
+      "forms": [
+        {
+          "href": "action/up",
+          "mediaType": "application/json"
+        }
+      ]
+    },
+    "down": {
+      "label": "down",
+      "forms": [
+        {
+          "href": "action/down",
+          "mediaType": "application/json"
+        }
+      ]
+    },
+    "left": {
+      "label": "left",
+      "forms": [
+        {
+          "href": "action/left",
+          "mediaType": "application/json"
+        }
+      ]
+    },
+    "right": {
+      "label": "right",
+      "forms": [
+        {
+          "href": "action/right",
+          "mediaType": "application/json"
+        }
+      ]
+    },
+    "release": {
+      "name": "release",
+      "forms": [
+        {
+          "href": "action/release",
+          "mediaType": "application/json"
+        }
+      ]
+    },
+    "capture": {
+      "label": "capture",
+      "forms": [
+        {
+          "href": "action/capture",
+          "mediaType": "application/json"
+        }
+      ]
+    }
+  }
+}

--- a/plugfest/2018-sept-online/TDs/Panasonic/Local_simulator_on_VLAN2/PanaSimHueGroup1.jsonld
+++ b/plugfest/2018-sept-online/TDs/Panasonic/Local_simulator_on_VLAN2/PanaSimHueGroup1.jsonld
@@ -1,0 +1,87 @@
+{
+  "@context": [
+    "https://w3c.github.io/wot/w3c-wot-td-context.jsonld",
+    "https://w3c.github.io/wot/w3c-wot-common-context.jsonld",
+    {
+      "iot": "http://iotschema.org/"
+    }
+  ],
+  "@type": "Thing",
+  "name": "PanaSimHueGroup1",
+  "id": "p-wot:PanaSimHueGroup1",
+  "base": "http://10.8.2.5/wot/things/PanaSimHueGroup1/",
+  "security": [
+    {
+      "scheme": "bearer",
+      "format": "jwt",
+      "alg": "ES256",
+      "authorizationUrl": "https://w3c.p-wot.com:8443/auth"
+    }
+  ],
+  "properties": {
+    "power": {
+      "@type": "iot:SwitchToggle",
+      "label": "power",
+      "type": "boolean",
+      "writable": true,
+      "observable": true,
+      "forms": [
+        {
+          "href": "power",
+          "mediaType": "application/json"
+        },
+        {
+          "href": "http://10.8.2.5:8003/poll/PanaSimHueGroup1/power",
+          "mediaType": "application/json",
+          "subProtocol": "LongPoll",
+          "rel": "observeProperty"
+        },
+        {
+          "href": "ws://10.8.2.5:8003/wot/things/PanaSimHueGroup1/power",
+          "mediaType": "application/json",
+          "rel": "observeProperty"
+        }
+      ]
+    },
+    "rgbValue": {
+      "label": "rgbValue",
+      "type": "object",
+      "properties": {
+        "red": {
+          "type": "number",
+          "minimum": 0,
+          "maximum": 1
+        },
+        "green": {
+          "type": "number",
+          "minimum": 0,
+          "maximum": 1
+        },
+        "blue": {
+          "type": "number",
+          "minimum": 0,
+          "maximum": 1
+        }
+      },
+      "writable": true,
+      "observable": true,
+      "forms": [
+        {
+          "href": "rgbValue",
+          "mediaType": "application/json"
+        },
+        {
+          "href": "http://10.8.2.5:8003/poll/PanaSimHueGroup1/rgbValue",
+          "mediaType": "application/json",
+          "subProtocol": "LongPoll",
+          "rel": "observeProperty"
+        },
+        {
+          "href": "ws://10.8.2.5:8003/wot/things/PanaSimHueGroup1/rgbValue",
+          "mediaType": "application/json",
+          "rel": "observeProperty"
+        }
+      ]
+    }
+  }
+}

--- a/plugfest/2018-sept-online/TDs/Panasonic/Local_simulator_on_VLAN2/PanaSimRoomLight1.jsonld
+++ b/plugfest/2018-sept-online/TDs/Panasonic/Local_simulator_on_VLAN2/PanaSimRoomLight1.jsonld
@@ -1,0 +1,135 @@
+{
+  "@context": [
+    "https://w3c.github.io/wot/w3c-wot-td-context.jsonld",
+    "https://w3c.github.io/wot/w3c-wot-common-context.jsonld",
+    {
+      "iot": "http://iotschema.org/"
+    }
+  ],
+  "@type": "Thing",
+  "name": "PanaSimRoomLight1",
+  "id": "p-wot:PanaSimRoomLight1",
+  "base": "http://10.8.2.5/wot/things/PanaSimRoomLight1/",
+  "security": [
+    {
+      "scheme": "bearer",
+      "format": "jwt",
+      "alg": "ES256",
+      "authorizationUrl": "https://w3c.p-wot.com:8443/auth"
+    }
+  ],
+  "properties": {
+    "power": {
+      "@type": "iot:SwitchToggle",
+      "label": "power",
+      "type": "boolean",
+      "writable": true,
+      "observable": true,
+      "forms": [
+        {
+          "href": "power",
+          "mediaType": "application/json"
+        },
+        {
+          "href": "http://10.8.2.5:8003/poll/PanaSimRoomLight1/power",
+          "mediaType": "application/json",
+          "subProtocol": "LongPoll",
+          "rel": "observeProperty"
+        },
+        {
+          "href": "ws://10.8.2.5:8003/wot/things/PanaSimRoomLight1/power",
+          "mediaType": "application/json",
+          "rel": "observeProperty"
+        }
+      ]
+    },
+    "color": {
+      "label": "color",
+      "type": "string",
+      "enum": [
+        "red",
+        "blue",
+        "white"
+      ],
+      "writable": true,
+      "observable": true,
+      "forms": [
+        {
+          "href": "color",
+          "mediaType": "application/json"
+        },
+        {
+          "href": "http://10.8.2.5:8003/poll/PanaSimRoomLight1/color",
+          "mediaType": "application/json",
+          "subProtocol": "LongPoll",
+          "rel": "observeProperty"
+        },
+        {
+          "href": "ws://10.8.2.5:8003/wot/things/PanaSimRoomLight1/color",
+          "mediaType": "application/json",
+          "rel": "observeProperty"
+        }
+      ]
+    },
+    "luminance": {
+      "@type": "iot:CurrentLevel",
+      "label": "luminance",
+      "type": "number",
+      "writable": false,
+      "observable": false,
+      "forms": [
+        {
+          "href": "luminance",
+          "mediaType": "application/json"
+        }
+      ]
+    }
+  },
+  "events": {
+    "alert": {
+      "label": "alert",
+      "type": "object",
+      "properties": {
+        "message": {
+          "type": "string"
+        }
+      },
+      "forms": [
+        {
+          "href": "event/alert",
+          "mediaType": "application/json",
+          "subProtocol": "X-Panasonic-LateBinding"
+        },
+        {
+          "href": "http://10.8.2.5:8003/poll/PanaSimRoomLight1/alert",
+          "mediaType": "application/json",
+          "subProtocol": "LongPoll"
+        },
+        {
+          "href": "ws://10.8.2.5:8003/wot/things/PanaSimRoomLight1/alert",
+          "mediaType": "application/json"
+        }
+      ]
+    },
+    "detect": {
+      "label": "detect",
+      "type": "null",
+      "forms": [
+        {
+          "href": "event/detect",
+          "mediaType": "application/json",
+          "subProtocol": "X-Panasonic-LateBinding"
+        },
+        {
+          "href": "http://10.8.2.5:8003/poll/PanaSimRoomLight1/detect",
+          "mediaType": "application/json",
+          "subProtocol": "LongPoll"
+        },
+        {
+          "href": "ws://10.8.2.5:8003/wot/things/PanaSimRoomLight1/detect",
+          "mediaType": "application/json"
+        }
+      ]
+    }
+  }
+}

--- a/plugfest/2018-sept-online/TDs/Panasonic/README.md
+++ b/plugfest/2018-sept-online/TDs/Panasonic/README.md
@@ -14,3 +14,8 @@
 ## Online simulator
 
 See [simulator portal](https://w3c.p-wot.com:3011) (Access restricted to plugfest participants only).
+
+## Local simulator on VLAN2
+
+- You can use Local simulator on VLAN2 just like Online simulator.
+- TDs that include ip address are [here](Local_simulator_on_VLAN2).

--- a/plugfest/2018-sept-online/TDs/Panasonic/README.md
+++ b/plugfest/2018-sept-online/TDs/Panasonic/README.md
@@ -18,4 +18,5 @@ See [simulator portal](https://w3c.p-wot.com:3011) (Access restricted to plugfes
 ## Local simulator on VLAN2
 
 - You can use Local simulator on VLAN2 just like Online simulator.
+- Local simulator is [here](http://10.8.2.5) (Access restricted to VLAN2 only).
 - TDs that include ip address are [here](Local_simulator_on_VLAN2).


### PR DESCRIPTION
- You can use Local simulator on VLAN2 just like Online simulator.
- TDs include ip address.