### PR TITLE
Fixed a link to EXI and added OGC as an external organization.

### DIFF
--- a/charters/wot-ig-2019.html
+++ b/charters/wot-ig-2019.html
@@ -377,7 +377,7 @@
         <dd>For collaboration on areas of mutual interest in respect to security for the Web of Things.</dd>
         <dt><a href="http://www.w3.org/auto/">Web and Automotive Business &amp; Working Groups</a></dt>
         <dd>For collaboration on technologies and requirements relating to connected cars and the Web of Things.</dd>
-        <dt><a href="http://www.w3.org/XML/EXI/">Efficient XML Interchange Working Group</a></dt>
+        <dt><a href="https://www.w3.org/community/exi-next/">Efficient Extensible Interchange Community Group</a></dt>
         <dd>In relation to efficient interchange for thing descriptions.</dd>
     </dl>
 
@@ -402,10 +402,12 @@
         <dd>For collaboration on integrating M2M based platforms within the Web of Things, including platform metadata and approaches for enabling semantic interoperability, and end to end security across platforms.</dd>
         <dt><a href="http://www.gsma.com">GSMA</a></dt>
         <dd>For coordination in respect to the interests of Network Operators.</dd>
-        dt><a href="https://www.omaspecworks.org">OMA SpecWorks</a>
+        <dt><a href="https://www.omaspecworks.org">OMA SpecWorks</a>
         <dd>For collaboration on integrating LWM2M based platforms with the Web of Things.</dd>
-        dt><a href="https://www.etsi.org">ETSI</a>
+        <dt><a href="https://www.etsi.org">ETSI</a>
         <dd>For collaboration on IoT, M2M, security and semantic interoperability.</dd>
+        <dt><a href="http://www.opengeospatial.org/">OGC</a>
+        <dd>For collaboration on integrating SensorThings API based platforms with the Web of Things.</dd>
     </dl>
     </div>
 <!--


### PR DESCRIPTION
- [EXI](https://www.w3.org/community/exi-next/) is now a community group.
- I suggest to add OGC as an external group.