### PR TITLE
Where to put implemetation description HTML files

### DIFF
--- a/testfest/2018-12-online/README.md
+++ b/testfest/2018-12-online/README.md
@@ -15,7 +15,8 @@ For the Test Fest,
 1. Submit TDs at https://github.com/w3c/wot/tree/master/testfest/2018-12-online/TDs
 2. Submit CSV-based reports: https://github.com/w3c/wot/tree/master/testfest/2018-12-online/results
       - McCool will copy them here: https://github.com/mmccool/wot-thing-description/tree/updated-test-results/testing/inputs/results
-3. Implementation description: https://github.com/mmccool/wot-thing-description/tree/updated-test-results/testing/inputs/implementations
+3. Implementation description: https://github.com/w3c/wot/tree/master/testfest/2018-12-online/implementations
+      - McCool will copy them here: https://github.com/mmccool/wot-thing-description/tree/updated-test-results/testing/inputs/implementations
 
 ## Automation
 Not yet working but eventually...


### PR DESCRIPTION
Based on the discussion during the TestFest yesterday (https://www.w3.org/2018/12/12-wot-pf-minutes.html), people are encouraged to make pullrequests to copy their implementation description HTML to https://github.com/w3c/wot/tree/master/testfest/2018-12-online/implementations , and McCool will copy them to his repo.