### PR TITLE
revised Hitachi's test report.

### DIFF
--- a/testing/tests/2019-05/inputs/Hitachi/hitachi.csv
+++ b/testing/tests/2019-05/inputs/Hitachi/hitachi.csv
@@ -3,21 +3,37 @@
 "client-data-schema-accept-extras","pass",
 "client-data-schema-no-extras","pass",
 "client-uri-template","pass",
-"td-content-type-default","pass",
-"td-idempotent-safe-default","pass",
-"td-readOnly-observable-writeOnly-default","pass",
-"td-default-readOnly","pass",
-"td-default-writeOnly","pass",
-"td-default-observable","pass",
-"td-default-contentType","pass",
-"td-default-safe","pass",
-"td-default-idempotent","pass",
-"td-default-in-1","pass",
-"td-default-in-2","pass",
-"td-default-qop","pass",
-"td-default-alg","pass",
-"td-default-format","pass",
-"td-default-flow","pass",
-"td-default-context-of-dataschema", "fail",
-"td-default-context-of-securityscheme", "pass",
-"td-default-context-of-thing", "pass",
+"iana-security-alter","null","remote context is not supported"
+"iana-security-execution","pass",
+"iana-security-expansion","null","sanitization is not yet tested"
+"iana-security-remote","null","remote context is not supported"
+"td-default-alg","pass","see issue #702; ES256 for alg"
+"td-default-alg-pop","pass","see issue #702; ES256 for alg"
+"td-default-contentType","pass","see issue #702; application/json for contentType"
+"td-default-flow","pass","see issue #702; implicit for flow"
+"td-default-format","pass","see issue #702; jwt for format"
+"td-default-format-pop","pass","see issue #702; jwt for format"
+"td-default-http-method_get","pass","see issue #702; GET for readproperty"
+"td-default-http-method_post","pass","see issue #702; POST for invokeaction"
+"td-default-http-method_put","pass","see issue #702; PUT for writeproperty"
+"td-default-idempotent-1","null","see issue #701"
+"td-default-idempotent-2","pass","see issue #702; false for idempotent"
+"td-default-in-apikey","pass","see issue #702; query for in"
+"td-default-in-basic","pass","see issue #702; header for in"
+"td-default-in-bearer","pass","see issue #702; header for in"
+"td-default-in-digest","pass","see issue #702; header for in"
+"td-default-in-pop","pass","see issue #702; header for in"
+"td-default-op-actions","pass","see issue #702; invokeaction for op"
+"td-default-op-events","pass","see issue #702; subscriveevent for op"
+"td-default-op-properties","pass","see issue #702; [readproperty,writeproperty] for op"
+"td-default-qop","pass","see issue #702; auth for qop"
+"td-default-readOnly","pass","see issue #702; false for readOnly"
+"td-default-writeOnly","pass","see issue #701,#702"
+"td-default-safe","pass","see issue #702; false for safe"
+"td-format-validation-known-values","pass",
+"td-format-validation-other-values","null", 
+"td-security-overrides","pass",
+"td-title-description_descriptions","pass",
+"td-title-description_titles","pass",
+"td-vocabulary-defaults","pass",
+


### PR DESCRIPTION
- based on [recent test assertion list](https://cdn.staticaly.com/gh/w3c/wot-thing-description/fd89b0c4/testing/report.html#test_assertions).
- use id `td-default-writeOnly` instead of `td-default-idempotent-1` (see https://github.com/w3c/wot-thing-description/issues/701)
