### PR TITLE
Add implementation descriptions so far for testfest

### DIFF
--- a/testfest/2018-12-online/implementations/ercim.html
+++ b/testfest/2018-12-online/implementations/ercim.html
@@ -1,0 +1,28 @@
+<div class="impl" id="impl-ercim">
+<h3>W3C/ERCIM</h3>   
+<p><a href="https://github.com/draggett/arena-webhub">Arena Web Hub</a> 
+is an open source node-based application server for the Web of Things 
+that has been implemented with support from the European Commission for the 
+<a href="https://www.f-interop.eu">F-Interop project</a> 
+as a means to demonstrate high level interoperability testing for the Web of Things.</p>
+<p>One of the example applications is a browser-based test suite for both client and server 
+in respect to the contract implied by a Thing Description. 
+This uses a specially designed Thing Description, 
+together with associated client and server applications,
+and has been developed to cover the constraints implied by 
+the data schemas defined by the Thing Description specification.</p>
+<h4 id="impl-ercim-arena-client">Arena Client: TD Consumer</h4>
+<p>This is a browser-based JavaScript library designed to support multiple server platforms, 
+including the Arena Web Hub, Eclipse ThingWeb (node-wot), and Mozilla's Things Gateway.</p>
+<h4 id="impl-ercim-arena-webhub">Arena WebHub: TD Producer</h4>
+<p>Arena Web Hub is a secure by design application server with support for HTTPS and WebSockets. 
+HTTPS is used together with a bearer token for access control, 
+along with support for Server-Sent Events and Long Polling. 
+You can get or set the values of all properties in a single transaction. 
+The WebSockets sub-protocol is initiated via a protocol upgrade request from HTTPS, 
+and includes suppport for properties, actions and events. 
+This makes use of a RESTful request/response pattern with the same status codes as for HTTPS. 
+Arena has minimal dependencies on other modules and can be installed 
+via npm or a git clone of the open source repository. 
+Applications can combine the producer and consumer modules as needed.</p>
+</div>

--- a/testfest/2018-12-online/implementations/hitachi.html
+++ b/testfest/2018-12-online/implementations/hitachi.html
@@ -1,0 +1,15 @@
+<div class="impl" id="impl-hitachi">   
+<h3>Hitachi, Ltd.</h3>   
+<p>Hitachi understands the importance of standardization
+    to make the world seamlessly connected, and strongly supports W3C's activities.</p>
+<p>Hitachi expects that standardization of Web of Things enables easy integration
+    accross various Things and IoT platforms.  We create a tool for
+    rapid application development using <a href="https://nodered.org/">Node-RED</a>,
+    called <a href="https://github.com/k-toumura/node-red-nodegen/tree/webofthings">Node generator</a>.</p>
+<h4 id="impl-hitachi-nodegen">Node generator for Node-RED: TD consumer</h4>
+<p>Node generator is command line tool to generate Node-RED node modules from several
+ various sources including Thing Description of Web of Things. 
+ Using this tool, node developers can dramatically reduce their time 
+ to implement Node-RED node modules.
+</p>
+</div>

--- a/testfest/2018-12-online/implementations/intel.html
+++ b/testfest/2018-12-online/implementations/intel.html
@@ -1,0 +1,78 @@
+<div class="impl" id="impl-intel">
+<h3>Intel Corporation</h3>   
+<p>Intel supports this specification as it enables interoperation between devices
+from different manufacturers, supporting the growth of an ecosystem of interoperating
+IoT services and easing barriers to adoption.
+</p>
+<p>Three separate implementations were developed, all based on Node.js.
+The core implementations focused on basic local network access without built-in security.
+A separate project, used by all three implementations, provided security (encryption and
+authentication) by means of a reverse proxy. 
+For the purposes of validation this reverse proxy was considered a shared component of all three implementations, 
+and the features it implemented were only counted once in the results.
+</p>
+<h4 id="impl-intel-security">Security Proxy: Shared Component</h4>
+This component, shared across all implementations provided by Intel, was a reverse proxy service that provided
+authentication (via various mechanisms indicated by the schemes indicated in the Thing
+Description) and encrypted transport termination.
+The reverse proxy service was made accessible over a secure tunnel, and depending on the circumstances,
+was run in the cloud, on a gateway computer, or locally on a device.
+As this component implemented the security features in all other implementations
+from Intel, for the purposes of validation
+these features are only recorded as being supported in a single implementation.
+</p>
+<h4 id="impl-intel-ocf">OCF Metadata Translator: TD Producer</h4>
+<p>This implementation translated metadata made available by devices implemented using
+the OCF standard and re-expressed that metadata in the form of WoT Thing Descriptions.
+The actual network interfaces were however provided either by the OCF devices themselves
+directly via CoAP, or via a CoAP/HTTP bridge developed by OCF. 
+The metadata
+translator also had the ability to add semantic markup to the generated WoT Thing Descriptions,
+using a database that related OCF Resource Types to iotschema.org capabilities.
+It also had the capability to register generated TDs with directory services.
+Secure interfaces (e.g. HTTPS combined with an authentication scheme) were provided
+via a reverse proxy attached to the HTTP interface provided by the OCF CoAP/HTTP bridge.
+</p>
+<p>The OCF devices were based on the OCF Smart Home Demo and included both
+real and simulated devices. Real devices used for testing included
+<ol>
+<li>ON\OFF Lights (various: MOSFET, Relay, LEDs),</li>
+<li>RGB Light,</li>
+<li>Potentiometer (analog input),</li>
+<li>Toggle Switch,</li>
+<li>Pushbutton,</li>
+<li>IR Motion Sensor,</li>
+<li>Illuminance Sensor, and</li>
+<li>Buzzer.</li>
+</ol>
+There were also multiple instances of many of these devices, each given 
+unique identifiers.
+</p>
+</p>
+<h4 id="impl-intel-speak">WebSpeak: TD Producer</h4>
+<p>This implementation provided a service to convert text to speech.  English
+text set to its network interface was spoken audibily.  This service was used to
+test several accessibility scenarios, including automatic conversion of visible status
+and event information to spoken announcements in order to support blind users.
+This implementation only supported an HTTP network interface, without security.
+Secure interfaces (eg HTTPS combined with an authentication scheme) were provided
+via a reverse proxy attached to the HTTP interface.
+The TDs for this service were generated using a template mechanism,
+and the service also had the capability to automatically register these
+TDs with a directory service.
+</p>
+<h4 id="impl-intel-camera">Simple Web Camera: TD Producer</h4>
+<p>This implementation provided a service to capture still images from a camera
+and provide them over its network interface.  This was used to test various aspects
+of actions, including support for inputs and outputs with different content types.
+The service was also capaple of introspecting the parameters made available via any
+particular attached video4linux camera
+and made those parameters available as WoT Thing Description properties.
+This implementation only supported an HTTP network interface, without security.
+Secure interfaces (eg HTTPS combined with an authentication scheme) were provided
+via a reverse proxy attached to the HTTP interface.
+The TDs for this service were generated using a template mechanism,
+and the service also had the capability to automatically register these
+TDs with a directory service.
+</p>
+</div>

--- a/testfest/2018-12-online/implementations/oracle.html
+++ b/testfest/2018-12-online/implementations/oracle.html
@@ -1,0 +1,86 @@
+<div class="impl" id="impl-oracle"> 
+<h3>Oracle Corporation</h3>
+<p>
+Oracle supports this specification as it enables manufacturers of IoT cloud platforms and applications
+to integrate devices across multiple vendors, who describe their features and functionality in a uniform way. 
+This enables application scenarios that allow monitoring and control of devices from different manufacturers.
+Flexible rules can be used to define alert conditions that trigger actions on devices based on sensor data from other devices.
+Sensor data combined with big data analytics can be used to predict maintenance needs of devices
+to prevent downtime.
+</p>
+<p>
+A common way of describing devices grows the ecosystem of devices that can be easily integrated into 
+cloud platforms out of the box and thus enables creating digital twins of physical devices
+for asset monitoring, production monitoring, fleet management, and the management of buildings and smart cities.
+</p>
+<p>
+Oracle offers an IoT cloud platform that enables management of devices, messages and alerts.
+This platform is complemented with applications for asset monitoring, production monitoring, fleet management
+and connected workers.
+This platform interoperates with WoT servients as described in the sections below.
+</p>
+
+<h4 id="impl-oracle-converters">Thing description - Device Model Converters</h4>
+<p>Oracle's IoT cloud platform defines a device model abstraction that is used to describe the common
+behaviour of a class of devices via properties (attributes), actions, messages and alerts.
+This format is similar to the WoT thing description and thing descriptions can be converted
+to device models and vice versa.<br>
+Devices that are managed by the IoT cloud platform can be expose using the WoT thing description format
+and devices that are described via thing descriptions can be consumed from the IoT cloud service. 
+Oracle provides open source implementations of converters to generate a device model from a thing description (td2dm)
+and vice versa (dm2td).
+</p>
+
+<h4 id="impl-oracle-simulators">Oracle Digital Twin Simulator: Exposing Device TDs</h4>
+<p> 
+Oracle's IoT Cloud Service includes a simulator for devices which allows to model 
+and test asset monitoring scenarios without having the physical device already available.
+This allows experimenting with different device models and finding the right abstraction
+before a device is actually manufacturered and thus reduce the implementation risk.
+Various device simulations were defined:
+
+<ul>
+<li>HVAC</li>  
+<li>BluePump</li>
+<li>Truck</li>
+<li>Connected Car</li>  
+</ul>
+
+These simulations were exposed via TDs that were generated from device models using 
+the converters above.
+The simulator uses HTTP/REST with JSON to interact with the devices. 
+
+TD's for devices from other manufacterer were imported using the td2dm converter and
+simulators were defined for the following devices:
+
+<ul>
+<li>Fujitsu's rotary beacon light</li>
+<li>Intel's RGB light</li>
+<li>Panasonic's air conditioner</li>
+<li>Panasonic's hue light</li>
+<li>Siemens Festo Plant</li>
+<li>KETI environment sensor</li>
+</ul>
+
+</p>
+
+<h4 id="impl-oracle-node-wot">Node-WoT with Oracle Binding: Consuming TDs</h4>
+<p> 
+Node-Wot contains a binding to Oracle's IoT Cloud Service.
+The binding uses Oracle's JavaScript client library that encapsulates 
+Oracle's proprietary device to cloud communication protocol.
+The integration allows to consume TDs for devices from other manufacturers and to read properties
+and trigger actions on these devices.
+</p>
+
+<h4 id="impl-oracle-asset-monitoring">Oracle Asset Monitoring: Interoperability across Manufacturers</h4>
+<p>
+Oracle's Asset Monitoring application is used to define scenarios that combine devices from 
+different manufacturers. Flexible rules trigger actions and issue alerts based on sensor data from 
+other devices.<br>
+In an industrial scenario that integrates devices from KETI, Fujitsu, Siemens and Intel was defined
+and several rules control RGB lights, speech output, a valve and a pump based on sensor 
+data from different devices.
+</p>
+
+</div>

--- a/testfest/2018-12-online/implementations/panasonic.html
+++ b/testfest/2018-12-online/implementations/panasonic.html
@@ -1,0 +1,89 @@
+<div class="impl" id="impl-panasonic"> 
+<h3>Panasonic Corporation</h3>
+<p>
+Panasonic supports this specification as it enables device manufacturers 
+to describe features and functionality of multiple devices in a uniform way. 
+This will make it possible to build mash-up applications easily with multiple devices 
+not only from single vendor but also from different vendors, which will expand the ecosystem.
+</p>
+<p>
+Panasonic already has various IoT devices in the market and this specification is the 
+first candidate to be used for the directory system to discover those devices.
+At the moment, 
+Panasonic implements two types of clients (TD consumer) as well as two types of servers (TD producer), 
+together with independent authentication server as a shared component, for experimental purposes.
+</p>
+
+<h4 id="impl-panasonic-authentication">Authentication Server: Shared Component</h4>
+<p>This component provides authentication functionality for users who access Panasonic things (TD producers) 
+such as the real things or simulated things provided by other implementations. 
+This component supports HTTPS, 
+receives a predetermined userid and password via an HTTP POST method and sends back a bearer token based on JWT.
+The token should be placed in the Authentication request header upon access to a Thing supporting
+the `"bearer"` security scheme. 
+The URL and other information of this component is provided in the security 
+elements of the Thing Descriptions produced by Panasonic things. </p>
+
+<h4 id="impl-panasonic-client-browser">Browser Based Client: TD Consumer</h4>
+<p>This implementation is a TD Consumer which works on the Chrome browser. 
+This implementation reads a Thing Description from a designated URL via HTTP(S), 
+expands its properties, actions and events into UI form, 
+then allows user to read, write or observe a property value, 
+invoke an action, 
+or subscribe/unsubscribe to an event through the UI. 
+When the TD indicates that the thing needs a bearer token, 
+this implementation also supports the settting of user credentials such as userid and password 
+and retrieves the access token from the authentication service at the URL designated in the TD, 
+such as the Panasonic Authentication Server explained above. 
+This implementation also allows the manual addition of any HTTP headers 
+to the request message sent to the things.
+</p>
+<p>This implementation basically supports only HTTP(S) and does not support CoAP and MQTT. 
+For observe property and events, 
+this implementation supports both HTTP(S) long poll and a simple WebSocket protocol 
+which contains only a data value in its transaction. 
+This implementation only supports application/json as message body and does not support text/plain. 
+Since this implementation is browser based and uses Ajax, 
+its default mode requires support of CORS from the server exposing the Things, 
+unless the chrome browser is launched with the <code>--disable-web-security</code> option.
+</p>
+
+<h4 id="impl-panasonic-client-nodered">Node-RED Based Client: TD Consumer</h4>
+<p>This implementation is a TD Consumer which works on Node-RED. 
+This implementation reads a Thing Description from a designated URL via HTTP(S) and from a local folder, 
+finds a specific thing according to a semantic annotation, and turns the thing on/off. 
+The implementation supports only HTTP(S) with `"nosec"` and `"basic"` authorization. 
+For MQTT and WebSockets, 
+this implementation needs a hard-coded URL due to the restriction of normal Node-RED.
+</p>
+
+<h4 id="impl-panasonic-server-real">WoT Server for Real Devices: TD Producer</h4>
+<p>This implementation is a TD producer which is hosted on a cloud server and 
+connected to real things in the lab through a proprietary tunneling mechanism alike to remote and local WoT proxy. 
+This implementation accepts HTTP bindings with bearer token authorization issued by the 
+Panasonic Authentication Server explained above. 
+This implementation currently provides the following things: 
+<ol>
+<li>Two Home Air Conditioners,</li> 
+<li>One robotics cleaner,</li> 
+<li>One set of Philips Hue Lighting and</li> 
+<li>Two LED bulletin boards.</li> 
+</ol>
+This implementation is based on Apache HTTP server with plugins written in PHP. </p>
+
+<h4 id="impl-panasonic-server-simulator">WoT Simulator: TD Producer</h4>
+<p>This implementation is a TD producer which is hosted on a cloud server and 
+hosts virtual things running on the server. 
+This implementation accepts HTTP bindings with bearer token authorization issued by the 
+Panasonic Authentication Server explained above. 
+This implementation currently provides simulation of things such as 
+<ol>
+<li>Home Air Conditioner,</li> 
+<li>Robotics cleaner,</li> 
+<li>Philips Hue Lighting and</li> 
+<li>Simple LED lighting.</li> 
+</ol>
+This implementation is based on Node.js. 
+This implementation is portable and also can be run on a local machine such as a Raspberry Pi. 
+</p>
+</div>

--- a/testfest/2018-12-online/implementations/siemens.html
+++ b/testfest/2018-12-online/implementations/siemens.html
@@ -1,0 +1,51 @@
+<div class="impl" id="impl-siemens">   
+<h3>Siemens AG</h3>   
+<p>
+Siemens supports this specification as it allows manufacturers
+to attach metadata to heterogeneous IoT devices and services in a uniform way.
+The extensible model with a standardized serialization format in particular remedies interoperability challenges 
+with an installed base of long-lived industrial devices.
+Furthermore, 
+this specification is a central building block for several digitalization topics such as 
+device onboarding, 
+device management, 
+digital twins, 
+and 
+data analytics.
+</p>
+<p>
+Siemens commits to several open-source implementations of W3C Web of Things, 
+which are managed in the public Eclipse Thingweb project.
+Siemens also implemented concepts of this specification in products and 
+aims at aligning the implementations and opening the features to customers 
+once this specification reaches REC status.
+</p>
+<h4 id="impl-siemens-node-wot">node-wot: TD Consumer and Producer</h4>
+<p>
+The node-wot implementation is a Node.js-based framework for WoT Servients.
+It features an implementation of the WoT Scripting API to both consume TDs to instantiate Consumed Things 
+and produce Exposed Things that provide a TD.
+The node-wot implementation supports several Protocol Bindings including 
+HTTP, CoAP, WebSockets, and MQTT,
+with corresponding security mechanisms such as 
+DTLS (CoAP); 
+TLS (HTTP, MQTT),
+Basic, Digest, and Bearer Token authentication (HTTP), 
+PSK (CoAP), and 
+username/password authentication (MQTT). 
+</p>
+<h4 id="impl-siemens-thingweb-directory">Thingweb Directory: TD Consumer and Producer</h4>
+<p>
+The Thingweb Directory provides a directory service written in Java to register TDs 
+and look them up through queries (primarily SPARQL).
+The implementation consumes TDs registered with it through a web API,
+represent their metadata in a KnowledgeGraph, and (re-)produces TDs to return the results of queries.
+Currently it supports HTTP and CoAP bindings.
+</p>
+<h4 id="impl-siemens-wot-fxui">WoT-fxUI: TD Consumer</h4>
+<p>
+WoT-fxUI is a generic user interface (UI) for Things based on Java with JavaFX.
+It consumes TDs to render UI elements that allow human users to interact with Things.
+The implementation currently supports HTTP and CoAP bindings.
+</p>
+</div>

--- a/testfest/2018-12-online/implementations/template.html
+++ b/testfest/2018-12-online/implementations/template.html
@@ -1,0 +1,19 @@
+<div class="impl" id="impl-ORG">   
+<h3>TEMPLATE: YOUR ORG NAME HERE</h3>   
+<p><em>Testimonial. State support for specification, and organizational reasons for support.</em></p>
+<p><em>State any additional general statements about implementations; omit if not needed.</em></p>
+<h4 id="impl-ORG-NAME1">Component 1: Shared Component</h4>
+<p><em>If a service or module is used as a component in more than one implementation, and if that 
+component is used to implement some testable feature, describe it separately so its contribution is only counted once.
+Describe Shared Component 1.</em></p>
+<h4 id="impl-ORG-NAME1">Implementation 1: TD Consumer</h4>
+<p><em>Example for a client (consumes at least one TD).  This category can include other services that consume TDs, such
+as proxies.  Describe Implementation 1.</em></p>
+<h4 id="impl-ORG-NAME2">Implementation 2: TD Procuder</h4>
+<p><em>Example for a server (exposes at least one TD).  This category can include other services that generate TDs, such 
+as metadata translators.  Describe Implementation 2.</em></p>
+<h4 id="impl-ORG-NAME3">Implementation 2: TD Producer and Consumer</h4>
+<p><em>Example for a servient (exposes at least one TD and consumes at least one other TD).
+This category can include other services that both consume and produce TDs, such as directories.
+Describe Implementation 3.</em></p>
+</div>


### PR DESCRIPTION
Try to put all the testfest data in one place so we have a historical record.    I will pull data from here to create the report.  Note: the Oracle implementation description needs some work to make it consistent with the others, I will create a PR (against this repo) for that with some suggested changes.