### PR TITLE
Update Intel TDs for Workshop

### DIFF
--- a/workshop/ws2/demos-2019-Munich/TDs/Intel/intel-camera.jsonld
+++ b/workshop/ws2/demos-2019-Munich/TDs/Intel/intel-camera.jsonld
@@ -1,52 +1,33 @@
 {
-  "@context": [
-    "http://www.w3.org/ns/td",
-    {
-      "iot": "http://iotschema.org/",
-      "http": "http://www.w3.org/2011/http#"
-    }
+  "@context": ["https://www.w3.org/2019/wot/td/v1",
+               {
+                 "iot": "http://iotschema.org/"
+               }
   ],
-  "@type": [
-    "Thing"
-  ],
-  "name": "SimpleWebCamera-upsq1c.local-0",
+  "@type": ["Thing"],
+  "title": "SimpleWebCamera-upsq1c.local-0",
   "description": "A simple interface to V4L2 cameras",
   "support": "mailto:michael.mccool@intel.com",
-  "version": {
-    "instance": "0.1.0"
-  },
-  "created": "2018-09-10T06:30+00:00",
-  "lastModified": "2018-12-19T03:29+00:00",
-  "links": [
-    {
-      "href": "https://github.com/mmccool/simple-webcam",
-      "rel": "repository",
-      "type": "application/vnd.github.v3+json"
-    }
-  ],
+  "version": {"instance":"0.1.0"},
+  "created": "2018-09-10T06:30:00Z",
+  "modified": "2019-05-28T03:29:00Z",
+  "links": [{
+        "href": "https://github.com/mmccool/simple-webcam",
+        "rel": "repository",
+        "type": "application/vnd.github.v3+json"
+  }],
   "id": "urn:uuid:6f6d4d0b-3d8b-58a1-a90b-7d05680553d6",
   "securityDefinitions": {
-    "nosec_sc": {
-      "scheme": "nosec"
-    },
-    "basic_sc": {
-      "scheme": "basic"
-    },
-    "digest_sc": {
-      "scheme": "digest"
-    }
+    "nosec_sc": {"scheme": "nosec"},
+    "basic_sc": {"scheme": "basic"},
+    "digest_sc": {"scheme": "digest"}
   },
-  "security": [
-    "nosec_sc"
-  ],
+  "security": ["nosec_sc"],
   "properties": {
     "brightness": {
       "title": "Brightness",
       "description": "The current brightness setting",
-      "@type": [
-        "iot:CurrentLevel",
-        "iot:LevelData"
-      ],
+      "@type": ["iot:CurrentLevel","iot:LevelData"],
       "type": "integer",
       "minimum": -64,
       "maximum": 64,
@@ -55,162 +36,102 @@
         {
           "href": "http://upsq1c.local:9191/api/brightness",
           "contentType": "application/json",
-          "op": [
-            "readproperty"
-          ],
-          "http:methodName": "GET"
+          "op": ["readproperty"]
         },
         {
           "href": "http://upsq1c.local:9191/api/brightness",
           "contentType": "application/json",
-          "op": [
-            "writeproperty"
-          ],
-          "http:methodName": "POST"
+          "op": ["writeproperty"]
         },
         {
           "href": "http://upsq1c.local:9191/api/brightness/observe",
           "contentType": "application/json",
-          "op": [
-            "observeproperty"
-          ],
-          "http:methodName": "GET",
+          "op": ["observeproperty"],
+          "htv:methodName": "GET",
           "subProtocol": "longpoll"
         },
         {
           "href": "https://tiktok.mmccool.org:8098/api/brightness",
           "contentType": "application/json",
-          "op": [
-            "readproperty"
-          ],
-          "security": [
-            "basic_sc"
-          ],
-          "http:methodName": "GET"
+          "op": ["readproperty"],
+          "security": ["basic_sc"]
         },
         {
           "href": "https://tiktok.mmccool.org:8098/api/brightness",
           "contentType": "application/json",
-          "op": [
-            "writeproperty"
-          ],
-          "security": [
-            "basic_sc"
-          ],
-          "http:methodName": "POST"
+          "op": ["writeproperty"],
+          "security": ["basic_sc"],
+          "htv:methodName": "POST"
         },
         {
           "href": "https://tiktok.mmccool.org:8098/api/brightness/observe",
           "contentType": "application/json",
-          "op": [
-            "observeproperty"
-          ],
-          "security": [
-            "basic_sc"
-          ],
-          "http:methodName": "GET",
+          "op": ["observeproperty"],
+          "security": ["basic_sc"],
+          "htv:methodName": "GET",
           "subProtocol": "longpoll"
         },
         {
           "href": "https://tiktok.mmccool.org:8099/api/brightness",
           "contentType": "application/json",
-          "op": [
-            "readproperty"
-          ],
-          "security": [
-            "digest_sc"
-          ],
-          "http:methodName": "GET"
+          "op": ["readproperty"],
+          "security": ["digest_sc"]
         },
         {
           "href": "https://tiktok.mmccool.org:8099/api/brightness",
           "contentType": "application/json",
-          "op": [
-            "writeproperty"
-          ],
-          "security": [
-            "digest_sc"
-          ],
-          "http:methodName": "POST"
+          "op": ["writeproperty"],
+          "security": ["digest_sc"],
+          "htv:methodName": "POST"
         },
         {
           "href": "https://tiktok.mmccool.org:8099/api/brightness/observe",
           "contentType": "application/json",
-          "op": [
-            "observeproperty"
-          ],
-          "security": [
-            "digest_sc"
-          ],
-          "http:methodName": "GET",
+          "op": ["observeproperty"],
+          "security": ["digest_sc"],
+          "htv:methodName": "GET",
           "subProtocol": "longpoll"
         },
         {
           "href": "https://portal.mmccool.net:8098/api/brightness",
           "contentType": "application/json",
-          "op": [
-            "readproperty"
-          ],
-          "security": [
-            "basic_sc"
-          ],
-          "http:methodName": "GET"
+          "op": ["readproperty"],
+          "security": ["basic_sc"]
         },
         {
           "href": "https://portal.mmccool.net:8098/api/brightness",
           "contentType": "application/json",
-          "op": [
-            "writeproperty"
-          ],
-          "security": [
-            "basic_sc"
-          ],
-          "http:methodName": "POST"
+          "op": ["writeproperty"],
+          "security": ["basic_sc"],
+          "htv:methodName": "POST"
         },
         {
           "href": "https://portal.mmccool.net:8098/api/brightness/observe",
           "contentType": "application/json",
-          "op": [
-            "observeproperty"
-          ],
-          "security": [
-            "basic_sc"
-          ],
-          "http:methodName": "GET",
+          "op": ["observeproperty"],
+          "security": ["basic_sc"],
+          "htv:methodName": "GET",
           "subProtocol": "longpoll"
         },
         {
           "href": "https://portal.mmccool.net:8099/api/brightness",
           "contentType": "application/json",
-          "op": [
-            "readproperty"
-          ],
-          "security": [
-            "digest_sc"
-          ],
-          "http:methodName": "GET"
+          "op": ["readproperty"],
+          "security": ["digest_sc"]
         },
         {
           "href": "https://portal.mmccool.net:8099/api/brightness",
           "contentType": "application/json",
-          "op": [
-            "writeproperty"
-          ],
-          "security": [
-            "digest_sc"
-          ],
-          "http:methodName": "POST"
+          "op": ["writeproperty"],
+          "security": ["digest_sc"],
+          "htv:methodName": "POST"
         },
         {
           "href": "https://portal.mmccool.net:8099/api/brightness/observe",
           "contentType": "application/json",
-          "op": [
-            "observeproperty"
-          ],
-          "security": [
-            "digest_sc"
-          ],
-          "http:methodName": "GET",
+          "op": ["observeproperty"],
+          "security": ["digest_sc"],
+          "htv:methodName": "GET",
           "subProtocol": "longpoll"
         }
       ]
@@ -218,10 +139,7 @@
     "contrast": {
       "title": "Contrast",
       "description": "The current contrast setting",
-      "@type": [
-        "iot:CurrentLevel",
-        "iot:LevelData"
-      ],
+      "@type": ["iot:CurrentLevel","iot:LevelData"],
       "type": "integer",
       "minimum": 0,
       "maximum": 64,
@@ -230,162 +148,103 @@
         {
           "href": "http://upsq1c.local:9191/api/contrast",
           "contentType": "application/json",
-          "op": [
-            "readproperty"
-          ],
-          "http:methodName": "GET"
+          "op": ["readproperty"]
         },
         {
           "href": "http://upsq1c.local:9191/api/contrast",
           "contentType": "application/json",
-          "op": [
-            "writeproperty"
-          ],
-          "http:methodName": "POST"
+          "op": ["writeproperty"],
+          "htv:methodName": "POST"
         },
         {
           "href": "http://upsq1c.local:9191/api/contrast/observe",
           "contentType": "application/json",
-          "op": [
-            "observeproperty"
-          ],
-          "http:methodName": "GET",
+          "op": ["observeproperty"],
+          "htv:methodName": "GET",
           "subProtocol": "longpoll"
         },
         {
           "href": "https://tiktok.mmccool.org:8098/api/contrast",
           "contentType": "application/json",
-          "op": [
-            "readproperty"
-          ],
-          "security": [
-            "basic_sc"
-          ],
-          "http:methodName": "GET"
+          "op": ["readproperty"],
+          "security": ["basic_sc"]
         },
         {
           "href": "https://tiktok.mmccool.org:8098/api/contrast",
           "contentType": "application/json",
-          "op": [
-            "writeproperty"
-          ],
-          "security": [
-            "basic_sc"
-          ],
-          "http:methodName": "POST"
+          "op": ["writeproperty"],
+          "security": ["basic_sc"],
+          "htv:methodName": "POST"
         },
         {
           "href": "https://tiktok.mmccool.org:8098/api/contrast/observe",
           "contentType": "application/json",
-          "op": [
-            "observeproperty"
-          ],
-          "security": [
-            "basic_sc"
-          ],
-          "http:methodName": "GET",
+          "op": ["observeproperty"],
+          "security": ["basic_sc"],
+          "htv:methodName": "GET",
           "subProtocol": "longpoll"
         },
         {
           "href": "https://tiktok.mmccool.org:8099/api/contrast",
           "contentType": "application/json",
-          "op": [
-            "readproperty"
-          ],
-          "security": [
-            "digest_sc"
-          ],
-          "http:methodName": "GET"
+          "op": ["readproperty"],
+          "security": ["digest_sc"]
         },
         {
           "href": "https://tiktok.mmccool.org:8099/api/contrast",
           "contentType": "application/json",
-          "op": [
-            "writeproperty"
-          ],
-          "security": [
-            "digest_sc"
-          ],
-          "http:methodName": "POST"
+          "op": ["writeproperty"],
+          "security": ["digest_sc"],
+          "htv:methodName": "POST"
         },
         {
           "href": "https://tiktok.mmccool.org:8099/api/contrast/observe",
           "contentType": "application/json",
-          "op": [
-            "observeproperty"
-          ],
-          "security": [
-            "digest_sc"
-          ],
-          "http:methodName": "GET",
+          "op": ["observeproperty"],
+          "security": ["digest_sc"],
+          "htv:methodName": "GET",
           "subProtocol": "longpoll"
         },
         {
           "href": "https://portal.mmccool.net:8098/api/contrast",
           "contentType": "application/json",
-          "op": [
-            "readproperty"
-          ],
-          "security": [
-            "basic_sc"
-          ],
-          "http:methodName": "GET"
+          "op": ["readproperty"],
+          "security": ["basic_sc"]
         },
         {
           "href": "https://portal.mmccool.net:8098/api/contrast",
           "contentType": "application/json",
-          "op": [
-            "writeproperty"
-          ],
-          "security": [
-            "basic_sc"
-          ],
-          "http:methodName": "POST"
+          "op": ["writeproperty"],
+          "security": ["basic_sc"],
+          "htv:methodName": "POST"
         },
         {
           "href": "https://portal.mmccool.net:8098/api/contrast/observe",
           "contentType": "application/json",
-          "op": [
-            "observeproperty"
-          ],
-          "security": [
-            "basic_sc"
-          ],
-          "http:methodName": "GET",
+          "op": ["observeproperty"],
+          "security": ["basic_sc"],
+          "htv:methodName": "GET",
           "subProtocol": "longpoll"
         },
         {
           "href": "https://portal.mmccool.net:8099/api/contrast",
           "contentType": "application/json",
-          "op": [
-            "readproperty"
-          ],
-          "security": [
-            "digest_sc"
-          ],
-          "http:methodName": "GET"
+          "op": ["readproperty"],
+          "security": ["digest_sc"]
         },
         {
           "href": "https://portal.mmccool.net:8099/api/contrast",
           "contentType": "application/json",
-          "op": [
-            "writeproperty"
-          ],
-          "security": [
-            "digest_sc"
-          ],
-          "http:methodName": "POST"
+          "op": ["writeproperty"],
+          "security": ["digest_sc"],
+          "htv:methodName": "POST"
         },
         {
           "href": "https://portal.mmccool.net:8099/api/contrast/observe",
           "contentType": "application/json",
-          "op": [
-            "observeproperty"
-          ],
-          "security": [
-            "digest_sc"
-          ],
-          "http:methodName": "GET",
+          "op": ["observeproperty"],
+          "security": ["digest_sc"],
+          "htv:methodName": "GET",
           "subProtocol": "longpoll"
         }
       ]
@@ -393,10 +252,7 @@
     "gamma": {
       "title": "Gamma",
       "description": "The current gamma setting, x100",
-      "@type": [
-        "iot:CurrentLevel",
-        "iot:LevelData"
-      ],
+      "@type": ["iot:CurrentLevel","iot:LevelData"],
       "type": "integer",
       "minimum": 16,
       "maximum": 500,
@@ -405,94 +261,61 @@
         {
           "href": "http://upsq1c.local:9191/api/gamma",
           "contentType": "application/json",
-          "op": [
-            "readproperty"
-          ],
-          "http:methodName": "GET"
+          "op": ["readproperty"]
         },
         {
           "href": "http://upsq1c.local:9191/api/gamma",
           "contentType": "application/json",
-          "op": [
-            "writeproperty"
-          ],
-          "http:methodName": "POST"
+          "op": ["writeproperty"],
+          "htv:methodName": "POST"
         },
         {
           "href": "http://upsq1c.local:9191/api/gamma/observe",
           "contentType": "application/json",
-          "op": [
-            "observeproperty"
-          ],
-          "http:methodName": "GET",
+          "op": ["observeproperty"],
+          "htv:methodName": "GET",
           "subProtocol": "longpoll"
         },
         {
           "href": "https://tiktok.mmccool.org:8098/api/gamma",
           "contentType": "application/json",
-          "op": [
-            "readproperty"
-          ],
-          "security": [
-            "basic_sc"
-          ],
-          "http:methodName": "GET"
+          "op": ["readproperty"],
+          "security": ["basic_sc"]
         },
         {
           "href": "https://tiktok.mmccool.org:8098/api/gamma",
           "contentType": "application/json",
-          "op": [
-            "writeproperty"
-          ],
-          "security": [
-            "basic_sc"
-          ],
-          "http:methodName": "POST"
+          "op": ["writeproperty"],
+          "security": ["basic_sc"],
+          "htv:methodName": "POST"
         },
         {
           "href": "https://tiktok.mmccool.org:8098/api/gamma/observe",
           "contentType": "application/json",
-          "op": [
-            "observeproperty"
-          ],
-          "security": [
-            "basic_sc"
-          ],
-          "http:methodName": "GET",
+          "op": ["observeproperty"],
+          "security": ["basic_sc"],
+          "htv:methodName": "GET",
           "subProtocol": "longpoll"
         },
         {
           "href": "https://tiktok.mmccool.org:8099/api/gamma",
           "contentType": "application/json",
-          "op": [
-            "readproperty"
-          ],
-          "security": [
-            "digest_sc"
-          ],
-          "http:methodName": "GET"
+          "op": ["readproperty"],
+          "security": ["digest_sc"]
         },
         {
           "href": "https://tiktok.mmccool.org:8099/api/gamma",
           "contentType": "application/json",
-          "op": [
-            "writeproperty"
-          ],
-          "security": [
-            "digest_sc"
-          ],
-          "http:methodName": "POST"
+          "op": ["writeproperty"],
+          "security": ["digest_sc"],
+          "htv:methodName": "POST"
         },
         {
           "href": "https://tiktok.mmccool.org:8099/api/gamma/observe",
           "contentType": "application/json",
-          "op": [
-            "observeproperty"
-          ],
-          "security": [
-            "digest_sc"
-          ],
-          "http:methodName": "GET",
+          "op": ["observeproperty"],
+          "security": ["digest_sc"],
+          "htv:methodName": "GET",
           "subProtocol": "longpoll"
         }
       ]
@@ -500,10 +323,7 @@
     "saturation": {
       "title": "Saturation",
       "description": "The current saturation setting",
-      "@type": [
-        "iot:CurrentLevel",
-        "iot:LevelData"
-      ],
+      "@type": ["iot:CurrentLevel","iot:LevelData"],
       "type": "integer",
       "minimum": 0,
       "maximum": 100,
@@ -512,162 +332,103 @@
         {
           "href": "http://upsq1c.local:9191/api/saturation",
           "contentType": "application/json",
-          "op": [
-            "readproperty"
-          ],
-          "http:methodName": "GET"
+          "op": ["readproperty"]
         },
         {
           "href": "http://upsq1c.local:9191/api/saturation",
           "contentType": "application/json",
-          "op": [
-            "writeproperty"
-          ],
-          "http:methodName": "POST"
+          "op": ["writeproperty"],
+          "htv:methodName": "POST"
         },
         {
           "href": "http://upsq1c.local:9191/api/saturation/observe",
           "contentType": "application/json",
-          "op": [
-            "observeproperty"
-          ],
-          "http:methodName": "GET",
+          "op": ["observeproperty"],
+          "htv:methodName": "GET",
           "subProtocol": "longpoll"
         },
         {
           "href": "https://tiktok.mmccool.org:8098/api/saturation",
           "contentType": "application/json",
-          "op": [
-            "readproperty"
-          ],
-          "security": [
-            "basic_sc"
-          ],
-          "http:methodName": "GET"
+          "op": ["readproperty"],
+          "security": ["basic_sc"]
         },
         {
           "href": "https://tiktok.mmccool.org:8098/api/saturation",
           "contentType": "application/json",
-          "op": [
-            "writeproperty"
-          ],
-          "security": [
-            "basic_sc"
-          ],
-          "http:methodName": "POST"
+          "op": ["writeproperty"],
+          "security": ["basic_sc"],
+          "htv:methodName": "POST"
         },
         {
           "href": "https://tiktok.mmccool.org:8098/api/saturation/observe",
           "contentType": "application/json",
-          "op": [
-            "observeproperty"
-          ],
-          "security": [
-            "basic_sc"
-          ],
-          "http:methodName": "GET",
+          "op": ["observeproperty"],
+          "security": ["basic_sc"],
+          "htv:methodName": "GET",
           "subProtocol": "longpoll"
         },
         {
           "href": "https://tiktok.mmccool.org:8099/api/saturation",
           "contentType": "application/json",
-          "op": [
-            "readproperty"
-          ],
-          "security": [
-            "digest_sc"
-          ],
-          "http:methodName": "GET"
+          "op": ["readproperty"],
+          "security": ["digest_sc"]
         },
         {
           "href": "https://tiktok.mmccool.org:8099/api/saturation",
           "contentType": "application/json",
-          "op": [
-            "writeproperty"
-          ],
-          "security": [
-            "digest_sc"
-          ],
-          "http:methodName": "POST"
+          "op": ["writeproperty"],
+          "security": ["digest_sc"],
+          "htv:methodName": "POST"
         },
         {
           "href": "https://tiktok.mmccool.org:8099/api/saturation/observe",
           "contentType": "application/json",
-          "op": [
-            "observeproperty"
-          ],
-          "security": [
-            "digest_sc"
-          ],
-          "http:methodName": "GET",
+          "op": ["observeproperty"],
+          "security": ["digest_sc"],
+          "htv:methodName": "GET",
           "subProtocol": "longpoll"
         },
         {
           "href": "https://portal.mmccool.net:8098/api/saturation",
           "contentType": "application/json",
-          "op": [
-            "readproperty"
-          ],
-          "security": [
-            "basic_sc"
-          ],
-          "http:methodName": "GET"
+          "op": ["readproperty"],
+          "security": ["basic_sc"]
         },
         {
           "href": "https://portal.mmccool.net:8098/api/saturation",
           "contentType": "application/json",
-          "op": [
-            "writeproperty"
-          ],
-          "security": [
-            "basic_sc"
-          ],
-          "http:methodName": "POST"
+          "op": ["writeproperty"],
+          "security": ["basic_sc"],
+          "htv:methodName": "POST"
         },
         {
           "href": "https://portal.mmccool.net:8098/api/saturation/observe",
           "contentType": "application/json",
-          "op": [
-            "observeproperty"
-          ],
-          "security": [
-            "basic_sc"
-          ],
-          "http:methodName": "GET",
+          "op": ["observeproperty"],
+          "security": ["basic_sc"],
+          "htv:methodName": "GET",
           "subProtocol": "longpoll"
         },
         {
           "href": "https://portal.mmccool.net:8099/api/saturation",
           "contentType": "application/json",
-          "op": [
-            "readproperty"
-          ],
-          "security": [
-            "digest_sc"
-          ],
-          "http:methodName": "GET"
+          "op": ["readproperty"],
+          "security": ["digest_sc"]
         },
         {
           "href": "https://portal.mmccool.net:8099/api/saturation",
           "contentType": "application/json",
-          "op": [
-            "writeproperty"
-          ],
-          "security": [
-            "digest_sc"
-          ],
-          "http:methodName": "POST"
+          "op": ["writeproperty"],
+          "security": ["digest_sc"],
+          "htv:methodName": "POST"
         },
         {
           "href": "https://portal.mmccool.net:8099/api/saturation/observe",
           "contentType": "application/json",
-          "op": [
-            "observeproperty"
-          ],
-          "security": [
-            "digest_sc"
-          ],
-          "http:methodName": "GET",
+          "op": ["observeproperty"],
+          "security": ["digest_sc"],
+          "htv:methodName": "GET",
           "subProtocol": "longpoll"
         }
       ]
@@ -675,10 +436,7 @@
     "hue": {
       "title": "Hue",
       "description": "The current hue setting",
-      "@type": [
-        "iot:CurrentLevel",
-        "iot:LevelData"
-      ],
+      "@type": ["iot:CurrentLevel","iot:LevelData"],
       "type": "integer",
       "minimum": -40,
       "maximum": 40,
@@ -687,94 +445,61 @@
         {
           "href": "http://upsq1c.local:9191/api/hue",
           "contentType": "application/json",
-          "op": [
-            "readproperty"
-          ],
-          "http:methodName": "GET"
+          "op": ["readproperty"]
         },
         {
           "href": "http://upsq1c.local:9191/api/hue",
           "contentType": "application/json",
-          "op": [
-            "writeproperty"
-          ],
-          "http:methodName": "POST"
+          "op": ["writeproperty"],
+          "htv:methodName": "POST"
         },
         {
           "href": "http://upsq1c.local:9191/api/hue/observe",
           "contentType": "application/json",
-          "op": [
-            "observeproperty"
-          ],
-          "http:methodName": "GET",
+          "op": ["observeproperty"],
+          "htv:methodName": "GET",
           "subProtocol": "longpoll"
         },
         {
           "href": "https://tiktok.mmccool.org:8098/api/hue",
           "contentType": "application/json",
-          "op": [
-            "readproperty"
-          ],
-          "security": [
-            "basic_sc"
-          ],
-          "http:methodName": "GET"
+          "op": ["readproperty"],
+          "security": ["basic_sc"]
         },
         {
           "href": "https://tiktok.mmccool.org:8098/api/hue",
           "contentType": "application/json",
-          "op": [
-            "writeproperty"
-          ],
-          "security": [
-            "basic_sc"
-          ],
-          "http:methodName": "POST"
+          "op": ["writeproperty"],
+          "security": ["basic_sc"],
+          "htv:methodName": "POST"
         },
         {
           "href": "https://tiktok.mmccool.org:8098/api/hue/observe",
           "contentType": "application/json",
-          "op": [
-            "observeproperty"
-          ],
-          "security": [
-            "basic_sc"
-          ],
-          "http:methodName": "GET",
+          "op": ["observeproperty"],
+          "security": ["basic_sc"],
+          "htv:methodName": "GET",
           "subProtocol": "longpoll"
         },
         {
           "href": "https://tiktok.mmccool.org:8099/api/hue",
           "contentType": "application/json",
-          "op": [
-            "readproperty"
-          ],
-          "security": [
-            "digest_sc"
-          ],
-          "http:methodName": "GET"
+          "op": ["readproperty"],
+          "security": ["digest_sc"]
         },
         {
           "href": "https://tiktok.mmccool.org:8099/api/hue",
           "contentType": "application/json",
-          "op": [
-            "writeproperty"
-          ],
-          "security": [
-            "digest_sc"
-          ],
-          "http:methodName": "POST"
+          "op": ["writeproperty"],
+          "security": ["digest_sc"],
+          "htv:methodName": "POST"
         },
         {
           "href": "https://tiktok.mmccool.org:8099/api/hue/observe",
           "contentType": "application/json",
-          "op": [
-            "observeproperty"
-          ],
-          "security": [
-            "digest_sc"
-          ],
-          "http:methodName": "GET",
+          "op": ["observeproperty"],
+          "security": ["digest_sc"],
+          "htv:methodName": "GET",
           "subProtocol": "longpoll"
         }
       ]
@@ -782,10 +507,7 @@
     "white_balance": {
       "title": "White Balance Temperature",
       "description": "The current white balance setting",
-      "@type": [
-        "iot:CurrentLevel",
-        "iot:LevelData"
-      ],
+      "@type": ["iot:CurrentLevel","iot:LevelData"],
       "type": "integer",
       "minimum": 2800,
       "maximum": 6500,
@@ -794,162 +516,103 @@
         {
           "href": "http://upsq1c.local:9191/api/white_balance",
           "contentType": "application/json",
-          "op": [
-            "readproperty"
-          ],
-          "http:methodName": "GET"
+          "op": ["readproperty"]
         },
         {
           "href": "http://upsq1c.local:9191/api/white_balance",
           "contentType": "application/json",
-          "op": [
-            "writeproperty"
-          ],
-          "http:methodName": "POST"
+          "op": ["writeproperty"],
+          "htv:methodName": "POST"
         },
         {
           "href": "http://upsq1c.local:9191/api/white_balance/observe",
           "contentType": "application/json",
-          "op": [
-            "observeproperty"
-          ],
-          "http:methodName": "GET",
+          "op": ["observeproperty"],
+          "htv:methodName": "GET",
           "subProtocol": "longpoll"
         },
         {
           "href": "https://tiktok.mmccool.org:8098/api/white_balance",
           "contentType": "application/json",
-          "op": [
-            "readproperty"
-          ],
-          "security": [
-            "basic_sc"
-          ],
-          "http:methodName": "GET"
+          "op": ["readproperty"],
+          "security": ["basic_sc"]
         },
         {
           "href": "https://tiktok.mmccool.org:8098/api/white_balance",
           "contentType": "application/json",
-          "op": [
-            "writeproperty"
-          ],
-          "security": [
-            "basic_sc"
-          ],
-          "http:methodName": "POST"
+          "op": ["writeproperty"],
+          "security": ["basic_sc"],
+          "htv:methodName": "POST"
         },
         {
           "href": "https://tiktok.mmccool.org:8098/api/white_balance/observe",
           "contentType": "application/json",
-          "op": [
-            "observeproperty"
-          ],
-          "security": [
-            "basic_sc"
-          ],
-          "http:methodName": "GET",
+          "op": ["observeproperty"],
+          "security": ["basic_sc"],
+          "htv:methodName": "GET",
           "subProtocol": "longpoll"
         },
         {
           "href": "https://tiktok.mmccool.org:8099/api/white_balance",
           "contentType": "application/json",
-          "op": [
-            "readproperty"
-          ],
-          "security": [
-            "digest_sc"
-          ],
-          "http:methodName": "GET"
+          "op": ["readproperty"],
+          "security": ["digest_sc"]
         },
         {
           "href": "https://tiktok.mmccool.org:8099/api/white_balance",
           "contentType": "application/json",
-          "op": [
-            "writeproperty"
-          ],
-          "security": [
-            "digest_sc"
-          ],
-          "http:methodName": "POST"
+          "op": ["writeproperty"],
+          "security": ["digest_sc"],
+          "htv:methodName": "POST"
         },
         {
           "href": "https://tiktok.mmccool.org:8099/api/white_balance/observe",
           "contentType": "application/json",
-          "op": [
-            "observeproperty"
-          ],
-          "security": [
-            "digest_sc"
-          ],
-          "http:methodName": "GET",
+          "op": ["observeproperty"],
+          "security": ["digest_sc"],
+          "htv:methodName": "GET",
           "subProtocol": "longpoll"
         },
         {
           "href": "https://portal.mmccool.net:8098/api/white_balance",
           "contentType": "application/json",
-          "op": [
-            "readproperty"
-          ],
-          "security": [
-            "basic_sc"
-          ],
-          "http:methodName": "GET"
+          "op": ["readproperty"],
+          "security": ["basic_sc"]
         },
         {
           "href": "https://portal.mmccool.net:8098/api/white_balance",
           "contentType": "application/json",
-          "op": [
-            "writeproperty"
-          ],
-          "security": [
-            "basic_sc"
-          ],
-          "http:methodName": "POST"
+          "op": ["writeproperty"],
+          "security": ["basic_sc"],
+          "htv:methodName": "POST"
         },
         {
           "href": "https://portal.mmccool.net:8098/api/white_balance/observe",
           "contentType": "application/json",
-          "op": [
-            "observeproperty"
-          ],
-          "security": [
-            "basic_sc"
-          ],
-          "http:methodName": "GET",
+          "op": ["observeproperty"],
+          "security": ["basic_sc"],
+          "htv:methodName": "GET",
           "subProtocol": "longpoll"
         },
         {
           "href": "https://portal.mmccool.net:8099/api/white_balance",
           "contentType": "application/json",
-          "op": [
-            "readproperty"
-          ],
-          "security": [
-            "digest_sc"
-          ],
-          "http:methodName": "GET"
+          "op": ["readproperty"],
+          "security": ["digest_sc"]
         },
         {
           "href": "https://portal.mmccool.net:8099/api/white_balance",
           "contentType": "application/json",
-          "op": [
-            "writeproperty"
-          ],
-          "security": [
-            "digest_sc"
-          ],
-          "http:methodName": "POST"
+          "op": ["writeproperty"],
+          "security": ["digest_sc"],
+          "htv:methodName": "POST"
         },
         {
           "href": "https://portal.mmccool.net:8099/api/white_balance/observe",
           "contentType": "application/json",
-          "op": [
-            "observeproperty"
-          ],
-          "security": [
-            "digest_sc"
-          ],
-          "http:methodName": "GET",
+          "op": ["observeproperty"],
+          "security": ["digest_sc"],
+          "htv:methodName": "GET",
           "subProtocol": "longpoll"
         }
       ]
@@ -957,172 +620,110 @@
     "white_balance_auto": {
       "title": "White Balance Temperature Auto Mode",
       "description": "Status of automatic white balance mode",
-      "@type": [
-        "iot:BinarySwitch",
-        "iot:StateData"
-      ],
+      "@type": ["iot:BinarySwitch","iot:StateData"],
       "type": "boolean",
       "observable": true,
       "forms": [
         {
           "href": "http://upsq1c.local:9191/api/white_balance_auto",
           "contentType": "application/json",
-          "op": [
-            "readproperty"
-          ],
-          "http:methodName": "GET"
+          "op": ["readproperty"]
         },
         {
           "href": "http://upsq1c.local:9191/api/white_balance_auto",
           "contentType": "application/json",
-          "op": [
-            "writeproperty"
-          ],
-          "http:methodName": "POST"
+          "op": ["writeproperty"],
+          "htv:methodName": "POST"
         },
         {
           "href": "http://upsq1c.local:9191/api/white_balance_auto/observe",
           "contentType": "application/json",
-          "op": [
-            "observeproperty"
-          ],
-          "http:methodName": "GET",
+          "op": ["observeproperty"],
+          "htv:methodName": "GET",
           "subProtocol": "longpoll"
         },
         {
           "href": "https://tiktok.mmccool.org:8098/api/white_balance_auto",
           "contentType": "application/json",
-          "op": [
-            "readproperty"
-          ],
-          "security": [
-            "basic_sc"
-          ],
-          "http:methodName": "GET"
+          "op": ["readproperty"],
+          "security": ["basic_sc"]
         },
         {
           "href": "https://tiktok.mmccool.org:8098/api/white_balance_auto",
           "contentType": "application/json",
-          "op": [
-            "writeproperty"
-          ],
-          "security": [
-            "basic_sc"
-          ],
-          "http:methodName": "POST"
+          "op": ["writeproperty"],
+          "security": ["basic_sc"],
+          "htv:methodName": "POST"
         },
         {
           "href": "https://tiktok.mmccool.org:8098/api/white_balance_auto/observe",
           "contentType": "application/json",
-          "op": [
-            "observeproperty"
-          ],
-          "security": [
-            "basic_sc"
-          ],
-          "http:methodName": "GET",
+          "op": ["observeproperty"],
+          "security": ["basic_sc"],
+          "htv:methodName": "GET",
           "subProtocol": "longpoll"
         },
         {
           "href": "https://tiktok.mmccool.org:8099/api/white_balance_auto",
           "contentType": "application/json",
-          "op": [
-            "readproperty"
-          ],
-          "security": [
-            "digest_sc"
-          ],
-          "http:methodName": "GET"
+          "op": ["readproperty"],
+          "security": ["digest_sc"]
         },
         {
           "href": "https://tiktok.mmccool.org:8099/api/white_balance_auto",
           "contentType": "application/json",
-          "op": [
-            "writeproperty"
-          ],
-          "security": [
-            "digest_sc"
-          ],
-          "http:methodName": "POST"
+          "op": ["writeproperty"],
+          "security": ["digest_sc"],
+          "htv:methodName": "POST"
         },
         {
           "href": "https://tiktok.mmccool.org:8099/api/white_balance_auto/observe",
           "contentType": "application/json",
-          "op": [
-            "observeproperty"
-          ],
-          "security": [
-            "digest_sc"
-          ],
-          "http:methodName": "GET",
+          "op": ["observeproperty"],
+          "security": ["digest_sc"],
+          "htv:methodName": "GET",
           "subProtocol": "longpoll"
         },
         {
           "href": "https://portal.mmccool.net:8098/api/white_balance_auto",
           "contentType": "application/json",
-          "op": [
-            "readproperty"
-          ],
-          "security": [
-            "basic_sc"
-          ],
-          "http:methodName": "GET"
+          "op": ["readproperty"],
+          "security": ["basic_sc"]
         },
         {
           "href": "https://portal.mmccool.net:8098/api/white_balance_auto",
           "contentType": "application/json",
-          "op": [
-            "writeproperty"
-          ],
-          "security": [
-            "basic_sc"
-          ],
-          "http:methodName": "POST"
+          "op": ["writeproperty"],
+          "security": ["basic_sc"],
+          "htv:methodName": "POST"
         },
         {
           "href": "https://portal.mmccool.net:8098/api/white_balance_auto/observe",
           "contentType": "application/json",
-          "op": [
-            "observeproperty"
-          ],
-          "security": [
-            "basic_sc"
-          ],
-          "http:methodName": "GET",
+          "op": ["observeproperty"],
+          "security": ["basic_sc"],
+          "htv:methodName": "GET",
           "subProtocol": "longpoll"
         },
         {
           "href": "https://portal.mmccool.net:8099/api/white_balance_auto",
           "contentType": "application/json",
-          "op": [
-            "readproperty"
-          ],
-          "security": [
-            "digest_sc"
-          ],
-          "http:methodName": "GET"
+          "op": ["readproperty"],
+          "security": ["digest_sc"]
         },
         {
           "href": "https://portal.mmccool.net:8099/api/white_balance_auto",
           "contentType": "application/json",
-          "op": [
-            "writeproperty"
-          ],
-          "security": [
-            "digest_sc"
-          ],
-          "http:methodName": "POST"
+          "op": ["writeproperty"],
+          "security": ["digest_sc"],
+          "htv:methodName": "POST"
         },
         {
           "href": "https://portal.mmccool.net:8099/api/white_balance_auto/observe",
           "contentType": "application/json",
-          "op": [
-            "observeproperty"
-          ],
-          "security": [
-            "digest_sc"
-          ],
-          "http:methodName": "GET",
+          "op": ["observeproperty"],
+          "security": ["digest_sc"],
+          "htv:methodName": "GET",
           "subProtocol": "longpoll"
         }
       ]
@@ -1130,10 +731,7 @@
     "exposure": {
       "title": "Exposure",
       "description": "The current absolute exposure setting",
-      "@type": [
-        "iot:CurrentLevel",
-        "iot:LevelData"
-      ],
+      "@type": ["iot:CurrentLevel","iot:LevelData"],
       "type": "integer",
       "minimum": 1,
       "maximum": 5000,
@@ -1142,162 +740,103 @@
         {
           "href": "http://upsq1c.local:9191/api/exposure",
           "contentType": "application/json",
-          "op": [
-            "readproperty"
-          ],
-          "http:methodName": "GET"
+          "op": ["readproperty"]
         },
         {
           "href": "http://upsq1c.local:9191/api/exposure",
           "contentType": "application/json",
-          "op": [
-            "writeproperty"
-          ],
-          "http:methodName": "POST"
+          "op": ["writeproperty"],
+          "htv:methodName": "POST"
         },
         {
           "href": "http://upsq1c.local:9191/api/exposure/observe",
           "contentType": "application/json",
-          "op": [
-            "observeproperty"
-          ],
-          "http:methodName": "GET",
+          "op": ["observeproperty"],
+          "htv:methodName": "GET",
           "subProtocol": "longpoll"
         },
         {
           "href": "https://tiktok.mmccool.org:8098/api/exposure",
           "contentType": "application/json",
-          "op": [
-            "readproperty"
-          ],
-          "security": [
-            "basic_sc"
-          ],
-          "http:methodName": "GET"
+          "op": ["readproperty"],
+          "security": ["basic_sc"]
         },
         {
           "href": "https://tiktok.mmccool.org:8098/api/exposure",
           "contentType": "application/json",
-          "op": [
-            "writeproperty"
-          ],
-          "security": [
-            "basic_sc"
-          ],
-          "http:methodName": "POST"
+          "op": ["writeproperty"],
+          "security": ["basic_sc"],
+          "htv:methodName": "POST"
         },
         {
           "href": "https://tiktok.mmccool.org:8098/api/exposure/observe",
           "contentType": "application/json",
-          "op": [
-            "observeproperty"
-          ],
-          "security": [
-            "basic_sc"
-          ],
-          "http:methodName": "GET",
+          "op": ["observeproperty"],
+          "security": ["basic_sc"],
+          "htv:methodName": "GET",
           "subProtocol": "longpoll"
         },
         {
           "href": "https://tiktok.mmccool.org:8099/api/exposure",
           "contentType": "application/json",
-          "op": [
-            "readproperty"
-          ],
-          "security": [
-            "digest_sc"
-          ],
-          "http:methodName": "GET"
+          "op": ["readproperty"],
+          "security": ["digest_sc"]
         },
         {
           "href": "https://tiktok.mmccool.org:8099/api/exposure",
           "contentType": "application/json",
-          "op": [
-            "writeproperty"
-          ],
-          "security": [
-            "digest_sc"
-          ],
-          "http:methodName": "POST"
+          "op": ["writeproperty"],
+          "security": ["digest_sc"],
+          "htv:methodName": "POST"
         },
         {
           "href": "https://tiktok.mmccool.org:8099/api/exposure/observe",
           "contentType": "application/json",
-          "op": [
-            "observeproperty"
-          ],
-          "security": [
-            "digest_sc"
-          ],
-          "http:methodName": "GET",
+          "op": ["observeproperty"],
+          "security": ["digest_sc"],
+          "htv:methodName": "GET",
           "subProtocol": "longpoll"
         },
         {
           "href": "https://portal.mmccool.net:8098/api/exposure",
           "contentType": "application/json",
-          "op": [
-            "readproperty"
-          ],
-          "security": [
-            "basic_sc"
-          ],
-          "http:methodName": "GET"
+          "op": ["readproperty"],
+          "security": ["basic_sc"]
         },
         {
           "href": "https://portal.mmccool.net:8098/api/exposure",
           "contentType": "application/json",
-          "op": [
-            "writeproperty"
-          ],
-          "security": [
-            "basic_sc"
-          ],
-          "http:methodName": "POST"
+          "op": ["writeproperty"],
+          "security": ["basic_sc"],
+          "htv:methodName": "POST"
         },
         {
           "href": "https://portal.mmccool.net:8098/api/exposure/observe",
           "contentType": "application/json",
-          "op": [
-            "observeproperty"
-          ],
-          "security": [
-            "basic_sc"
-          ],
-          "http:methodName": "GET",
+          "op": ["observeproperty"],
+          "security": ["basic_sc"],
+          "htv:methodName": "GET",
           "subProtocol": "longpoll"
         },
         {
           "href": "https://portal.mmccool.net:8099/api/exposure",
           "contentType": "application/json",
-          "op": [
-            "readproperty"
-          ],
-          "security": [
-            "digest_sc"
-          ],
-          "http:methodName": "GET"
+          "op": ["readproperty"],
+          "security": ["digest_sc"]
         },
         {
           "href": "https://portal.mmccool.net:8099/api/exposure",
           "contentType": "application/json",
-          "op": [
-            "writeproperty"
-          ],
-          "security": [
-            "digest_sc"
-          ],
-          "http:methodName": "POST"
+          "op": ["writeproperty"],
+          "security": ["digest_sc"],
+          "htv:methodName": "POST"
         },
         {
           "href": "https://tiktok.mmccool.org:8099/api/exposure/observe",
           "contentType": "application/json",
-          "op": [
-            "observeproperty"
-          ],
-          "security": [
-            "digest_sc"
-          ],
-          "http:methodName": "GET",
+          "op": ["observeproperty"],
+          "security": ["digest_sc"],
+          "htv:methodName": "GET",
           "subProtocol": "longpoll"
         }
       ]
@@ -1305,172 +844,110 @@
     "exposure_auto": {
       "title": "Exposure Auto Mode",
       "description": "Status of automatic exposure mode",
-      "@type": [
-        "iot:BinarySwitch",
-        "iot:StateData"
-      ],
+      "@type": ["iot:BinarySwitch","iot:StateData"],
       "type": "boolean",
       "observable": true,
       "forms": [
         {
           "href": "http://upsq1c.local:9191/api/exposure_auto",
           "contentType": "application/json",
-          "op": [
-            "readproperty"
-          ],
-          "http:methodName": "GET"
+          "op": ["readproperty"]
         },
         {
           "href": "http://upsq1c.local:9191/api/exposure_auto",
           "contentType": "application/json",
-          "op": [
-            "writeproperty"
-          ],
-          "http:methodName": "POST"
+          "op": ["writeproperty"],
+          "htv:methodName": "POST"
         },
         {
           "href": "http://upsq1c.local:9191/api/exposure_auto/observe",
           "contentType": "application/json",
-          "op": [
-            "observeproperty"
-          ],
-          "http:methodName": "GET",
+          "op": ["observeproperty"],
+          "htv:methodName": "GET",
           "subProtocol": "longpoll"
         },
         {
           "href": "https://tiktok.mmccool.org:8098/api/exposure_auto",
           "contentType": "application/json",
-          "op": [
-            "readproperty"
-          ],
-          "security": [
-            "basic_sc"
-          ],
-          "http:methodName": "GET"
+          "op": ["readproperty"],
+          "security": ["basic_sc"]
         },
         {
           "href": "https://tiktok.mmccool.org:8098/api/exposure_auto",
           "contentType": "application/json",
-          "op": [
-            "writeproperty"
-          ],
-          "security": [
-            "basic_sc"
-          ],
-          "http:methodName": "POST"
+          "op": ["writeproperty"],
+          "security": ["basic_sc"],
+          "htv:methodName": "POST"
         },
         {
           "href": "https://tiktok.mmccool.org:8098/api/exposure_auto/observe",
           "contentType": "application/json",
-          "op": [
-            "observeproperty"
-          ],
-          "security": [
-            "basic_sc"
-          ],
-          "http:methodName": "GET",
+          "op": ["observeproperty"],
+          "security": ["basic_sc"],
+          "htv:methodName": "GET",
           "subProtocol": "longpoll"
         },
         {
           "href": "https://tiktok.mmccool.org:8099/api/exposure_auto",
           "contentType": "application/json",
-          "op": [
-            "readproperty"
-          ],
-          "security": [
-            "digest_sc"
-          ],
-          "http:methodName": "GET"
+          "op": ["readproperty"],
+          "security": ["digest_sc"]
         },
         {
           "href": "https://tiktok.mmccool.org:8099/api/exposure_auto",
           "contentType": "application/json",
-          "op": [
-            "writeproperty"
-          ],
-          "security": [
-            "digest_sc"
-          ],
-          "http:methodName": "POST"
+          "op": ["writeproperty"],
+          "security": ["digest_sc"],
+          "htv:methodName": "POST"
         },
         {
           "href": "https://tiktok.mmccool.org:8099/api/exposure_auto/observe",
           "contentType": "application/json",
-          "op": [
-            "observeproperty"
-          ],
-          "security": [
-            "digest_sc"
-          ],
-          "http:methodName": "GET",
+          "op": ["observeproperty"],
+          "security": ["digest_sc"],
+          "htv:methodName": "GET",
           "subProtocol": "longpoll"
         },
         {
           "href": "https://portal.mmccool.net:8098/api/exposure_auto",
           "contentType": "application/json",
-          "op": [
-            "readproperty"
-          ],
-          "security": [
-            "basic_sc"
-          ],
-          "http:methodName": "GET"
+          "op": ["readproperty"],
+          "security": ["basic_sc"]
         },
         {
           "href": "https://portal.mmccool.net:8098/api/exposure_auto",
           "contentType": "application/json",
-          "op": [
-            "writeproperty"
-          ],
-          "security": [
-            "basic_sc"
-          ],
-          "http:methodName": "POST"
+          "op": ["writeproperty"],
+          "security": ["basic_sc"],
+          "htv:methodName": "POST"
         },
         {
           "href": "https://portal.mmccool.net:8098/api/exposure_auto/observe",
           "contentType": "application/json",
-          "op": [
-            "observeproperty"
-          ],
-          "security": [
-            "basic_sc"
-          ],
-          "http:methodName": "GET",
+          "op": ["observeproperty"],
+          "security": ["basic_sc"],
+          "htv:methodName": "GET",
           "subProtocol": "longpoll"
         },
         {
           "href": "https://portal.mmccool.net:8099/api/exposure_auto",
           "contentType": "application/json",
-          "op": [
-            "readproperty"
-          ],
-          "security": [
-            "digest_sc"
-          ],
-          "http:methodName": "GET"
+          "op": ["readproperty"],
+          "security": ["digest_sc"]
         },
         {
           "href": "https://portal.mmccool.net:8099/api/exposure_auto",
           "contentType": "application/json",
-          "op": [
-            "writeproperty"
-          ],
-          "security": [
-            "digest_sc"
-          ],
-          "http:methodName": "POST"
+          "op": ["writeproperty"],
+          "security": ["digest_sc"],
+          "htv:methodName": "POST"
         },
         {
           "href": "https://portal.mmccool.net:8099/api/exposure_auto/observe",
           "contentType": "application/json",
-          "op": [
-            "observeproperty"
-          ],
-          "security": [
-            "digest_sc"
-          ],
-          "http:methodName": "GET",
+          "op": ["observeproperty"],
+          "security": ["digest_sc"],
+          "htv:methodName": "GET",
           "subProtocol": "longpoll"
         }
       ]
@@ -1478,172 +955,110 @@
     "exposure_auto_priority": {
       "title": "Exposure Auto Priority",
       "description": "Statue of automatic exposure priority",
-      "@type": [
-        "iot:BinarySwitch",
-        "iot:StateData"
-      ],
+      "@type": ["iot:BinarySwitch","iot:StateData"],
       "type": "boolean",
       "observable": true,
       "forms": [
         {
           "href": "http://upsq1c.local:9191/api/exposure_auto_priority",
           "contentType": "application/json",
-          "op": [
-            "readproperty"
-          ],
-          "http:methodName": "GET"
+          "op": ["readproperty"]
         },
         {
           "href": "http://upsq1c.local:9191/api/exposure_auto_priority",
           "contentType": "application/json",
-          "op": [
-            "writeproperty"
-          ],
-          "http:methodName": "POST"
+          "op": ["writeproperty"],
+          "htv:methodName": "POST"
         },
         {
           "href": "http://upsq1c.local:9191/api/exposure_auto_priority/observe",
           "contentType": "application/json",
-          "op": [
-            "observeproperty"
-          ],
-          "http:methodName": "GET",
+          "op": ["observeproperty"],
+          "htv:methodName": "GET",
           "subProtocol": "longpoll"
         },
         {
           "href": "https://tiktok.mmccool.org:8098/api/exposure_auto_priority",
           "contentType": "application/json",
-          "op": [
-            "readproperty"
-          ],
-          "security": [
-            "basic_sc"
-          ],
-          "http:methodName": "GET"
+          "op": ["readproperty"],
+          "security": ["basic_sc"]
         },
         {
           "href": "https://tiktok.mmccool.org:8098/api/exposure_auto_priority",
           "contentType": "application/json",
-          "op": [
-            "writeproperty"
-          ],
-          "security": [
-            "basic_sc"
-          ],
-          "http:methodName": "POST"
+          "op": ["writeproperty"],
+          "security": ["basic_sc"],
+          "htv:methodName": "POST"
         },
         {
           "href": "https://tiktok.mmccool.org:8098/api/exposure_auto_priority/observe",
           "contentType": "application/json",
-          "op": [
-            "observeproperty"
-          ],
-          "security": [
-            "basic_sc"
-          ],
-          "http:methodName": "GET",
+          "op": ["observeproperty"],
+          "security": ["basic_sc"],
+          "htv:methodName": "GET",
           "subProtocol": "longpoll"
         },
         {
           "href": "https://tiktok.mmccool.org:8099/api/exposure_auto_priority",
           "contentType": "application/json",
-          "op": [
-            "readproperty"
-          ],
-          "security": [
-            "digest_sc"
-          ],
-          "http:methodName": "GET"
+          "op": ["readproperty"],
+          "security": ["digest_sc"]
         },
         {
           "href": "https://tiktok.mmccool.org:8099/api/exposure_auto_priority",
           "contentType": "application/json",
-          "op": [
-            "writeproperty"
-          ],
-          "security": [
-            "digest_sc"
-          ],
-          "http:methodName": "POST"
+          "op": ["writeproperty"],
+          "security": ["digest_sc"],
+          "htv:methodName": "POST"
         },
         {
           "href": "https://tiktok.mmccool.org:8099/api/exposure_auto_priority/observe",
           "contentType": "application/json",
-          "op": [
-            "observeproperty"
-          ],
-          "security": [
-            "digest_sc"
-          ],
-          "http:methodName": "GET",
+          "op": ["observeproperty"],
+          "security": ["digest_sc"],
+          "htv:methodName": "GET",
           "subProtocol": "longpoll"
         },
         {
           "href": "https://portal.mmccool.net:8098/api/exposure_auto_priority",
           "contentType": "application/json",
-          "op": [
-            "readproperty"
-          ],
-          "security": [
-            "basic_sc"
-          ],
-          "http:methodName": "GET"
+          "op": ["readproperty"],
+          "security": ["basic_sc"]
         },
         {
           "href": "https://portal.mmccool.net:8098/api/exposure_auto_priority",
           "contentType": "application/json",
-          "op": [
-            "writeproperty"
-          ],
-          "security": [
-            "basic_sc"
-          ],
-          "http:methodName": "POST"
+          "op": ["writeproperty"],
+          "security": ["basic_sc"],
+          "htv:methodName": "POST"
         },
         {
           "href": "https://portal.mmccool.net:8098/api/exposure_auto_priority/observe",
           "contentType": "application/json",
-          "op": [
-            "observeproperty"
-          ],
-          "security": [
-            "basic_sc"
-          ],
-          "http:methodName": "GET",
+          "op": ["observeproperty"],
+          "security": ["basic_sc"],
+          "htv:methodName": "GET",
           "subProtocol": "longpoll"
         },
         {
           "href": "https://portal.mmccool.net:8099/api/exposure_auto_priority",
           "contentType": "application/json",
-          "op": [
-            "readproperty"
-          ],
-          "security": [
-            "digest_sc"
-          ],
-          "http:methodName": "GET"
+          "op": ["readproperty"],
+          "security": ["digest_sc"]
         },
         {
           "href": "https://portal.mmccool.net:8099/api/exposure_auto_priority",
           "contentType": "application/json",
-          "op": [
-            "writeproperty"
-          ],
-          "security": [
-            "digest_sc"
-          ],
-          "http:methodName": "POST"
+          "op": ["writeproperty"],
+          "security": ["digest_sc"],
+          "htv:methodName": "POST"
         },
         {
           "href": "https://portal.mmccool.net:8099/api/exposure_auto_priority/observe",
           "contentType": "application/json",
-          "op": [
-            "observeproperty"
-          ],
-          "security": [
-            "digest_sc"
-          ],
-          "http:methodName": "GET",
+          "op": ["observeproperty"],
+          "security": ["digest_sc"],
+          "htv:methodName": "GET",
           "subProtocol": "longpoll"
         }
       ]
@@ -1651,10 +1066,7 @@
     "backlight_compensation": {
       "title": "Backlight Compensation",
       "description": "The current backlight compensation setting",
-      "@type": [
-        "iot:CurrentLevel",
-        "iot:LevelData"
-      ],
+      "@type": ["iot:CurrentLevel","iot:LevelData"],
       "type": "integer",
       "minimum": 0,
       "maximum": 2,
@@ -1663,162 +1075,103 @@
         {
           "href": "http://upsq1c.local:9191/api/backlight_compensation",
           "contentType": "application/json",
-          "op": [
-            "readproperty"
-          ],
-          "http:methodName": "GET"
+          "op": ["readproperty"]
         },
         {
           "href": "http://upsq1c.local:9191/api/backlight_compensation",
           "contentType": "application/json",
-          "op": [
-            "writeproperty"
-          ],
-          "http:methodName": "POST"
+          "op": ["writeproperty"],
+          "htv:methodName": "POST"
         },
         {
           "href": "http://upsq1c.local:9191/api/backlight_compensation/observe",
           "contentType": "application/json",
-          "op": [
-            "observeproperty"
-          ],
-          "http:methodName": "GET",
+          "op": ["observeproperty"],
+          "htv:methodName": "GET",
           "subProtocol": "longpoll"
         },
         {
           "href": "https://tiktok.mmccool.org:8098/api/backlight_compensation",
           "contentType": "application/json",
-          "op": [
-            "readproperty"
-          ],
-          "security": [
-            "basic_sc"
-          ],
-          "http:methodName": "GET"
+          "op": ["readproperty"],
+          "security": ["basic_sc"]
         },
         {
           "href": "https://tiktok.mmccool.org:8098/api/backlight_compensation",
           "contentType": "application/json",
-          "op": [
-            "writeproperty"
-          ],
-          "security": [
-            "basic_sc"
-          ],
-          "http:methodName": "POST"
+          "op": ["writeproperty"],
+          "security": ["basic_sc"],
+          "htv:methodName": "POST"
         },
         {
           "href": "https://tiktok.mmccool.org:8098/api/backlight_compensation/observe",
           "contentType": "application/json",
-          "op": [
-            "observeproperty"
-          ],
-          "security": [
-            "basic_sc"
-          ],
-          "http:methodName": "GET",
+          "op": ["observeproperty"],
+          "security": ["basic_sc"],
+          "htv:methodName": "GET",
           "subProtocol": "longpoll"
         },
         {
           "href": "https://tiktok.mmccool.org:8099/api/backlight_compensation",
           "contentType": "application/json",
-          "op": [
-            "readproperty"
-          ],
-          "security": [
-            "digest_sc"
-          ],
-          "http:methodName": "GET"
+          "op": ["readproperty"],
+          "security": ["digest_sc"]
         },
         {
           "href": "https://tiktok.mmccool.org:8099/api/backlight_compensation",
           "contentType": "application/json",
-          "op": [
-            "writeproperty"
-          ],
-          "security": [
-            "digest_sc"
-          ],
-          "http:methodName": "POST"
+          "op": ["writeproperty"],
+          "security": ["digest_sc"],
+          "htv:methodName": "POST"
         },
         {
           "href": "https://tiktok.mmccool.org:8099/api/backlight_compensation/observe",
           "contentType": "application/json",
-          "op": [
-            "observeproperty"
-          ],
-          "security": [
-            "digest_sc"
-          ],
-          "http:methodName": "GET",
+          "op": ["observeproperty"],
+          "security": ["digest_sc"],
+          "htv:methodName": "GET",
           "subProtocol": "longpoll"
         },
         {
           "href": "https://portal.mmccool.net:8098/api/backlight_compensation",
           "contentType": "application/json",
-          "op": [
-            "readproperty"
-          ],
-          "security": [
-            "basic_sc"
-          ],
-          "http:methodName": "GET"
+          "op": ["readproperty"],
+          "security": ["basic_sc"]
         },
         {
           "href": "https://portal.mmccool.net:8098/api/backlight_compensation",
           "contentType": "application/json",
-          "op": [
-            "writeproperty"
-          ],
-          "security": [
-            "basic_sc"
-          ],
-          "http:methodName": "POST"
+          "op": ["writeproperty"],
+          "security": ["basic_sc"],
+          "htv:methodName": "POST"
         },
         {
           "href": "https://portal.mmccool.net:8098/api/backlight_compensation/observe",
           "contentType": "application/json",
-          "op": [
-            "observeproperty"
-          ],
-          "security": [
-            "basic_sc"
-          ],
-          "http:methodName": "GET",
+          "op": ["observeproperty"],
+          "security": ["basic_sc"],
+          "htv:methodName": "GET",
           "subProtocol": "longpoll"
         },
         {
           "href": "https://portal.mmccool.net:8099/api/backlight_compensation",
           "contentType": "application/json",
-          "op": [
-            "readproperty"
-          ],
-          "security": [
-            "digest_sc"
-          ],
-          "http:methodName": "GET"
+          "op": ["readproperty"],
+          "security": ["digest_sc"]
         },
         {
           "href": "https://portal.mmccool.net:8099/api/backlight_compensation",
           "contentType": "application/json",
-          "op": [
-            "writeproperty"
-          ],
-          "security": [
-            "digest_sc"
-          ],
-          "http:methodName": "POST"
+          "op": ["writeproperty"],
+          "security": ["digest_sc"],
+          "htv:methodName": "POST"
         },
         {
           "href": "https://portal.mmccool.net:8099/api/backlight_compensation/observe",
           "contentType": "application/json",
-          "op": [
-            "observeproperty"
-          ],
-          "security": [
-            "digest_sc"
-          ],
-          "http:methodName": "GET",
+          "op": ["observeproperty"],
+          "security": ["digest_sc"],
+          "htv:methodName": "GET",
           "subProtocol": "longpoll"
         }
       ]
@@ -1834,162 +1187,103 @@
         {
           "href": "http://upsq1c.local:9191/api/sharpness",
           "contentType": "application/json",
-          "op": [
-            "readproperty"
-          ],
-          "http:methodName": "GET"
+          "op": ["readproperty"]
         },
         {
           "href": "http://upsq1c.local:9191/api/sharpness",
           "contentType": "application/json",
-          "op": [
-            "writeproperty"
-          ],
-          "http:methodName": "POST"
+          "op": ["writeproperty"],
+          "htv:methodName": "POST"
         },
         {
           "href": "http://upsq1c.local:9191/api/sharpness/observe",
           "contentType": "application/json",
-          "op": [
-            "observeproperty"
-          ],
-          "http:methodName": "GET",
+          "op": ["observeproperty"],
+          "htv:methodName": "GET",
           "subProtocol": "longpoll"
         },
         {
           "href": "https://tiktok.mmccool.org:8098/api/sharpness",
           "contentType": "application/json",
-          "op": [
-            "readproperty"
-          ],
-          "security": [
-            "basic_sc"
-          ],
-          "http:methodName": "GET"
+          "op": ["readproperty"],
+          "security": ["basic_sc"]
         },
         {
           "href": "https://tiktok.mmccool.org:8098/api/sharpness",
           "contentType": "application/json",
-          "op": [
-            "writeproperty"
-          ],
-          "security": [
-            "basic_sc"
-          ],
-          "http:methodName": "POST"
+          "op": ["writeproperty"],
+          "security": ["basic_sc"],
+          "htv:methodName": "POST"
         },
         {
           "href": "https://tiktok.mmccool.org:8098/api/sharpness/observe",
           "contentType": "application/json",
-          "op": [
-            "observeproperty"
-          ],
-          "security": [
-            "basic_sc"
-          ],
-          "http:methodName": "GET",
+          "op": ["observeproperty"],
+          "security": ["basic_sc"],
+          "htv:methodName": "GET",
           "subProtocol": "longpoll"
         },
         {
           "href": "https://tiktok.mmccool.org:8099/api/sharpness",
           "contentType": "application/json",
-          "op": [
-            "readproperty"
-          ],
-          "security": [
-            "digest_sc"
-          ],
-          "http:methodName": "GET"
+          "op": ["readproperty"],
+          "security": ["digest_sc"]
         },
         {
           "href": "https://tiktok.mmccool.org:8099/api/sharpness",
           "contentType": "application/json",
-          "op": [
-            "writeproperty"
-          ],
-          "security": [
-            "digest_sc"
-          ],
-          "http:methodName": "POST"
+          "op": ["writeproperty"],
+          "security": ["digest_sc"],
+          "htv:methodName": "POST"
         },
         {
           "href": "https://tiktok.mmccool.org:8099/api/sharpness/observe",
           "contentType": "application/json",
-          "op": [
-            "observeproperty"
-          ],
-          "security": [
-            "digest_sc"
-          ],
-          "http:methodName": "GET",
+          "op": ["observeproperty"],
+          "security": ["digest_sc"],
+          "htv:methodName": "GET",
           "subProtocol": "longpoll"
         },
         {
           "href": "https://portal.mmccool.net:8098/api/sharpness",
           "contentType": "application/json",
-          "op": [
-            "readproperty"
-          ],
-          "security": [
-            "basic_sc"
-          ],
-          "http:methodName": "GET"
+          "op": ["readproperty"],
+          "security": ["basic_sc"]
         },
         {
           "href": "https://portal.mmccool.net:8098/api/sharpness",
           "contentType": "application/json",
-          "op": [
-            "writeproperty"
-          ],
-          "security": [
-            "basic_sc"
-          ],
-          "http:methodName": "POST"
+          "op": ["writeproperty"],
+          "security": ["basic_sc"],
+          "htv:methodName": "POST"
         },
         {
           "href": "https://portal.mmccool.net:8098/api/sharpness/observe",
           "contentType": "application/json",
-          "op": [
-            "observeproperty"
-          ],
-          "security": [
-            "basic_sc"
-          ],
-          "http:methodName": "GET",
+          "op": ["observeproperty"],
+          "security": ["basic_sc"],
+          "htv:methodName": "GET",
           "subProtocol": "longpoll"
         },
         {
           "href": "https://portal.mmccool.net:8099/api/sharpness",
           "contentType": "application/json",
-          "op": [
-            "readproperty"
-          ],
-          "security": [
-            "digest_sc"
-          ],
-          "http:methodName": "GET"
+          "op": ["readproperty"],
+          "security": ["digest_sc"]
         },
         {
           "href": "https://portal.mmccool.net:8099/api/sharpness",
           "contentType": "application/json",
-          "op": [
-            "writeproperty"
-          ],
-          "security": [
-            "digest_sc"
-          ],
-          "http:methodName": "POST"
+          "op": ["writeproperty"],
+          "security": ["digest_sc"],
+          "htv:methodName": "POST"
         },
         {
           "href": "https://tiktok.mmccool.org:8099/api/sharpness/observe",
           "contentType": "application/json",
-          "op": [
-            "observeproperty"
-          ],
-          "security": [
-            "digest_sc"
-          ],
-          "http:methodName": "GET",
+          "op": ["observeproperty"],
+          "security": ["digest_sc"],
+          "htv:methodName": "GET",
           "subProtocol": "longpoll"
         }
       ]
@@ -2001,110 +1295,69 @@
         {
           "href": "http://upsq1c.local:9191/api/frame",
           "contentType": "image/jpeg",
-          "op": [
-            "readproperty"
-          ],
-          "http:methodName": "GET"
+          "op": ["readproperty"]
         },
         {
           "href": "http://upsq1c.local:9191/api/frame/observe",
           "contentType": "image/jpeg",
-          "op": [
-            "observeproperty"
-          ],
-          "http:methodName": "GET",
+          "op": ["observeproperty"],
+          "htv:methodName": "GET",
           "subProtocol": "longpoll"
         },
         {
           "href": "https://tiktok.mmccool.org:8098/api/frame",
           "contentType": "image/jpeg",
-          "op": [
-            "readproperty"
-          ],
-          "security": [
-            "basic_sc"
-          ],
-          "http:methodName": "GET"
+          "op": ["readproperty"],
+          "security": ["basic_sc"]
         },
         {
           "href": "https://tiktok.mmccool.org:8098/api/frame/observe",
           "contentType": "image/jpeg",
-          "op": [
-            "observeproperty"
-          ],
-          "security": [
-            "basic_sc"
-          ],
-          "http:methodName": "GET",
+          "op": ["observeproperty"],
+          "security": ["basic_sc"],
+          "htv:methodName": "GET",
           "subProtocol": "longpoll"
         },
         {
           "href": "https://tiktok.mmccool.org:8099/api/frame",
           "contentType": "image/jpeg",
-          "op": [
-            "readproperty"
-          ],
-          "security": [
-            "digest_sc"
-          ],
-          "http:methodName": "GET"
+          "op": ["readproperty"],
+          "security": ["digest_sc"]
         },
         {
           "href": "https://tiktok.mmccool.org:8099/api/frame/observe",
           "contentType": "image/jpeg",
-          "op": [
-            "observeproperty"
-          ],
-          "security": [
-            "digest_sc"
-          ],
-          "http:methodName": "GET",
+          "op": ["observeproperty"],
+          "security": ["digest_sc"],
+          "htv:methodName": "GET",
           "subProtocol": "longpoll"
         },
         {
           "href": "https://portal.mmccool.net:8098/api/frame",
           "contentType": "image/jpeg",
-          "op": [
-            "readproperty"
-          ],
-          "security": [
-            "basic_sc"
-          ],
-          "http:methodName": "GET"
+          "op": ["readproperty"],
+          "security": ["basic_sc"]
         },
         {
           "href": "https://portal.mmccool.net:8098/api/frame/observe",
           "contentType": "image/jpeg",
-          "op": [
-            "observeproperty"
-          ],
-          "security": [
-            "basic_sc"
-          ],
-          "http:methodName": "GET",
+          "op": ["observeproperty"],
+          "security": ["basic_sc"],
+          "htv:methodName": "GET",
           "subProtocol": "longpoll"
         },
         {
           "href": "https://portal.mmccool.net:8099/api/frame",
           "contentType": "image/jpeg",
-          "op": [
-            "readproperty"
-          ],
-          "security": [
-            "digest_sc"
-          ],
-          "http:methodName": "GET"
+          "op": ["readproperty"],
+          "security": ["digest_sc"]
         },
         {
           "href": "https://portal.mmccool.net:8099/api/frame/observe",
           "contentType": "image/jpeg",
-          "op": [
-            "observeproperty"
-          ],
-          "security": [
-            "digest_sc"
-          ],
-          "http:methodName": "GET",
+          "op": ["observeproperty"],
+          "security": ["digest_sc"],
+          "htv:methodName": "GET",
           "subProtocol": "longpoll"
         }
       ]
@@ -2115,91 +1368,75 @@
       "title": "Crop",
       "description": "Extract and return a portion of the most recently grabbed image",
       "input": {
-        "type": "object",
-        "properties": {
-          "xo": {
-            "title": "x origin (pixels)",
-            "type": "integer",
-            "minimum": 0
+          "type": "object",
+          "properties": {
+              "xo": {
+                  "title": "x origin (pixels)",
+                  "type": "integer",
+                  "minimum": 0
+              },
+              "yo": {
+                  "title": "y origin (pixels)",
+                  "type": "integer",
+                  "minimum": 0
+              },
+              "x": {
+                  "title": "x size (pixels)",
+                  "type": "integer",
+                  "minimum": 0
+              },
+              "y": {
+                  "title": "y size (pixels)",
+                  "type": "integer",
+                  "minimum": 0
+              }
           },
-          "yo": {
-            "title": "y origin (pixels)",
-            "type": "integer",
-            "minimum": 0
-          },
-          "x": {
-            "title": "x size (pixels)",
-            "type": "integer",
-            "minimum": 0
-          },
-          "y": {
-            "title": "y size (pixels)",
-            "type": "integer",
-            "minimum": 0
-          }
-        },
-        "required": [
-          "x",
-          "y"
-        ]
-      },
+          "required": ["x","y"]
+      }, 
       "forms": [
         {
           "href": "http://upsq1c.local:9191/api/frame/crop",
           "contentType": "application/json",
           "response": {
-            "contentType": "image/jpeg"
+              "contentType": "image/jpeg"
           },
-          "op": "invokeaction",
-          "http:methodName": "POST"
+          "op": "invokeaction"
         },
         {
           "href": "https://tiktok.mmccool.org:8098/api/frame/crop",
           "contentType": "application/json",
           "response": {
-            "contentType": "image/jpeg"
+              "contentType": "image/jpeg"
           },
           "op": "invokeaction",
-          "security": [
-            "basic_sc"
-          ],
-          "http:methodName": "POST"
+          "security": ["basic_sc"]
         },
         {
           "href": "https://tiktok.mmccool.org:8099/api/frame/crop",
           "contentType": "application/json",
           "response": {
-            "contentType": "image/jpeg"
+              "contentType": "image/jpeg"
           },
           "op": "invokeaction",
-          "security": [
-            "digest_sc"
-          ],
-          "http:methodName": "POST"
+          "security": ["digest_sc"]
         },
         {
           "href": "https://portal.mmccool.net:8098/api/frame/crop",
           "contentType": "application/json",
           "response": {
-            "contentType": "image/jpeg"
+              "contentType": "image/jpeg"
           },
           "op": "invokeaction",
-          "security": [
-            "basic_sc"
-          ],
-          "http:methodName": "POST"
+          "security": ["basic_sc"]
         },
         {
           "href": "https://portal.mmccool.net:8099/api/frame/crop",
           "contentType": "application/json",
           "response": {
-            "contentType": "image/jpeg"
+              "contentType": "image/jpeg"
           },
           "op": "invokeaction",
-          "security": [
-            "digest_sc"
-          ],
-          "http:methodName": "POST"
+          "security": ["digest_sc"]
         }
       ]
     },
@@ -2207,79 +1444,56 @@
       "title": "Region",
       "description": "Extract and return a portion of the most recently grabbed image.",
       "uriVariables": {
-        "xo": {
-          "title": "x origin (pixels)",
-          "type": "integer",
-          "minimum": 0
-        },
-        "yo": {
-          "title": "y origin (pixels)",
-          "type": "integer",
-          "minimum": 0
-        },
-        "x": {
-          "title": "x size (pixels)",
-          "type": "integer",
-          "minimum": 0
-        },
-        "y": {
-          "title": "y size (pixels)",
-          "type": "integer",
-          "minimum": 0
-        }
-      },
+          "xo": {
+              "title": "x origin (pixels)",
+              "type": "integer",
+              "minimum": 0
+          },
+          "yo": {
+              "title": "y origin (pixels)",
+              "type": "integer",
+              "minimum": 0
+          },
+          "x": {
+              "title": "x size (pixels)",
+              "type": "integer",
+              "minimum": 0
+          },
+          "y": {
+              "title": "y size (pixels)",
+              "type": "integer",
+              "minimum": 0
+          }
+      }, 
       "forms": [
         {
           "href": "http://upsq1c.local:9191/api/frame/region{?xo,yo,x,y}",
           "contentType": "image/jpeg",
-          "op": [
-            "invokeaction"
-          ],
-          "http:methodName": "GET"
+          "op": ["invokeaction"]
         },
         {
           "href": "https://tiktok.mmccool.org:8098/api/frame/region{?xo,yo,x,y}",
           "contentType": "image/jpeg",
-          "op": [
-            "invokeaction"
-          ],
-          "security": [
-            "basic_sc"
-          ],
-          "http:methodName": "GET"
+          "op": ["invokeaction"],
+          "security": ["basic_sc"]
         },
         {
           "href": "https://tiktok.mmccool.org:8099/api/frame/region{?xo,yo,x,y}",
           "contentType": "image/jpeg",
-          "op": [
-            "invokeaction"
-          ],
-          "security": [
-            "digest_sc"
-          ],
-          "http:methodName": "GET"
+          "op": ["invokeaction"],
+          "security": ["digest_sc"]
         },
         {
           "href": "https://portal.mmccool.net:8098/api/frame/region{?xo,yo,x,y}",
           "contentType": "image/jpeg",
-          "op": [
-            "invokeaction"
-          ],
-          "security": [
-            "basic_sc"
-          ],
-          "http:methodName": "GET"
+          "op": ["invokeaction"],
+          "security": ["basic_sc"]
         },
         {
           "href": "https://portal.mmccool.net:8099/api/frame/region{?xo,yo,x,y}",
           "contentType": "image/jpeg",
-          "op": [
-            "invokeaction"
-          ],
-          "security": [
-            "digest_sc"
-          ],
-          "http:methodName": "GET"
+          "op": ["invokeaction"],
+          "security": ["digest_sc"]
         }
       ]
     }

--- a/workshop/ws2/demos-2019-Munich/TDs/Intel/intel-ocf/Intel-OCF-button1touch.jsonld
+++ b/workshop/ws2/demos-2019-Munich/TDs/Intel/intel-ocf/Intel-OCF-button1touch.jsonld
@@ -1,18 +1,17 @@
 {
   "@context": [
-    "http://www.w3.org/ns/td",
+    "https://www.w3.org/2019/wot/td/v1",
     {
-      "iot": "http://iotschema.org/",
-      "http": "http://www.w3.org/2011/http#"
+      "iot": "http://iotschema.org/"
     }
   ],
   "@type": [
     "Thing",
-    "Motion",
-    "iot:MotionControl",
-    "iot:Sensor"
+    "Switch",
+    "iot:Sensor",
+    "iot:BinarySwitch"
   ],
-  "id": "urn:uuid:c440e5ef-a02f-49cf-b036-00b0738b0d86",
+  "id": "urn:uuid:3932ae08-31b4-4882-b299-5d488ec8775c",
   "securityDefinitions": {
     "nosec_sc": {
       "scheme": "nosec"
@@ -27,13 +26,13 @@
   "security": [
     "nosec_sc"
   ],
-  "name": "Intel-OCF-c440e5ef-a02f-49cf-b036-00b0738b0d86",
+  "title": "Intel-OCF-button1touch",
   "support": "mailto:michael.mccool@intel.com",
   "version": {
     "instance": "0.1.0"
   },
-  "created": "2018-09-10T06:30+00:00",
-  "lastModified": "2018-12-19T04:06:02.096Z",
+  "created": "2018-09-10T06:30:00Z",
+  "modified": "2019-05-28T05:43:02.346Z",
   "links": [
     {
       "href": "https://github.com/mmccool/ocf-wot-metadata-bridge",
@@ -42,13 +41,13 @@
     }
   ],
   "properties": {
-    "motion": {
-      "title": "Motion Sense Status",
+    "status": {
+      "title": "On/Off Status",
       "readOnly": true,
       "observable": true,
       "@type": [
-        "Occupancy",
-        "iot:MotionDetected"
+        "OnOffState",
+        "iot:SwitchStatus"
       ],
       "type": "object",
       "properties": {
@@ -57,7 +56,7 @@
         },
         "value": {
           "@type": [
-            "iot:StateData"
+            "iot:Toggle"
           ],
           "type": "boolean"
         }
@@ -68,87 +67,82 @@
       "forms": [
         {
           "contentType": "application/json",
-          "href": "http://upsq1c.local:8000/api/oic/a/motion2?di=c440e5ef-a02f-49cf-b036-00b0738b0d86",
-          "op": "readproperty",
-          "http:methodName": "GET"
+          "href": "http://upsq1c.local:8000/api/oic/a/button1touch?di=3932ae08-31b4-4882-b299-5d488ec8775c",
+          "op": "readproperty"
         },
         {
           "contentType": "application/json",
-          "href": "http://upsq1c.local:8000/api/oic/a/motion2?di=c440e5ef-a02f-49cf-b036-00b0738b0d86",
+          "href": "http://upsq1c.local:8000/api/oic/a/button1touch?di=3932ae08-31b4-4882-b299-5d488ec8775c",
           "op": "writeproperty",
-          "http:methodName": "POST"
+          "htv:methodName": "POST"
         },
         {
           "contentType": "application/json",
-          "href": "https://portal.mmccool.net:8090/api/oic/a/motion2?di=c440e5ef-a02f-49cf-b036-00b0738b0d86",
+          "href": "https://portal.mmccool.net:8090/api/oic/a/button1touch?di=3932ae08-31b4-4882-b299-5d488ec8775c",
           "security": [
             "basic_sc"
           ],
-          "op": "readproperty",
-          "http:methodName": "GET"
+          "op": "readproperty"
         },
         {
           "contentType": "application/json",
-          "href": "https://portal.mmccool.net:8090/api/oic/a/motion2?di=c440e5ef-a02f-49cf-b036-00b0738b0d86",
-          "security": [
-            "basic_sc"
-          ],
-          "op": "writeproperty",
-          "http:methodName": "POST"
-        },
-        {
-          "contentType": "application/json",
-          "href": "https://tiktok.mmccool.org:8091/api/oic/a/motion2?di=c440e5ef-a02f-49cf-b036-00b0738b0d86",
-          "security": [
-            "basic_sc"
-          ],
-          "op": "readproperty",
-          "http:methodName": "GET"
-        },
-        {
-          "contentType": "application/json",
-          "href": "https://tiktok.mmccool.org:8091/api/oic/a/motion2?di=c440e5ef-a02f-49cf-b036-00b0738b0d86",
+          "href": "https://portal.mmccool.net:8090/api/oic/a/button1touch?di=3932ae08-31b4-4882-b299-5d488ec8775c",
           "security": [
             "basic_sc"
           ],
           "op": "writeproperty",
-          "http:methodName": "POST"
+          "htv:methodName": "POST"
         },
         {
           "contentType": "application/json",
-          "href": "https://portal.mmccool.net:8090/api/oic/a/motion2?di=c440e5ef-a02f-49cf-b036-00b0738b0d86",
+          "href": "https://tiktok.mmccool.org:8091/api/oic/a/button1touch?di=3932ae08-31b4-4882-b299-5d488ec8775c",
+          "security": [
+            "basic_sc"
+          ],
+          "op": "readproperty"
+        },
+        {
+          "contentType": "application/json",
+          "href": "https://tiktok.mmccool.org:8091/api/oic/a/button1touch?di=3932ae08-31b4-4882-b299-5d488ec8775c",
+          "security": [
+            "basic_sc"
+          ],
+          "op": "writeproperty",
+          "htv:methodName": "POST"
+        },
+        {
+          "contentType": "application/json",
+          "href": "https://portal.mmccool.net:8090/api/oic/a/button1touch?di=3932ae08-31b4-4882-b299-5d488ec8775c",
           "security": [
             "digest_sc"
           ],
-          "op": "readproperty",
-          "http:methodName": "GET"
+          "op": "readproperty"
         },
         {
           "contentType": "application/json",
-          "href": "https://portal.mmccool.net:8090/api/oic/a/motion2?di=c440e5ef-a02f-49cf-b036-00b0738b0d86",
+          "href": "https://portal.mmccool.net:8090/api/oic/a/button1touch?di=3932ae08-31b4-4882-b299-5d488ec8775c",
           "security": [
             "digest_sc"
           ],
           "op": "writeproperty",
-          "http:methodName": "POST"
+          "htv:methodName": "POST"
         },
         {
           "contentType": "application/json",
-          "href": "https://tiktok.mmccool.org:8091/api/oic/a/motion2?di=c440e5ef-a02f-49cf-b036-00b0738b0d86",
+          "href": "https://tiktok.mmccool.org:8091/api/oic/a/button1touch?di=3932ae08-31b4-4882-b299-5d488ec8775c",
           "security": [
             "digest_sc"
           ],
-          "op": "readproperty",
-          "http:methodName": "GET"
+          "op": "readproperty"
         },
         {
           "contentType": "application/json",
-          "href": "https://tiktok.mmccool.org:8091/api/oic/a/motion2?di=c440e5ef-a02f-49cf-b036-00b0738b0d86",
+          "href": "https://tiktok.mmccool.org:8091/api/oic/a/button1touch?di=3932ae08-31b4-4882-b299-5d488ec8775c",
           "security": [
             "digest_sc"
           ],
           "op": "writeproperty",
-          "http:methodName": "POST"
+          "htv:methodName": "POST"
         }
       ]
     }

--- a/workshop/ws2/demos-2019-Munich/TDs/Intel/intel-ocf/Intel-OCF-button2touch.jsonld
+++ b/workshop/ws2/demos-2019-Munich/TDs/Intel/intel-ocf/Intel-OCF-button2touch.jsonld
@@ -1,9 +1,8 @@
 {
   "@context": [
-    "http://www.w3.org/ns/td",
+    "https://www.w3.org/2019/wot/td/v1",
     {
-      "iot": "http://iotschema.org/",
-      "http": "http://www.w3.org/2011/http#"
+      "iot": "http://iotschema.org/"
     }
   ],
   "@type": [
@@ -27,13 +26,13 @@
   "security": [
     "nosec_sc"
   ],
-  "name": "Intel-OCF-15603e08-5f45-4bd5-b3ef-6a192ae39f76",
+  "title": "Intel-OCF-button2touch",
   "support": "mailto:michael.mccool@intel.com",
   "version": {
     "instance": "0.1.0"
   },
-  "created": "2018-09-10T06:30+00:00",
-  "lastModified": "2018-12-19T04:06:02.096Z",
+  "created": "2018-09-10T06:30:00Z",
+  "modified": "2019-05-28T05:43:02.344Z",
   "links": [
     {
       "href": "https://github.com/mmccool/ocf-wot-metadata-bridge",
@@ -69,14 +68,13 @@
         {
           "contentType": "application/json",
           "href": "http://upsq1c.local:8000/api/oic/a/button2touch?di=15603e08-5f45-4bd5-b3ef-6a192ae39f76",
-          "op": "readproperty",
-          "http:methodName": "GET"
+          "op": "readproperty"
         },
         {
           "contentType": "application/json",
           "href": "http://upsq1c.local:8000/api/oic/a/button2touch?di=15603e08-5f45-4bd5-b3ef-6a192ae39f76",
           "op": "writeproperty",
-          "http:methodName": "POST"
+          "htv:methodName": "POST"
         },
         {
           "contentType": "application/json",
@@ -84,8 +82,7 @@
           "security": [
             "basic_sc"
           ],
-          "op": "readproperty",
-          "http:methodName": "GET"
+          "op": "readproperty"
         },
         {
           "contentType": "application/json",
@@ -94,7 +91,7 @@
             "basic_sc"
           ],
           "op": "writeproperty",
-          "http:methodName": "POST"
+          "htv:methodName": "POST"
         },
         {
           "contentType": "application/json",
@@ -102,8 +99,7 @@
           "security": [
             "basic_sc"
           ],
-          "op": "readproperty",
-          "http:methodName": "GET"
+          "op": "readproperty"
         },
         {
           "contentType": "application/json",
@@ -112,7 +108,7 @@
             "basic_sc"
           ],
           "op": "writeproperty",
-          "http:methodName": "POST"
+          "htv:methodName": "POST"
         },
         {
           "contentType": "application/json",
@@ -120,8 +116,7 @@
           "security": [
             "digest_sc"
           ],
-          "op": "readproperty",
-          "http:methodName": "GET"
+          "op": "readproperty"
         },
         {
           "contentType": "application/json",
@@ -130,7 +125,7 @@
             "digest_sc"
           ],
           "op": "writeproperty",
-          "http:methodName": "POST"
+          "htv:methodName": "POST"
         },
         {
           "contentType": "application/json",
@@ -138,8 +133,7 @@
           "security": [
             "digest_sc"
           ],
-          "op": "readproperty",
-          "http:methodName": "GET"
+          "op": "readproperty"
         },
         {
           "contentType": "application/json",
@@ -148,7 +142,7 @@
             "digest_sc"
           ],
           "op": "writeproperty",
-          "http:methodName": "POST"
+          "htv:methodName": "POST"
         }
       ]
     }

--- a/workshop/ws2/demos-2019-Munich/TDs/Intel/intel-ocf/Intel-OCF-buzzer0.jsonld
+++ b/workshop/ws2/demos-2019-Munich/TDs/Intel/intel-ocf/Intel-OCF-buzzer0.jsonld
@@ -1,18 +1,16 @@
 {
   "@context": [
-    "http://www.w3.org/ns/td",
+    "https://www.w3.org/2019/wot/td/v1",
     {
-      "iot": "http://iotschema.org/",
-      "http": "http://www.w3.org/2011/http#"
+      "iot": "http://iotschema.org/"
     }
   ],
   "@type": [
     "Thing",
-    "Switch",
-    "iot:Sensor",
+    "iot:Actuator",
     "iot:BinarySwitch"
   ],
-  "id": "urn:uuid:4b74842c-8bfe-4f14-8bc5-31b4c79658a4",
+  "id": "urn:uuid:893e9dbb-a298-4123-a041-80f386115958",
   "securityDefinitions": {
     "nosec_sc": {
       "scheme": "nosec"
@@ -27,13 +25,13 @@
   "security": [
     "nosec_sc"
   ],
-  "name": "Intel-OCF-4b74842c-8bfe-4f14-8bc5-31b4c79658a4",
+  "title": "Intel-OCF-buzzer0",
   "support": "mailto:michael.mccool@intel.com",
   "version": {
     "instance": "0.1.0"
   },
-  "created": "2018-09-10T06:30+00:00",
-  "lastModified": "2018-12-19T04:06:02.096Z",
+  "created": "2018-09-10T06:30:00Z",
+  "modified": "2019-05-28T05:43:02.335Z",
   "links": [
     {
       "href": "https://github.com/mmccool/ocf-wot-metadata-bridge",
@@ -44,7 +42,6 @@
   "properties": {
     "status": {
       "title": "On/Off Status",
-      "readOnly": true,
       "observable": true,
       "@type": [
         "OnOffState",
@@ -68,87 +65,82 @@
       "forms": [
         {
           "contentType": "application/json",
-          "href": "http://upsq1c.local:8000/api/oic/a/toggle0?di=4b74842c-8bfe-4f14-8bc5-31b4c79658a4",
-          "op": "readproperty",
-          "http:methodName": "GET"
+          "href": "http://upsq1c.local:8000/api/oic/a/buzzer0?di=893e9dbb-a298-4123-a041-80f386115958",
+          "op": "readproperty"
         },
         {
           "contentType": "application/json",
-          "href": "http://upsq1c.local:8000/api/oic/a/toggle0?di=4b74842c-8bfe-4f14-8bc5-31b4c79658a4",
+          "href": "http://upsq1c.local:8000/api/oic/a/buzzer0?di=893e9dbb-a298-4123-a041-80f386115958",
           "op": "writeproperty",
-          "http:methodName": "POST"
+          "htv:methodName": "POST"
         },
         {
           "contentType": "application/json",
-          "href": "https://portal.mmccool.net:8090/api/oic/a/toggle0?di=4b74842c-8bfe-4f14-8bc5-31b4c79658a4",
+          "href": "https://portal.mmccool.net:8090/api/oic/a/buzzer0?di=893e9dbb-a298-4123-a041-80f386115958",
           "security": [
             "basic_sc"
           ],
-          "op": "readproperty",
-          "http:methodName": "GET"
+          "op": "readproperty"
         },
         {
           "contentType": "application/json",
-          "href": "https://portal.mmccool.net:8090/api/oic/a/toggle0?di=4b74842c-8bfe-4f14-8bc5-31b4c79658a4",
-          "security": [
-            "basic_sc"
-          ],
-          "op": "writeproperty",
-          "http:methodName": "POST"
-        },
-        {
-          "contentType": "application/json",
-          "href": "https://tiktok.mmccool.org:8091/api/oic/a/toggle0?di=4b74842c-8bfe-4f14-8bc5-31b4c79658a4",
-          "security": [
-            "basic_sc"
-          ],
-          "op": "readproperty",
-          "http:methodName": "GET"
-        },
-        {
-          "contentType": "application/json",
-          "href": "https://tiktok.mmccool.org:8091/api/oic/a/toggle0?di=4b74842c-8bfe-4f14-8bc5-31b4c79658a4",
+          "href": "https://portal.mmccool.net:8090/api/oic/a/buzzer0?di=893e9dbb-a298-4123-a041-80f386115958",
           "security": [
             "basic_sc"
           ],
           "op": "writeproperty",
-          "http:methodName": "POST"
+          "htv:methodName": "POST"
         },
         {
           "contentType": "application/json",
-          "href": "https://portal.mmccool.net:8090/api/oic/a/toggle0?di=4b74842c-8bfe-4f14-8bc5-31b4c79658a4",
+          "href": "https://tiktok.mmccool.org:8091/api/oic/a/buzzer0?di=893e9dbb-a298-4123-a041-80f386115958",
+          "security": [
+            "basic_sc"
+          ],
+          "op": "readproperty"
+        },
+        {
+          "contentType": "application/json",
+          "href": "https://tiktok.mmccool.org:8091/api/oic/a/buzzer0?di=893e9dbb-a298-4123-a041-80f386115958",
+          "security": [
+            "basic_sc"
+          ],
+          "op": "writeproperty",
+          "htv:methodName": "POST"
+        },
+        {
+          "contentType": "application/json",
+          "href": "https://portal.mmccool.net:8090/api/oic/a/buzzer0?di=893e9dbb-a298-4123-a041-80f386115958",
           "security": [
             "digest_sc"
           ],
-          "op": "readproperty",
-          "http:methodName": "GET"
+          "op": "readproperty"
         },
         {
           "contentType": "application/json",
-          "href": "https://portal.mmccool.net:8090/api/oic/a/toggle0?di=4b74842c-8bfe-4f14-8bc5-31b4c79658a4",
+          "href": "https://portal.mmccool.net:8090/api/oic/a/buzzer0?di=893e9dbb-a298-4123-a041-80f386115958",
           "security": [
             "digest_sc"
           ],
           "op": "writeproperty",
-          "http:methodName": "POST"
+          "htv:methodName": "POST"
         },
         {
           "contentType": "application/json",
-          "href": "https://tiktok.mmccool.org:8091/api/oic/a/toggle0?di=4b74842c-8bfe-4f14-8bc5-31b4c79658a4",
+          "href": "https://tiktok.mmccool.org:8091/api/oic/a/buzzer0?di=893e9dbb-a298-4123-a041-80f386115958",
           "security": [
             "digest_sc"
           ],
-          "op": "readproperty",
-          "http:methodName": "GET"
+          "op": "readproperty"
         },
         {
           "contentType": "application/json",
-          "href": "https://tiktok.mmccool.org:8091/api/oic/a/toggle0?di=4b74842c-8bfe-4f14-8bc5-31b4c79658a4",
+          "href": "https://tiktok.mmccool.org:8091/api/oic/a/buzzer0?di=893e9dbb-a298-4123-a041-80f386115958",
           "security": [
             "digest_sc"
           ],
           "op": "writeproperty",
-          "http:methodName": "POST"
+          "htv:methodName": "POST"
         }
       ]
     }

--- a/workshop/ws2/demos-2019-Munich/TDs/Intel/intel-ocf/Intel-OCF-illuminance0.jsonld
+++ b/workshop/ws2/demos-2019-Munich/TDs/Intel/intel-ocf/Intel-OCF-illuminance0.jsonld
@@ -1,9 +1,8 @@
 {
   "@context": [
-    "http://www.w3.org/ns/td",
+    "https://www.w3.org/2019/wot/td/v1",
     {
-      "iot": "http://iotschema.org/",
-      "http": "http://www.w3.org/2011/http#"
+      "iot": "http://iotschema.org/"
     }
   ],
   "@type": [
@@ -27,13 +26,13 @@
   "security": [
     "nosec_sc"
   ],
-  "name": "Intel-OCF-3255959d-741c-4b2b-81c2-42a4caa2223e",
+  "title": "Intel-OCF-illuminance0",
   "support": "mailto:michael.mccool@intel.com",
   "version": {
     "instance": "0.1.0"
   },
-  "created": "2018-09-10T06:30+00:00",
-  "lastModified": "2018-12-19T04:06:02.096Z",
+  "created": "2018-09-10T06:30:00Z",
+  "modified": "2019-05-28T05:43:02.346Z",
   "links": [
     {
       "href": "https://github.com/mmccool/ocf-wot-metadata-bridge",
@@ -69,14 +68,13 @@
         {
           "contentType": "application/json",
           "href": "http://upsq1c.local:8000/api/oic/a/illuminance0?di=3255959d-741c-4b2b-81c2-42a4caa2223e",
-          "op": "readproperty",
-          "http:methodName": "GET"
+          "op": "readproperty"
         },
         {
           "contentType": "application/json",
           "href": "http://upsq1c.local:8000/api/oic/a/illuminance0?di=3255959d-741c-4b2b-81c2-42a4caa2223e",
           "op": "writeproperty",
-          "http:methodName": "POST"
+          "htv:methodName": "POST"
         },
         {
           "contentType": "application/json",
@@ -84,8 +82,7 @@
           "security": [
             "basic_sc"
           ],
-          "op": "readproperty",
-          "http:methodName": "GET"
+          "op": "readproperty"
         },
         {
           "contentType": "application/json",
@@ -94,7 +91,7 @@
             "basic_sc"
           ],
           "op": "writeproperty",
-          "http:methodName": "POST"
+          "htv:methodName": "POST"
         },
         {
           "contentType": "application/json",
@@ -102,8 +99,7 @@
           "security": [
             "basic_sc"
           ],
-          "op": "readproperty",
-          "http:methodName": "GET"
+          "op": "readproperty"
         },
         {
           "contentType": "application/json",
@@ -112,7 +108,7 @@
             "basic_sc"
           ],
           "op": "writeproperty",
-          "http:methodName": "POST"
+          "htv:methodName": "POST"
         },
         {
           "contentType": "application/json",
@@ -120,8 +116,7 @@
           "security": [
             "digest_sc"
           ],
-          "op": "readproperty",
-          "http:methodName": "GET"
+          "op": "readproperty"
         },
         {
           "contentType": "application/json",
@@ -130,7 +125,7 @@
             "digest_sc"
           ],
           "op": "writeproperty",
-          "http:methodName": "POST"
+          "htv:methodName": "POST"
         },
         {
           "contentType": "application/json",
@@ -138,8 +133,7 @@
           "security": [
             "digest_sc"
           ],
-          "op": "readproperty",
-          "http:methodName": "GET"
+          "op": "readproperty"
         },
         {
           "contentType": "application/json",
@@ -148,7 +142,7 @@
             "digest_sc"
           ],
           "op": "writeproperty",
-          "http:methodName": "POST"
+          "htv:methodName": "POST"
         }
       ]
     }

--- a/workshop/ws2/demos-2019-Munich/TDs/Intel/intel-ocf/Intel-OCF-illuminance2.jsonld
+++ b/workshop/ws2/demos-2019-Munich/TDs/Intel/intel-ocf/Intel-OCF-illuminance2.jsonld
@@ -1,17 +1,17 @@
 {
   "@context": [
-    "http://www.w3.org/ns/td",
+    "https://www.w3.org/2019/wot/td/v1",
     {
-      "iot": "http://iotschema.org/",
-      "http": "http://www.w3.org/2011/http#"
+      "iot": "http://iotschema.org/"
     }
   ],
   "@type": [
     "Thing",
-    "iot:Actuator",
-    "iot:BinarySwitch"
+    "Meter",
+    "iot:IlluminanceSensing",
+    "iot:Sensor"
   ],
-  "id": "urn:uuid:893e9dbb-a298-4123-a041-80f386115958",
+  "id": "urn:uuid:c75fe336-28d3-4b02-b52c-9a4daa9577f6",
   "securityDefinitions": {
     "nosec_sc": {
       "scheme": "nosec"
@@ -26,13 +26,13 @@
   "security": [
     "nosec_sc"
   ],
-  "name": "Intel-OCF-893e9dbb-a298-4123-a041-80f386115958",
+  "title": "Intel-OCF-illuminance2",
   "support": "mailto:michael.mccool@intel.com",
   "version": {
     "instance": "0.1.0"
   },
-  "created": "2018-09-10T06:30+00:00",
-  "lastModified": "2018-12-19T04:06:02.096Z",
+  "created": "2018-09-10T06:30:00Z",
+  "modified": "2019-05-28T05:43:02.338Z",
   "links": [
     {
       "href": "https://github.com/mmccool/ocf-wot-metadata-bridge",
@@ -41,12 +41,13 @@
     }
   ],
   "properties": {
-    "status": {
-      "title": "On/Off Status",
+    "illuminance": {
+      "title": "Illuminance",
+      "readOnly": true,
       "observable": true,
       "@type": [
-        "OnOffState",
-        "iot:SwitchStatus"
+        "MultiLevelState",
+        "iot:Illuminance"
       ],
       "type": "object",
       "properties": {
@@ -55,9 +56,9 @@
         },
         "value": {
           "@type": [
-            "iot:Toggle"
+            "iot:IlluminanceData"
           ],
-          "type": "boolean"
+          "type": "number"
         }
       },
       "required": [
@@ -66,87 +67,82 @@
       "forms": [
         {
           "contentType": "application/json",
-          "href": "http://upsq1c.local:8000/api/oic/a/buzzer0?di=893e9dbb-a298-4123-a041-80f386115958",
-          "op": "readproperty",
-          "http:methodName": "GET"
+          "href": "http://upsq1c.local:8000/api/oic/a/illuminance2?di=c75fe336-28d3-4b02-b52c-9a4daa9577f6",
+          "op": "readproperty"
         },
         {
           "contentType": "application/json",
-          "href": "http://upsq1c.local:8000/api/oic/a/buzzer0?di=893e9dbb-a298-4123-a041-80f386115958",
+          "href": "http://upsq1c.local:8000/api/oic/a/illuminance2?di=c75fe336-28d3-4b02-b52c-9a4daa9577f6",
           "op": "writeproperty",
-          "http:methodName": "POST"
+          "htv:methodName": "POST"
         },
         {
           "contentType": "application/json",
-          "href": "https://portal.mmccool.net:8090/api/oic/a/buzzer0?di=893e9dbb-a298-4123-a041-80f386115958",
+          "href": "https://portal.mmccool.net:8090/api/oic/a/illuminance2?di=c75fe336-28d3-4b02-b52c-9a4daa9577f6",
           "security": [
             "basic_sc"
           ],
-          "op": "readproperty",
-          "http:methodName": "GET"
+          "op": "readproperty"
         },
         {
           "contentType": "application/json",
-          "href": "https://portal.mmccool.net:8090/api/oic/a/buzzer0?di=893e9dbb-a298-4123-a041-80f386115958",
-          "security": [
-            "basic_sc"
-          ],
-          "op": "writeproperty",
-          "http:methodName": "POST"
-        },
-        {
-          "contentType": "application/json",
-          "href": "https://tiktok.mmccool.org:8091/api/oic/a/buzzer0?di=893e9dbb-a298-4123-a041-80f386115958",
-          "security": [
-            "basic_sc"
-          ],
-          "op": "readproperty",
-          "http:methodName": "GET"
-        },
-        {
-          "contentType": "application/json",
-          "href": "https://tiktok.mmccool.org:8091/api/oic/a/buzzer0?di=893e9dbb-a298-4123-a041-80f386115958",
+          "href": "https://portal.mmccool.net:8090/api/oic/a/illuminance2?di=c75fe336-28d3-4b02-b52c-9a4daa9577f6",
           "security": [
             "basic_sc"
           ],
           "op": "writeproperty",
-          "http:methodName": "POST"
+          "htv:methodName": "POST"
         },
         {
           "contentType": "application/json",
-          "href": "https://portal.mmccool.net:8090/api/oic/a/buzzer0?di=893e9dbb-a298-4123-a041-80f386115958",
+          "href": "https://tiktok.mmccool.org:8091/api/oic/a/illuminance2?di=c75fe336-28d3-4b02-b52c-9a4daa9577f6",
+          "security": [
+            "basic_sc"
+          ],
+          "op": "readproperty"
+        },
+        {
+          "contentType": "application/json",
+          "href": "https://tiktok.mmccool.org:8091/api/oic/a/illuminance2?di=c75fe336-28d3-4b02-b52c-9a4daa9577f6",
+          "security": [
+            "basic_sc"
+          ],
+          "op": "writeproperty",
+          "htv:methodName": "POST"
+        },
+        {
+          "contentType": "application/json",
+          "href": "https://portal.mmccool.net:8090/api/oic/a/illuminance2?di=c75fe336-28d3-4b02-b52c-9a4daa9577f6",
           "security": [
             "digest_sc"
           ],
-          "op": "readproperty",
-          "http:methodName": "GET"
+          "op": "readproperty"
         },
         {
           "contentType": "application/json",
-          "href": "https://portal.mmccool.net:8090/api/oic/a/buzzer0?di=893e9dbb-a298-4123-a041-80f386115958",
+          "href": "https://portal.mmccool.net:8090/api/oic/a/illuminance2?di=c75fe336-28d3-4b02-b52c-9a4daa9577f6",
           "security": [
             "digest_sc"
           ],
           "op": "writeproperty",
-          "http:methodName": "POST"
+          "htv:methodName": "POST"
         },
         {
           "contentType": "application/json",
-          "href": "https://tiktok.mmccool.org:8091/api/oic/a/buzzer0?di=893e9dbb-a298-4123-a041-80f386115958",
+          "href": "https://tiktok.mmccool.org:8091/api/oic/a/illuminance2?di=c75fe336-28d3-4b02-b52c-9a4daa9577f6",
           "security": [
             "digest_sc"
           ],
-          "op": "readproperty",
-          "http:methodName": "GET"
+          "op": "readproperty"
         },
         {
           "contentType": "application/json",
-          "href": "https://tiktok.mmccool.org:8091/api/oic/a/buzzer0?di=893e9dbb-a298-4123-a041-80f386115958",
+          "href": "https://tiktok.mmccool.org:8091/api/oic/a/illuminance2?di=c75fe336-28d3-4b02-b52c-9a4daa9577f6",
           "security": [
             "digest_sc"
           ],
           "op": "writeproperty",
-          "http:methodName": "POST"
+          "htv:methodName": "POST"
         }
       ]
     }

--- a/workshop/ws2/demos-2019-Munich/TDs/Intel/intel-ocf/Intel-OCF-led0blue.jsonld
+++ b/workshop/ws2/demos-2019-Munich/TDs/Intel/intel-ocf/Intel-OCF-led0blue.jsonld
@@ -1,9 +1,8 @@
 {
   "@context": [
-    "http://www.w3.org/ns/td",
+    "https://www.w3.org/2019/wot/td/v1",
     {
-      "iot": "http://iotschema.org/",
-      "http": "http://www.w3.org/2011/http#"
+      "iot": "http://iotschema.org/"
     }
   ],
   "@type": [
@@ -13,7 +12,7 @@
     "iot:Actuator",
     "iot:BinarySwitch"
   ],
-  "id": "urn:uuid:79683ab5-8df1-4b7a-b110-c1b8fe251e7d",
+  "id": "urn:uuid:397a9167-88bc-4b52-844a-dade5b772c30",
   "securityDefinitions": {
     "nosec_sc": {
       "scheme": "nosec"
@@ -28,13 +27,13 @@
   "security": [
     "nosec_sc"
   ],
-  "name": "Intel-OCF-79683ab5-8df1-4b7a-b110-c1b8fe251e7d",
+  "title": "Intel-OCF-led0blue",
   "support": "mailto:michael.mccool@intel.com",
   "version": {
     "instance": "0.1.0"
   },
-  "created": "2018-09-10T06:30+00:00",
-  "lastModified": "2018-12-19T04:06:02.096Z",
+  "created": "2018-09-10T06:30:00Z",
+  "modified": "2019-05-28T05:43:02.346Z",
   "links": [
     {
       "href": "https://github.com/mmccool/ocf-wot-metadata-bridge",
@@ -68,87 +67,82 @@
       "forms": [
         {
           "contentType": "application/json",
-          "href": "http://upsq1c.local:8000/api/oic/a/led2relay?di=79683ab5-8df1-4b7a-b110-c1b8fe251e7d",
-          "op": "readproperty",
-          "http:methodName": "GET"
+          "href": "http://upsq1c.local:8000/api/oic/a/led0blue?di=397a9167-88bc-4b52-844a-dade5b772c30",
+          "op": "readproperty"
         },
         {
           "contentType": "application/json",
-          "href": "http://upsq1c.local:8000/api/oic/a/led2relay?di=79683ab5-8df1-4b7a-b110-c1b8fe251e7d",
+          "href": "http://upsq1c.local:8000/api/oic/a/led0blue?di=397a9167-88bc-4b52-844a-dade5b772c30",
           "op": "writeproperty",
-          "http:methodName": "POST"
+          "htv:methodName": "POST"
         },
         {
           "contentType": "application/json",
-          "href": "https://portal.mmccool.net:8090/api/oic/a/led2relay?di=79683ab5-8df1-4b7a-b110-c1b8fe251e7d",
+          "href": "https://portal.mmccool.net:8090/api/oic/a/led0blue?di=397a9167-88bc-4b52-844a-dade5b772c30",
           "security": [
             "basic_sc"
           ],
-          "op": "readproperty",
-          "http:methodName": "GET"
+          "op": "readproperty"
         },
         {
           "contentType": "application/json",
-          "href": "https://portal.mmccool.net:8090/api/oic/a/led2relay?di=79683ab5-8df1-4b7a-b110-c1b8fe251e7d",
-          "security": [
-            "basic_sc"
-          ],
-          "op": "writeproperty",
-          "http:methodName": "POST"
-        },
-        {
-          "contentType": "application/json",
-          "href": "https://tiktok.mmccool.org:8091/api/oic/a/led2relay?di=79683ab5-8df1-4b7a-b110-c1b8fe251e7d",
-          "security": [
-            "basic_sc"
-          ],
-          "op": "readproperty",
-          "http:methodName": "GET"
-        },
-        {
-          "contentType": "application/json",
-          "href": "https://tiktok.mmccool.org:8091/api/oic/a/led2relay?di=79683ab5-8df1-4b7a-b110-c1b8fe251e7d",
+          "href": "https://portal.mmccool.net:8090/api/oic/a/led0blue?di=397a9167-88bc-4b52-844a-dade5b772c30",
           "security": [
             "basic_sc"
           ],
           "op": "writeproperty",
-          "http:methodName": "POST"
+          "htv:methodName": "POST"
         },
         {
           "contentType": "application/json",
-          "href": "https://portal.mmccool.net:8090/api/oic/a/led2relay?di=79683ab5-8df1-4b7a-b110-c1b8fe251e7d",
+          "href": "https://tiktok.mmccool.org:8091/api/oic/a/led0blue?di=397a9167-88bc-4b52-844a-dade5b772c30",
+          "security": [
+            "basic_sc"
+          ],
+          "op": "readproperty"
+        },
+        {
+          "contentType": "application/json",
+          "href": "https://tiktok.mmccool.org:8091/api/oic/a/led0blue?di=397a9167-88bc-4b52-844a-dade5b772c30",
+          "security": [
+            "basic_sc"
+          ],
+          "op": "writeproperty",
+          "htv:methodName": "POST"
+        },
+        {
+          "contentType": "application/json",
+          "href": "https://portal.mmccool.net:8090/api/oic/a/led0blue?di=397a9167-88bc-4b52-844a-dade5b772c30",
           "security": [
             "digest_sc"
           ],
-          "op": "readproperty",
-          "http:methodName": "GET"
+          "op": "readproperty"
         },
         {
           "contentType": "application/json",
-          "href": "https://portal.mmccool.net:8090/api/oic/a/led2relay?di=79683ab5-8df1-4b7a-b110-c1b8fe251e7d",
+          "href": "https://portal.mmccool.net:8090/api/oic/a/led0blue?di=397a9167-88bc-4b52-844a-dade5b772c30",
           "security": [
             "digest_sc"
           ],
           "op": "writeproperty",
-          "http:methodName": "POST"
+          "htv:methodName": "POST"
         },
         {
           "contentType": "application/json",
-          "href": "https://tiktok.mmccool.org:8091/api/oic/a/led2relay?di=79683ab5-8df1-4b7a-b110-c1b8fe251e7d",
+          "href": "https://tiktok.mmccool.org:8091/api/oic/a/led0blue?di=397a9167-88bc-4b52-844a-dade5b772c30",
           "security": [
             "digest_sc"
           ],
-          "op": "readproperty",
-          "http:methodName": "GET"
+          "op": "readproperty"
         },
         {
           "contentType": "application/json",
-          "href": "https://tiktok.mmccool.org:8091/api/oic/a/led2relay?di=79683ab5-8df1-4b7a-b110-c1b8fe251e7d",
+          "href": "https://tiktok.mmccool.org:8091/api/oic/a/led0blue?di=397a9167-88bc-4b52-844a-dade5b772c30",
           "security": [
             "digest_sc"
           ],
           "op": "writeproperty",
-          "http:methodName": "POST"
+          "htv:methodName": "POST"
         }
       ]
     }
@@ -180,32 +174,32 @@
       "forms": [
         {
           "contentType": "application/json",
-          "href": "http://upsq1c.local:8000/api/oic/a/led2relay?di=79683ab5-8df1-4b7a-b110-c1b8fe251e7d"
+          "href": "http://upsq1c.local:8000/api/oic/a/led0blue?di=397a9167-88bc-4b52-844a-dade5b772c30"
         },
         {
           "contentType": "application/json",
-          "href": "https://portal.mmccool.net:8090/api/oic/a/led2relay?di=79683ab5-8df1-4b7a-b110-c1b8fe251e7d",
+          "href": "https://portal.mmccool.net:8090/api/oic/a/led0blue?di=397a9167-88bc-4b52-844a-dade5b772c30",
           "security": [
             "basic_sc"
           ]
         },
         {
           "contentType": "application/json",
-          "href": "https://tiktok.mmccool.org:8091/api/oic/a/led2relay?di=79683ab5-8df1-4b7a-b110-c1b8fe251e7d",
+          "href": "https://tiktok.mmccool.org:8091/api/oic/a/led0blue?di=397a9167-88bc-4b52-844a-dade5b772c30",
           "security": [
             "basic_sc"
           ]
         },
         {
           "contentType": "application/json",
-          "href": "https://portal.mmccool.net:8090/api/oic/a/led2relay?di=79683ab5-8df1-4b7a-b110-c1b8fe251e7d",
+          "href": "https://portal.mmccool.net:8090/api/oic/a/led0blue?di=397a9167-88bc-4b52-844a-dade5b772c30",
           "security": [
             "digest_sc"
           ]
         },
         {
           "contentType": "application/json",
-          "href": "https://tiktok.mmccool.org:8091/api/oic/a/led2relay?di=79683ab5-8df1-4b7a-b110-c1b8fe251e7d",
+          "href": "https://tiktok.mmccool.org:8091/api/oic/a/led0blue?di=397a9167-88bc-4b52-844a-dade5b772c30",
           "security": [
             "digest_sc"
           ]
@@ -238,32 +232,32 @@
       "forms": [
         {
           "contentType": "application/json",
-          "href": "http://upsq1c.local:8000/api/oic/a/led2relay?di=79683ab5-8df1-4b7a-b110-c1b8fe251e7d"
+          "href": "http://upsq1c.local:8000/api/oic/a/led0blue?di=397a9167-88bc-4b52-844a-dade5b772c30"
         },
         {
           "contentType": "application/json",
-          "href": "https://portal.mmccool.net:8090/api/oic/a/led2relay?di=79683ab5-8df1-4b7a-b110-c1b8fe251e7d",
+          "href": "https://portal.mmccool.net:8090/api/oic/a/led0blue?di=397a9167-88bc-4b52-844a-dade5b772c30",
           "security": [
             "basic_sc"
           ]
         },
         {
           "contentType": "application/json",
-          "href": "https://tiktok.mmccool.org:8091/api/oic/a/led2relay?di=79683ab5-8df1-4b7a-b110-c1b8fe251e7d",
+          "href": "https://tiktok.mmccool.org:8091/api/oic/a/led0blue?di=397a9167-88bc-4b52-844a-dade5b772c30",
           "security": [
             "basic_sc"
           ]
         },
         {
           "contentType": "application/json",
-          "href": "https://portal.mmccool.net:8090/api/oic/a/led2relay?di=79683ab5-8df1-4b7a-b110-c1b8fe251e7d",
+          "href": "https://portal.mmccool.net:8090/api/oic/a/led0blue?di=397a9167-88bc-4b52-844a-dade5b772c30",
           "security": [
             "digest_sc"
           ]
         },
         {
           "contentType": "application/json",
-          "href": "https://tiktok.mmccool.org:8091/api/oic/a/led2relay?di=79683ab5-8df1-4b7a-b110-c1b8fe251e7d",
+          "href": "https://tiktok.mmccool.org:8091/api/oic/a/led0blue?di=397a9167-88bc-4b52-844a-dade5b772c30",
           "security": [
             "digest_sc"
           ]

--- a/workshop/ws2/demos-2019-Munich/TDs/Intel/intel-ocf/Intel-OCF-led0green.jsonld
+++ b/workshop/ws2/demos-2019-Munich/TDs/Intel/intel-ocf/Intel-OCF-led0green.jsonld
@@ -1,9 +1,8 @@
 {
   "@context": [
-    "http://www.w3.org/ns/td",
+    "https://www.w3.org/2019/wot/td/v1",
     {
-      "iot": "http://iotschema.org/",
-      "http": "http://www.w3.org/2011/http#"
+      "iot": "http://iotschema.org/"
     }
   ],
   "@type": [
@@ -13,7 +12,7 @@
     "iot:Actuator",
     "iot:BinarySwitch"
   ],
-  "id": "urn:uuid:e6b060cf-dc10-4375-ae08-1f9e2de0aa2b",
+  "id": "urn:uuid:6573313c-da1e-4068-beb1-884b0c4c3c5d",
   "securityDefinitions": {
     "nosec_sc": {
       "scheme": "nosec"
@@ -28,13 +27,13 @@
   "security": [
     "nosec_sc"
   ],
-  "name": "Intel-OCF-e6b060cf-dc10-4375-ae08-1f9e2de0aa2b",
+  "title": "Intel-OCF-led0green",
   "support": "mailto:michael.mccool@intel.com",
   "version": {
     "instance": "0.1.0"
   },
-  "created": "2018-09-10T06:30+00:00",
-  "lastModified": "2018-12-19T04:06:02.096Z",
+  "created": "2018-09-10T06:30:00Z",
+  "modified": "2019-05-28T05:43:02.359Z",
   "links": [
     {
       "href": "https://github.com/mmccool/ocf-wot-metadata-bridge",
@@ -68,87 +67,82 @@
       "forms": [
         {
           "contentType": "application/json",
-          "href": "http://upsq1c.local:8000/api/oic/a/led2top?di=e6b060cf-dc10-4375-ae08-1f9e2de0aa2b",
-          "op": "readproperty",
-          "http:methodName": "GET"
+          "href": "http://upsq1c.local:8000/api/oic/a/led0green?di=6573313c-da1e-4068-beb1-884b0c4c3c5d",
+          "op": "readproperty"
         },
         {
           "contentType": "application/json",
-          "href": "http://upsq1c.local:8000/api/oic/a/led2top?di=e6b060cf-dc10-4375-ae08-1f9e2de0aa2b",
+          "href": "http://upsq1c.local:8000/api/oic/a/led0green?di=6573313c-da1e-4068-beb1-884b0c4c3c5d",
           "op": "writeproperty",
-          "http:methodName": "POST"
+          "htv:methodName": "POST"
         },
         {
           "contentType": "application/json",
-          "href": "https://portal.mmccool.net:8090/api/oic/a/led2top?di=e6b060cf-dc10-4375-ae08-1f9e2de0aa2b",
+          "href": "https://portal.mmccool.net:8090/api/oic/a/led0green?di=6573313c-da1e-4068-beb1-884b0c4c3c5d",
           "security": [
             "basic_sc"
           ],
-          "op": "readproperty",
-          "http:methodName": "GET"
+          "op": "readproperty"
         },
         {
           "contentType": "application/json",
-          "href": "https://portal.mmccool.net:8090/api/oic/a/led2top?di=e6b060cf-dc10-4375-ae08-1f9e2de0aa2b",
-          "security": [
-            "basic_sc"
-          ],
-          "op": "writeproperty",
-          "http:methodName": "POST"
-        },
-        {
-          "contentType": "application/json",
-          "href": "https://tiktok.mmccool.org:8091/api/oic/a/led2top?di=e6b060cf-dc10-4375-ae08-1f9e2de0aa2b",
-          "security": [
-            "basic_sc"
-          ],
-          "op": "readproperty",
-          "http:methodName": "GET"
-        },
-        {
-          "contentType": "application/json",
-          "href": "https://tiktok.mmccool.org:8091/api/oic/a/led2top?di=e6b060cf-dc10-4375-ae08-1f9e2de0aa2b",
+          "href": "https://portal.mmccool.net:8090/api/oic/a/led0green?di=6573313c-da1e-4068-beb1-884b0c4c3c5d",
           "security": [
             "basic_sc"
           ],
           "op": "writeproperty",
-          "http:methodName": "POST"
+          "htv:methodName": "POST"
         },
         {
           "contentType": "application/json",
-          "href": "https://portal.mmccool.net:8090/api/oic/a/led2top?di=e6b060cf-dc10-4375-ae08-1f9e2de0aa2b",
+          "href": "https://tiktok.mmccool.org:8091/api/oic/a/led0green?di=6573313c-da1e-4068-beb1-884b0c4c3c5d",
+          "security": [
+            "basic_sc"
+          ],
+          "op": "readproperty"
+        },
+        {
+          "contentType": "application/json",
+          "href": "https://tiktok.mmccool.org:8091/api/oic/a/led0green?di=6573313c-da1e-4068-beb1-884b0c4c3c5d",
+          "security": [
+            "basic_sc"
+          ],
+          "op": "writeproperty",
+          "htv:methodName": "POST"
+        },
+        {
+          "contentType": "application/json",
+          "href": "https://portal.mmccool.net:8090/api/oic/a/led0green?di=6573313c-da1e-4068-beb1-884b0c4c3c5d",
           "security": [
             "digest_sc"
           ],
-          "op": "readproperty",
-          "http:methodName": "GET"
+          "op": "readproperty"
         },
         {
           "contentType": "application/json",
-          "href": "https://portal.mmccool.net:8090/api/oic/a/led2top?di=e6b060cf-dc10-4375-ae08-1f9e2de0aa2b",
+          "href": "https://portal.mmccool.net:8090/api/oic/a/led0green?di=6573313c-da1e-4068-beb1-884b0c4c3c5d",
           "security": [
             "digest_sc"
           ],
           "op": "writeproperty",
-          "http:methodName": "POST"
+          "htv:methodName": "POST"
         },
         {
           "contentType": "application/json",
-          "href": "https://tiktok.mmccool.org:8091/api/oic/a/led2top?di=e6b060cf-dc10-4375-ae08-1f9e2de0aa2b",
+          "href": "https://tiktok.mmccool.org:8091/api/oic/a/led0green?di=6573313c-da1e-4068-beb1-884b0c4c3c5d",
           "security": [
             "digest_sc"
           ],
-          "op": "readproperty",
-          "http:methodName": "GET"
+          "op": "readproperty"
         },
         {
           "contentType": "application/json",
-          "href": "https://tiktok.mmccool.org:8091/api/oic/a/led2top?di=e6b060cf-dc10-4375-ae08-1f9e2de0aa2b",
+          "href": "https://tiktok.mmccool.org:8091/api/oic/a/led0green?di=6573313c-da1e-4068-beb1-884b0c4c3c5d",
           "security": [
             "digest_sc"
           ],
           "op": "writeproperty",
-          "http:methodName": "POST"
+          "htv:methodName": "POST"
         }
       ]
     }
@@ -180,32 +174,32 @@
       "forms": [
         {
           "contentType": "application/json",
-          "href": "http://upsq1c.local:8000/api/oic/a/led2top?di=e6b060cf-dc10-4375-ae08-1f9e2de0aa2b"
+          "href": "http://upsq1c.local:8000/api/oic/a/led0green?di=6573313c-da1e-4068-beb1-884b0c4c3c5d"
         },
         {
           "contentType": "application/json",
-          "href": "https://portal.mmccool.net:8090/api/oic/a/led2top?di=e6b060cf-dc10-4375-ae08-1f9e2de0aa2b",
+          "href": "https://portal.mmccool.net:8090/api/oic/a/led0green?di=6573313c-da1e-4068-beb1-884b0c4c3c5d",
           "security": [
             "basic_sc"
           ]
         },
         {
           "contentType": "application/json",
-          "href": "https://tiktok.mmccool.org:8091/api/oic/a/led2top?di=e6b060cf-dc10-4375-ae08-1f9e2de0aa2b",
+          "href": "https://tiktok.mmccool.org:8091/api/oic/a/led0green?di=6573313c-da1e-4068-beb1-884b0c4c3c5d",
           "security": [
             "basic_sc"
           ]
         },
         {
           "contentType": "application/json",
-          "href": "https://portal.mmccool.net:8090/api/oic/a/led2top?di=e6b060cf-dc10-4375-ae08-1f9e2de0aa2b",
+          "href": "https://portal.mmccool.net:8090/api/oic/a/led0green?di=6573313c-da1e-4068-beb1-884b0c4c3c5d",
           "security": [
             "digest_sc"
           ]
         },
         {
           "contentType": "application/json",
-          "href": "https://tiktok.mmccool.org:8091/api/oic/a/led2top?di=e6b060cf-dc10-4375-ae08-1f9e2de0aa2b",
+          "href": "https://tiktok.mmccool.org:8091/api/oic/a/led0green?di=6573313c-da1e-4068-beb1-884b0c4c3c5d",
           "security": [
             "digest_sc"
           ]
@@ -238,32 +232,32 @@
       "forms": [
         {
           "contentType": "application/json",
-          "href": "http://upsq1c.local:8000/api/oic/a/led2top?di=e6b060cf-dc10-4375-ae08-1f9e2de0aa2b"
+          "href": "http://upsq1c.local:8000/api/oic/a/led0green?di=6573313c-da1e-4068-beb1-884b0c4c3c5d"
         },
         {
           "contentType": "application/json",
-          "href": "https://portal.mmccool.net:8090/api/oic/a/led2top?di=e6b060cf-dc10-4375-ae08-1f9e2de0aa2b",
+          "href": "https://portal.mmccool.net:8090/api/oic/a/led0green?di=6573313c-da1e-4068-beb1-884b0c4c3c5d",
           "security": [
             "basic_sc"
           ]
         },
         {
           "contentType": "application/json",
-          "href": "https://tiktok.mmccool.org:8091/api/oic/a/led2top?di=e6b060cf-dc10-4375-ae08-1f9e2de0aa2b",
+          "href": "https://tiktok.mmccool.org:8091/api/oic/a/led0green?di=6573313c-da1e-4068-beb1-884b0c4c3c5d",
           "security": [
             "basic_sc"
           ]
         },
         {
           "contentType": "application/json",
-          "href": "https://portal.mmccool.net:8090/api/oic/a/led2top?di=e6b060cf-dc10-4375-ae08-1f9e2de0aa2b",
+          "href": "https://portal.mmccool.net:8090/api/oic/a/led0green?di=6573313c-da1e-4068-beb1-884b0c4c3c5d",
           "security": [
             "digest_sc"
           ]
         },
         {
           "contentType": "application/json",
-          "href": "https://tiktok.mmccool.org:8091/api/oic/a/led2top?di=e6b060cf-dc10-4375-ae08-1f9e2de0aa2b",
+          "href": "https://tiktok.mmccool.org:8091/api/oic/a/led0green?di=6573313c-da1e-4068-beb1-884b0c4c3c5d",
           "security": [
             "digest_sc"
           ]

--- a/workshop/ws2/demos-2019-Munich/TDs/Intel/intel-ocf/Intel-OCF-led0mosfet.jsonld
+++ b/workshop/ws2/demos-2019-Munich/TDs/Intel/intel-ocf/Intel-OCF-led0mosfet.jsonld
@@ -1,9 +1,8 @@
 {
   "@context": [
-    "http://www.w3.org/ns/td",
+    "https://www.w3.org/2019/wot/td/v1",
     {
-      "iot": "http://iotschema.org/",
-      "http": "http://www.w3.org/2011/http#"
+      "iot": "http://iotschema.org/"
     }
   ],
   "@type": [
@@ -13,7 +12,7 @@
     "iot:Actuator",
     "iot:BinarySwitch"
   ],
-  "id": "urn:uuid:3ee85e44-7a56-4f0e-a8b8-b250c868e513",
+  "id": "urn:uuid:ea16d184-95ad-4af7-bfc9-53e86f55f3a4",
   "securityDefinitions": {
     "nosec_sc": {
       "scheme": "nosec"
@@ -28,13 +27,13 @@
   "security": [
     "nosec_sc"
   ],
-  "name": "Intel-OCF-3ee85e44-7a56-4f0e-a8b8-b250c868e513",
+  "title": "Intel-OCF-led0mosfet",
   "support": "mailto:michael.mccool@intel.com",
   "version": {
     "instance": "0.1.0"
   },
-  "created": "2018-09-10T06:30+00:00",
-  "lastModified": "2018-12-19T04:06:02.096Z",
+  "created": "2018-09-10T06:30:00Z",
+  "modified": "2019-05-28T05:43:02.344Z",
   "links": [
     {
       "href": "https://github.com/mmccool/ocf-wot-metadata-bridge",
@@ -68,87 +67,82 @@
       "forms": [
         {
           "contentType": "application/json",
-          "href": "http://upsq1c.local:8000/api/oic/a/led2mosfet?di=3ee85e44-7a56-4f0e-a8b8-b250c868e513",
-          "op": "readproperty",
-          "http:methodName": "GET"
+          "href": "http://upsq1c.local:8000/api/oic/a/led0mosfet?di=ea16d184-95ad-4af7-bfc9-53e86f55f3a4",
+          "op": "readproperty"
         },
         {
           "contentType": "application/json",
-          "href": "http://upsq1c.local:8000/api/oic/a/led2mosfet?di=3ee85e44-7a56-4f0e-a8b8-b250c868e513",
+          "href": "http://upsq1c.local:8000/api/oic/a/led0mosfet?di=ea16d184-95ad-4af7-bfc9-53e86f55f3a4",
           "op": "writeproperty",
-          "http:methodName": "POST"
+          "htv:methodName": "POST"
         },
         {
           "contentType": "application/json",
-          "href": "https://portal.mmccool.net:8090/api/oic/a/led2mosfet?di=3ee85e44-7a56-4f0e-a8b8-b250c868e513",
+          "href": "https://portal.mmccool.net:8090/api/oic/a/led0mosfet?di=ea16d184-95ad-4af7-bfc9-53e86f55f3a4",
           "security": [
             "basic_sc"
           ],
-          "op": "readproperty",
-          "http:methodName": "GET"
+          "op": "readproperty"
         },
         {
           "contentType": "application/json",
-          "href": "https://portal.mmccool.net:8090/api/oic/a/led2mosfet?di=3ee85e44-7a56-4f0e-a8b8-b250c868e513",
-          "security": [
-            "basic_sc"
-          ],
-          "op": "writeproperty",
-          "http:methodName": "POST"
-        },
-        {
-          "contentType": "application/json",
-          "href": "https://tiktok.mmccool.org:8091/api/oic/a/led2mosfet?di=3ee85e44-7a56-4f0e-a8b8-b250c868e513",
-          "security": [
-            "basic_sc"
-          ],
-          "op": "readproperty",
-          "http:methodName": "GET"
-        },
-        {
-          "contentType": "application/json",
-          "href": "https://tiktok.mmccool.org:8091/api/oic/a/led2mosfet?di=3ee85e44-7a56-4f0e-a8b8-b250c868e513",
+          "href": "https://portal.mmccool.net:8090/api/oic/a/led0mosfet?di=ea16d184-95ad-4af7-bfc9-53e86f55f3a4",
           "security": [
             "basic_sc"
           ],
           "op": "writeproperty",
-          "http:methodName": "POST"
+          "htv:methodName": "POST"
         },
         {
           "contentType": "application/json",
-          "href": "https://portal.mmccool.net:8090/api/oic/a/led2mosfet?di=3ee85e44-7a56-4f0e-a8b8-b250c868e513",
+          "href": "https://tiktok.mmccool.org:8091/api/oic/a/led0mosfet?di=ea16d184-95ad-4af7-bfc9-53e86f55f3a4",
+          "security": [
+            "basic_sc"
+          ],
+          "op": "readproperty"
+        },
+        {
+          "contentType": "application/json",
+          "href": "https://tiktok.mmccool.org:8091/api/oic/a/led0mosfet?di=ea16d184-95ad-4af7-bfc9-53e86f55f3a4",
+          "security": [
+            "basic_sc"
+          ],
+          "op": "writeproperty",
+          "htv:methodName": "POST"
+        },
+        {
+          "contentType": "application/json",
+          "href": "https://portal.mmccool.net:8090/api/oic/a/led0mosfet?di=ea16d184-95ad-4af7-bfc9-53e86f55f3a4",
           "security": [
             "digest_sc"
           ],
-          "op": "readproperty",
-          "http:methodName": "GET"
+          "op": "readproperty"
         },
         {
           "contentType": "application/json",
-          "href": "https://portal.mmccool.net:8090/api/oic/a/led2mosfet?di=3ee85e44-7a56-4f0e-a8b8-b250c868e513",
+          "href": "https://portal.mmccool.net:8090/api/oic/a/led0mosfet?di=ea16d184-95ad-4af7-bfc9-53e86f55f3a4",
           "security": [
             "digest_sc"
           ],
           "op": "writeproperty",
-          "http:methodName": "POST"
+          "htv:methodName": "POST"
         },
         {
           "contentType": "application/json",
-          "href": "https://tiktok.mmccool.org:8091/api/oic/a/led2mosfet?di=3ee85e44-7a56-4f0e-a8b8-b250c868e513",
+          "href": "https://tiktok.mmccool.org:8091/api/oic/a/led0mosfet?di=ea16d184-95ad-4af7-bfc9-53e86f55f3a4",
           "security": [
             "digest_sc"
           ],
-          "op": "readproperty",
-          "http:methodName": "GET"
+          "op": "readproperty"
         },
         {
           "contentType": "application/json",
-          "href": "https://tiktok.mmccool.org:8091/api/oic/a/led2mosfet?di=3ee85e44-7a56-4f0e-a8b8-b250c868e513",
+          "href": "https://tiktok.mmccool.org:8091/api/oic/a/led0mosfet?di=ea16d184-95ad-4af7-bfc9-53e86f55f3a4",
           "security": [
             "digest_sc"
           ],
           "op": "writeproperty",
-          "http:methodName": "POST"
+          "htv:methodName": "POST"
         }
       ]
     }
@@ -180,32 +174,32 @@
       "forms": [
         {
           "contentType": "application/json",
-          "href": "http://upsq1c.local:8000/api/oic/a/led2mosfet?di=3ee85e44-7a56-4f0e-a8b8-b250c868e513"
+          "href": "http://upsq1c.local:8000/api/oic/a/led0mosfet?di=ea16d184-95ad-4af7-bfc9-53e86f55f3a4"
         },
         {
           "contentType": "application/json",
-          "href": "https://portal.mmccool.net:8090/api/oic/a/led2mosfet?di=3ee85e44-7a56-4f0e-a8b8-b250c868e513",
+          "href": "https://portal.mmccool.net:8090/api/oic/a/led0mosfet?di=ea16d184-95ad-4af7-bfc9-53e86f55f3a4",
           "security": [
             "basic_sc"
           ]
         },
         {
           "contentType": "application/json",
-          "href": "https://tiktok.mmccool.org:8091/api/oic/a/led2mosfet?di=3ee85e44-7a56-4f0e-a8b8-b250c868e513",
+          "href": "https://tiktok.mmccool.org:8091/api/oic/a/led0mosfet?di=ea16d184-95ad-4af7-bfc9-53e86f55f3a4",
           "security": [
             "basic_sc"
           ]
         },
         {
           "contentType": "application/json",
-          "href": "https://portal.mmccool.net:8090/api/oic/a/led2mosfet?di=3ee85e44-7a56-4f0e-a8b8-b250c868e513",
+          "href": "https://portal.mmccool.net:8090/api/oic/a/led0mosfet?di=ea16d184-95ad-4af7-bfc9-53e86f55f3a4",
           "security": [
             "digest_sc"
           ]
         },
         {
           "contentType": "application/json",
-          "href": "https://tiktok.mmccool.org:8091/api/oic/a/led2mosfet?di=3ee85e44-7a56-4f0e-a8b8-b250c868e513",
+          "href": "https://tiktok.mmccool.org:8091/api/oic/a/led0mosfet?di=ea16d184-95ad-4af7-bfc9-53e86f55f3a4",
           "security": [
             "digest_sc"
           ]
@@ -238,32 +232,32 @@
       "forms": [
         {
           "contentType": "application/json",
-          "href": "http://upsq1c.local:8000/api/oic/a/led2mosfet?di=3ee85e44-7a56-4f0e-a8b8-b250c868e513"
+          "href": "http://upsq1c.local:8000/api/oic/a/led0mosfet?di=ea16d184-95ad-4af7-bfc9-53e86f55f3a4"
         },
         {
           "contentType": "application/json",
-          "href": "https://portal.mmccool.net:8090/api/oic/a/led2mosfet?di=3ee85e44-7a56-4f0e-a8b8-b250c868e513",
+          "href": "https://portal.mmccool.net:8090/api/oic/a/led0mosfet?di=ea16d184-95ad-4af7-bfc9-53e86f55f3a4",
           "security": [
             "basic_sc"
           ]
         },
         {
           "contentType": "application/json",
-          "href": "https://tiktok.mmccool.org:8091/api/oic/a/led2mosfet?di=3ee85e44-7a56-4f0e-a8b8-b250c868e513",
+          "href": "https://tiktok.mmccool.org:8091/api/oic/a/led0mosfet?di=ea16d184-95ad-4af7-bfc9-53e86f55f3a4",
           "security": [
             "basic_sc"
           ]
         },
         {
           "contentType": "application/json",
-          "href": "https://portal.mmccool.net:8090/api/oic/a/led2mosfet?di=3ee85e44-7a56-4f0e-a8b8-b250c868e513",
+          "href": "https://portal.mmccool.net:8090/api/oic/a/led0mosfet?di=ea16d184-95ad-4af7-bfc9-53e86f55f3a4",
           "security": [
             "digest_sc"
           ]
         },
         {
           "contentType": "application/json",
-          "href": "https://tiktok.mmccool.org:8091/api/oic/a/led2mosfet?di=3ee85e44-7a56-4f0e-a8b8-b250c868e513",
+          "href": "https://tiktok.mmccool.org:8091/api/oic/a/led0mosfet?di=ea16d184-95ad-4af7-bfc9-53e86f55f3a4",
           "security": [
             "digest_sc"
           ]

--- a/workshop/ws2/demos-2019-Munich/TDs/Intel/intel-ocf/Intel-OCF-led0red.jsonld
+++ b/workshop/ws2/demos-2019-Munich/TDs/Intel/intel-ocf/Intel-OCF-led0red.jsonld
@@ -1,9 +1,8 @@
 {
   "@context": [
-    "http://www.w3.org/ns/td",
+    "https://www.w3.org/2019/wot/td/v1",
     {
-      "iot": "http://iotschema.org/",
-      "http": "http://www.w3.org/2011/http#"
+      "iot": "http://iotschema.org/"
     }
   ],
   "@type": [
@@ -13,7 +12,7 @@
     "iot:Actuator",
     "iot:BinarySwitch"
   ],
-  "id": "urn:uuid:5081db06-f405-4ecf-bcdd-2424bf5af1ca",
+  "id": "urn:uuid:c331fb1b-8568-48be-9033-4aaaa95bf2cf",
   "securityDefinitions": {
     "nosec_sc": {
       "scheme": "nosec"
@@ -28,13 +27,13 @@
   "security": [
     "nosec_sc"
   ],
-  "name": "Intel-OCF-5081db06-f405-4ecf-bcdd-2424bf5af1ca",
+  "title": "Intel-OCF-led0red",
   "support": "mailto:michael.mccool@intel.com",
   "version": {
     "instance": "0.1.0"
   },
-  "created": "2018-09-10T06:30+00:00",
-  "lastModified": "2018-12-19T04:06:02.096Z",
+  "created": "2018-09-10T06:30:00Z",
+  "modified": "2019-05-28T05:43:02.347Z",
   "links": [
     {
       "href": "https://github.com/mmccool/ocf-wot-metadata-bridge",
@@ -68,87 +67,82 @@
       "forms": [
         {
           "contentType": "application/json",
-          "href": "http://upsq1c.local:8000/api/oic/a/led1relay?di=5081db06-f405-4ecf-bcdd-2424bf5af1ca",
-          "op": "readproperty",
-          "http:methodName": "GET"
+          "href": "http://upsq1c.local:8000/api/oic/a/led0red?di=c331fb1b-8568-48be-9033-4aaaa95bf2cf",
+          "op": "readproperty"
         },
         {
           "contentType": "application/json",
-          "href": "http://upsq1c.local:8000/api/oic/a/led1relay?di=5081db06-f405-4ecf-bcdd-2424bf5af1ca",
+          "href": "http://upsq1c.local:8000/api/oic/a/led0red?di=c331fb1b-8568-48be-9033-4aaaa95bf2cf",
           "op": "writeproperty",
-          "http:methodName": "POST"
+          "htv:methodName": "POST"
         },
         {
           "contentType": "application/json",
-          "href": "https://portal.mmccool.net:8090/api/oic/a/led1relay?di=5081db06-f405-4ecf-bcdd-2424bf5af1ca",
+          "href": "https://portal.mmccool.net:8090/api/oic/a/led0red?di=c331fb1b-8568-48be-9033-4aaaa95bf2cf",
           "security": [
             "basic_sc"
           ],
-          "op": "readproperty",
-          "http:methodName": "GET"
+          "op": "readproperty"
         },
         {
           "contentType": "application/json",
-          "href": "https://portal.mmccool.net:8090/api/oic/a/led1relay?di=5081db06-f405-4ecf-bcdd-2424bf5af1ca",
-          "security": [
-            "basic_sc"
-          ],
-          "op": "writeproperty",
-          "http:methodName": "POST"
-        },
-        {
-          "contentType": "application/json",
-          "href": "https://tiktok.mmccool.org:8091/api/oic/a/led1relay?di=5081db06-f405-4ecf-bcdd-2424bf5af1ca",
-          "security": [
-            "basic_sc"
-          ],
-          "op": "readproperty",
-          "http:methodName": "GET"
-        },
-        {
-          "contentType": "application/json",
-          "href": "https://tiktok.mmccool.org:8091/api/oic/a/led1relay?di=5081db06-f405-4ecf-bcdd-2424bf5af1ca",
+          "href": "https://portal.mmccool.net:8090/api/oic/a/led0red?di=c331fb1b-8568-48be-9033-4aaaa95bf2cf",
           "security": [
             "basic_sc"
           ],
           "op": "writeproperty",
-          "http:methodName": "POST"
+          "htv:methodName": "POST"
         },
         {
           "contentType": "application/json",
-          "href": "https://portal.mmccool.net:8090/api/oic/a/led1relay?di=5081db06-f405-4ecf-bcdd-2424bf5af1ca",
+          "href": "https://tiktok.mmccool.org:8091/api/oic/a/led0red?di=c331fb1b-8568-48be-9033-4aaaa95bf2cf",
+          "security": [
+            "basic_sc"
+          ],
+          "op": "readproperty"
+        },
+        {
+          "contentType": "application/json",
+          "href": "https://tiktok.mmccool.org:8091/api/oic/a/led0red?di=c331fb1b-8568-48be-9033-4aaaa95bf2cf",
+          "security": [
+            "basic_sc"
+          ],
+          "op": "writeproperty",
+          "htv:methodName": "POST"
+        },
+        {
+          "contentType": "application/json",
+          "href": "https://portal.mmccool.net:8090/api/oic/a/led0red?di=c331fb1b-8568-48be-9033-4aaaa95bf2cf",
           "security": [
             "digest_sc"
           ],
-          "op": "readproperty",
-          "http:methodName": "GET"
+          "op": "readproperty"
         },
         {
           "contentType": "application/json",
-          "href": "https://portal.mmccool.net:8090/api/oic/a/led1relay?di=5081db06-f405-4ecf-bcdd-2424bf5af1ca",
+          "href": "https://portal.mmccool.net:8090/api/oic/a/led0red?di=c331fb1b-8568-48be-9033-4aaaa95bf2cf",
           "security": [
             "digest_sc"
           ],
           "op": "writeproperty",
-          "http:methodName": "POST"
+          "htv:methodName": "POST"
         },
         {
           "contentType": "application/json",
-          "href": "https://tiktok.mmccool.org:8091/api/oic/a/led1relay?di=5081db06-f405-4ecf-bcdd-2424bf5af1ca",
+          "href": "https://tiktok.mmccool.org:8091/api/oic/a/led0red?di=c331fb1b-8568-48be-9033-4aaaa95bf2cf",
           "security": [
             "digest_sc"
           ],
-          "op": "readproperty",
-          "http:methodName": "GET"
+          "op": "readproperty"
         },
         {
           "contentType": "application/json",
-          "href": "https://tiktok.mmccool.org:8091/api/oic/a/led1relay?di=5081db06-f405-4ecf-bcdd-2424bf5af1ca",
+          "href": "https://tiktok.mmccool.org:8091/api/oic/a/led0red?di=c331fb1b-8568-48be-9033-4aaaa95bf2cf",
           "security": [
             "digest_sc"
           ],
           "op": "writeproperty",
-          "http:methodName": "POST"
+          "htv:methodName": "POST"
         }
       ]
     }
@@ -180,32 +174,32 @@
       "forms": [
         {
           "contentType": "application/json",
-          "href": "http://upsq1c.local:8000/api/oic/a/led1relay?di=5081db06-f405-4ecf-bcdd-2424bf5af1ca"
+          "href": "http://upsq1c.local:8000/api/oic/a/led0red?di=c331fb1b-8568-48be-9033-4aaaa95bf2cf"
         },
         {
           "contentType": "application/json",
-          "href": "https://portal.mmccool.net:8090/api/oic/a/led1relay?di=5081db06-f405-4ecf-bcdd-2424bf5af1ca",
+          "href": "https://portal.mmccool.net:8090/api/oic/a/led0red?di=c331fb1b-8568-48be-9033-4aaaa95bf2cf",
           "security": [
             "basic_sc"
           ]
         },
         {
           "contentType": "application/json",
-          "href": "https://tiktok.mmccool.org:8091/api/oic/a/led1relay?di=5081db06-f405-4ecf-bcdd-2424bf5af1ca",
+          "href": "https://tiktok.mmccool.org:8091/api/oic/a/led0red?di=c331fb1b-8568-48be-9033-4aaaa95bf2cf",
           "security": [
             "basic_sc"
           ]
         },
         {
           "contentType": "application/json",
-          "href": "https://portal.mmccool.net:8090/api/oic/a/led1relay?di=5081db06-f405-4ecf-bcdd-2424bf5af1ca",
+          "href": "https://portal.mmccool.net:8090/api/oic/a/led0red?di=c331fb1b-8568-48be-9033-4aaaa95bf2cf",
           "security": [
             "digest_sc"
           ]
         },
         {
           "contentType": "application/json",
-          "href": "https://tiktok.mmccool.org:8091/api/oic/a/led1relay?di=5081db06-f405-4ecf-bcdd-2424bf5af1ca",
+          "href": "https://tiktok.mmccool.org:8091/api/oic/a/led0red?di=c331fb1b-8568-48be-9033-4aaaa95bf2cf",
           "security": [
             "digest_sc"
           ]
@@ -238,32 +232,32 @@
       "forms": [
         {
           "contentType": "application/json",
-          "href": "http://upsq1c.local:8000/api/oic/a/led1relay?di=5081db06-f405-4ecf-bcdd-2424bf5af1ca"
+          "href": "http://upsq1c.local:8000/api/oic/a/led0red?di=c331fb1b-8568-48be-9033-4aaaa95bf2cf"
         },
         {
           "contentType": "application/json",
-          "href": "https://portal.mmccool.net:8090/api/oic/a/led1relay?di=5081db06-f405-4ecf-bcdd-2424bf5af1ca",
+          "href": "https://portal.mmccool.net:8090/api/oic/a/led0red?di=c331fb1b-8568-48be-9033-4aaaa95bf2cf",
           "security": [
             "basic_sc"
           ]
         },
         {
           "contentType": "application/json",
-          "href": "https://tiktok.mmccool.org:8091/api/oic/a/led1relay?di=5081db06-f405-4ecf-bcdd-2424bf5af1ca",
+          "href": "https://tiktok.mmccool.org:8091/api/oic/a/led0red?di=c331fb1b-8568-48be-9033-4aaaa95bf2cf",
           "security": [
             "basic_sc"
           ]
         },
         {
           "contentType": "application/json",
-          "href": "https://portal.mmccool.net:8090/api/oic/a/led1relay?di=5081db06-f405-4ecf-bcdd-2424bf5af1ca",
+          "href": "https://portal.mmccool.net:8090/api/oic/a/led0red?di=c331fb1b-8568-48be-9033-4aaaa95bf2cf",
           "security": [
             "digest_sc"
           ]
         },
         {
           "contentType": "application/json",
-          "href": "https://tiktok.mmccool.org:8091/api/oic/a/led1relay?di=5081db06-f405-4ecf-bcdd-2424bf5af1ca",
+          "href": "https://tiktok.mmccool.org:8091/api/oic/a/led0red?di=c331fb1b-8568-48be-9033-4aaaa95bf2cf",
           "security": [
             "digest_sc"
           ]

--- a/workshop/ws2/demos-2019-Munich/TDs/Intel/intel-ocf/Intel-OCF-led1mosfet.jsonld
+++ b/workshop/ws2/demos-2019-Munich/TDs/Intel/intel-ocf/Intel-OCF-led1mosfet.jsonld
@@ -1,9 +1,8 @@
 {
   "@context": [
-    "http://www.w3.org/ns/td",
+    "https://www.w3.org/2019/wot/td/v1",
     {
-      "iot": "http://iotschema.org/",
-      "http": "http://www.w3.org/2011/http#"
+      "iot": "http://iotschema.org/"
     }
   ],
   "@type": [
@@ -13,7 +12,7 @@
     "iot:Actuator",
     "iot:BinarySwitch"
   ],
-  "id": "urn:uuid:397a9167-88bc-4b52-844a-dade5b772c30",
+  "id": "urn:uuid:336db92b-45f6-496b-997c-e196ba7b49fd",
   "securityDefinitions": {
     "nosec_sc": {
       "scheme": "nosec"
@@ -28,13 +27,13 @@
   "security": [
     "nosec_sc"
   ],
-  "name": "Intel-OCF-397a9167-88bc-4b52-844a-dade5b772c30",
+  "title": "Intel-OCF-led1mosfet",
   "support": "mailto:michael.mccool@intel.com",
   "version": {
     "instance": "0.1.0"
   },
-  "created": "2018-09-10T06:30+00:00",
-  "lastModified": "2018-12-19T04:06:02.096Z",
+  "created": "2018-09-10T06:30:00Z",
+  "modified": "2019-05-28T05:43:02.356Z",
   "links": [
     {
       "href": "https://github.com/mmccool/ocf-wot-metadata-bridge",
@@ -68,87 +67,82 @@
       "forms": [
         {
           "contentType": "application/json",
-          "href": "http://upsq1c.local:8000/api/oic/a/led0blue?di=397a9167-88bc-4b52-844a-dade5b772c30",
-          "op": "readproperty",
-          "http:methodName": "GET"
+          "href": "http://upsq1c.local:8000/api/oic/a/led1mosfet?di=336db92b-45f6-496b-997c-e196ba7b49fd",
+          "op": "readproperty"
         },
         {
           "contentType": "application/json",
-          "href": "http://upsq1c.local:8000/api/oic/a/led0blue?di=397a9167-88bc-4b52-844a-dade5b772c30",
+          "href": "http://upsq1c.local:8000/api/oic/a/led1mosfet?di=336db92b-45f6-496b-997c-e196ba7b49fd",
           "op": "writeproperty",
-          "http:methodName": "POST"
+          "htv:methodName": "POST"
         },
         {
           "contentType": "application/json",
-          "href": "https://portal.mmccool.net:8090/api/oic/a/led0blue?di=397a9167-88bc-4b52-844a-dade5b772c30",
+          "href": "https://portal.mmccool.net:8090/api/oic/a/led1mosfet?di=336db92b-45f6-496b-997c-e196ba7b49fd",
           "security": [
             "basic_sc"
           ],
-          "op": "readproperty",
-          "http:methodName": "GET"
+          "op": "readproperty"
         },
         {
           "contentType": "application/json",
-          "href": "https://portal.mmccool.net:8090/api/oic/a/led0blue?di=397a9167-88bc-4b52-844a-dade5b772c30",
-          "security": [
-            "basic_sc"
-          ],
-          "op": "writeproperty",
-          "http:methodName": "POST"
-        },
-        {
-          "contentType": "application/json",
-          "href": "https://tiktok.mmccool.org:8091/api/oic/a/led0blue?di=397a9167-88bc-4b52-844a-dade5b772c30",
-          "security": [
-            "basic_sc"
-          ],
-          "op": "readproperty",
-          "http:methodName": "GET"
-        },
-        {
-          "contentType": "application/json",
-          "href": "https://tiktok.mmccool.org:8091/api/oic/a/led0blue?di=397a9167-88bc-4b52-844a-dade5b772c30",
+          "href": "https://portal.mmccool.net:8090/api/oic/a/led1mosfet?di=336db92b-45f6-496b-997c-e196ba7b49fd",
           "security": [
             "basic_sc"
           ],
           "op": "writeproperty",
-          "http:methodName": "POST"
+          "htv:methodName": "POST"
         },
         {
           "contentType": "application/json",
-          "href": "https://portal.mmccool.net:8090/api/oic/a/led0blue?di=397a9167-88bc-4b52-844a-dade5b772c30",
+          "href": "https://tiktok.mmccool.org:8091/api/oic/a/led1mosfet?di=336db92b-45f6-496b-997c-e196ba7b49fd",
+          "security": [
+            "basic_sc"
+          ],
+          "op": "readproperty"
+        },
+        {
+          "contentType": "application/json",
+          "href": "https://tiktok.mmccool.org:8091/api/oic/a/led1mosfet?di=336db92b-45f6-496b-997c-e196ba7b49fd",
+          "security": [
+            "basic_sc"
+          ],
+          "op": "writeproperty",
+          "htv:methodName": "POST"
+        },
+        {
+          "contentType": "application/json",
+          "href": "https://portal.mmccool.net:8090/api/oic/a/led1mosfet?di=336db92b-45f6-496b-997c-e196ba7b49fd",
           "security": [
             "digest_sc"
           ],
-          "op": "readproperty",
-          "http:methodName": "GET"
+          "op": "readproperty"
         },
         {
           "contentType": "application/json",
-          "href": "https://portal.mmccool.net:8090/api/oic/a/led0blue?di=397a9167-88bc-4b52-844a-dade5b772c30",
+          "href": "https://portal.mmccool.net:8090/api/oic/a/led1mosfet?di=336db92b-45f6-496b-997c-e196ba7b49fd",
           "security": [
             "digest_sc"
           ],
           "op": "writeproperty",
-          "http:methodName": "POST"
+          "htv:methodName": "POST"
         },
         {
           "contentType": "application/json",
-          "href": "https://tiktok.mmccool.org:8091/api/oic/a/led0blue?di=397a9167-88bc-4b52-844a-dade5b772c30",
+          "href": "https://tiktok.mmccool.org:8091/api/oic/a/led1mosfet?di=336db92b-45f6-496b-997c-e196ba7b49fd",
           "security": [
             "digest_sc"
           ],
-          "op": "readproperty",
-          "http:methodName": "GET"
+          "op": "readproperty"
         },
         {
           "contentType": "application/json",
-          "href": "https://tiktok.mmccool.org:8091/api/oic/a/led0blue?di=397a9167-88bc-4b52-844a-dade5b772c30",
+          "href": "https://tiktok.mmccool.org:8091/api/oic/a/led1mosfet?di=336db92b-45f6-496b-997c-e196ba7b49fd",
           "security": [
             "digest_sc"
           ],
           "op": "writeproperty",
-          "http:methodName": "POST"
+          "htv:methodName": "POST"
         }
       ]
     }
@@ -180,32 +174,32 @@
       "forms": [
         {
           "contentType": "application/json",
-          "href": "http://upsq1c.local:8000/api/oic/a/led0blue?di=397a9167-88bc-4b52-844a-dade5b772c30"
+          "href": "http://upsq1c.local:8000/api/oic/a/led1mosfet?di=336db92b-45f6-496b-997c-e196ba7b49fd"
         },
         {
           "contentType": "application/json",
-          "href": "https://portal.mmccool.net:8090/api/oic/a/led0blue?di=397a9167-88bc-4b52-844a-dade5b772c30",
+          "href": "https://portal.mmccool.net:8090/api/oic/a/led1mosfet?di=336db92b-45f6-496b-997c-e196ba7b49fd",
           "security": [
             "basic_sc"
           ]
         },
         {
           "contentType": "application/json",
-          "href": "https://tiktok.mmccool.org:8091/api/oic/a/led0blue?di=397a9167-88bc-4b52-844a-dade5b772c30",
+          "href": "https://tiktok.mmccool.org:8091/api/oic/a/led1mosfet?di=336db92b-45f6-496b-997c-e196ba7b49fd",
           "security": [
             "basic_sc"
           ]
         },
         {
           "contentType": "application/json",
-          "href": "https://portal.mmccool.net:8090/api/oic/a/led0blue?di=397a9167-88bc-4b52-844a-dade5b772c30",
+          "href": "https://portal.mmccool.net:8090/api/oic/a/led1mosfet?di=336db92b-45f6-496b-997c-e196ba7b49fd",
           "security": [
             "digest_sc"
           ]
         },
         {
           "contentType": "application/json",
-          "href": "https://tiktok.mmccool.org:8091/api/oic/a/led0blue?di=397a9167-88bc-4b52-844a-dade5b772c30",
+          "href": "https://tiktok.mmccool.org:8091/api/oic/a/led1mosfet?di=336db92b-45f6-496b-997c-e196ba7b49fd",
           "security": [
             "digest_sc"
           ]
@@ -238,32 +232,32 @@
       "forms": [
         {
           "contentType": "application/json",
-          "href": "http://upsq1c.local:8000/api/oic/a/led0blue?di=397a9167-88bc-4b52-844a-dade5b772c30"
+          "href": "http://upsq1c.local:8000/api/oic/a/led1mosfet?di=336db92b-45f6-496b-997c-e196ba7b49fd"
         },
         {
           "contentType": "application/json",
-          "href": "https://portal.mmccool.net:8090/api/oic/a/led0blue?di=397a9167-88bc-4b52-844a-dade5b772c30",
+          "href": "https://portal.mmccool.net:8090/api/oic/a/led1mosfet?di=336db92b-45f6-496b-997c-e196ba7b49fd",
           "security": [
             "basic_sc"
           ]
         },
         {
           "contentType": "application/json",
-          "href": "https://tiktok.mmccool.org:8091/api/oic/a/led0blue?di=397a9167-88bc-4b52-844a-dade5b772c30",
+          "href": "https://tiktok.mmccool.org:8091/api/oic/a/led1mosfet?di=336db92b-45f6-496b-997c-e196ba7b49fd",
           "security": [
             "basic_sc"
           ]
         },
         {
           "contentType": "application/json",
-          "href": "https://portal.mmccool.net:8090/api/oic/a/led0blue?di=397a9167-88bc-4b52-844a-dade5b772c30",
+          "href": "https://portal.mmccool.net:8090/api/oic/a/led1mosfet?di=336db92b-45f6-496b-997c-e196ba7b49fd",
           "security": [
             "digest_sc"
           ]
         },
         {
           "contentType": "application/json",
-          "href": "https://tiktok.mmccool.org:8091/api/oic/a/led0blue?di=397a9167-88bc-4b52-844a-dade5b772c30",
+          "href": "https://tiktok.mmccool.org:8091/api/oic/a/led1mosfet?di=336db92b-45f6-496b-997c-e196ba7b49fd",
           "security": [
             "digest_sc"
           ]

--- a/workshop/ws2/demos-2019-Munich/TDs/Intel/intel-ocf/Intel-OCF-led1red.jsonld
+++ b/workshop/ws2/demos-2019-Munich/TDs/Intel/intel-ocf/Intel-OCF-led1red.jsonld
@@ -1,9 +1,8 @@
 {
   "@context": [
-    "http://www.w3.org/ns/td",
+    "https://www.w3.org/2019/wot/td/v1",
     {
-      "iot": "http://iotschema.org/",
-      "http": "http://www.w3.org/2011/http#"
+      "iot": "http://iotschema.org/"
     }
   ],
   "@type": [
@@ -13,7 +12,7 @@
     "iot:Actuator",
     "iot:BinarySwitch"
   ],
-  "id": "urn:uuid:ea16d184-95ad-4af7-bfc9-53e86f55f3a4",
+  "id": "urn:uuid:8c2c6907-ed4a-4527-8f23-57df6999b8aa",
   "securityDefinitions": {
     "nosec_sc": {
       "scheme": "nosec"
@@ -28,13 +27,13 @@
   "security": [
     "nosec_sc"
   ],
-  "name": "Intel-OCF-ea16d184-95ad-4af7-bfc9-53e86f55f3a4",
+  "title": "Intel-OCF-led1red",
   "support": "mailto:michael.mccool@intel.com",
   "version": {
     "instance": "0.1.0"
   },
-  "created": "2018-09-10T06:30+00:00",
-  "lastModified": "2018-12-19T04:06:02.096Z",
+  "created": "2018-09-10T06:30:00Z",
+  "modified": "2019-05-28T05:43:02.348Z",
   "links": [
     {
       "href": "https://github.com/mmccool/ocf-wot-metadata-bridge",
@@ -68,87 +67,82 @@
       "forms": [
         {
           "contentType": "application/json",
-          "href": "http://upsq1c.local:8000/api/oic/a/led0mosfet?di=ea16d184-95ad-4af7-bfc9-53e86f55f3a4",
-          "op": "readproperty",
-          "http:methodName": "GET"
+          "href": "http://upsq1c.local:8000/api/oic/a/led1red?di=8c2c6907-ed4a-4527-8f23-57df6999b8aa",
+          "op": "readproperty"
         },
         {
           "contentType": "application/json",
-          "href": "http://upsq1c.local:8000/api/oic/a/led0mosfet?di=ea16d184-95ad-4af7-bfc9-53e86f55f3a4",
+          "href": "http://upsq1c.local:8000/api/oic/a/led1red?di=8c2c6907-ed4a-4527-8f23-57df6999b8aa",
           "op": "writeproperty",
-          "http:methodName": "POST"
+          "htv:methodName": "POST"
         },
         {
           "contentType": "application/json",
-          "href": "https://portal.mmccool.net:8090/api/oic/a/led0mosfet?di=ea16d184-95ad-4af7-bfc9-53e86f55f3a4",
+          "href": "https://portal.mmccool.net:8090/api/oic/a/led1red?di=8c2c6907-ed4a-4527-8f23-57df6999b8aa",
           "security": [
             "basic_sc"
           ],
-          "op": "readproperty",
-          "http:methodName": "GET"
+          "op": "readproperty"
         },
         {
           "contentType": "application/json",
-          "href": "https://portal.mmccool.net:8090/api/oic/a/led0mosfet?di=ea16d184-95ad-4af7-bfc9-53e86f55f3a4",
-          "security": [
-            "basic_sc"
-          ],
-          "op": "writeproperty",
-          "http:methodName": "POST"
-        },
-        {
-          "contentType": "application/json",
-          "href": "https://tiktok.mmccool.org:8091/api/oic/a/led0mosfet?di=ea16d184-95ad-4af7-bfc9-53e86f55f3a4",
-          "security": [
-            "basic_sc"
-          ],
-          "op": "readproperty",
-          "http:methodName": "GET"
-        },
-        {
-          "contentType": "application/json",
-          "href": "https://tiktok.mmccool.org:8091/api/oic/a/led0mosfet?di=ea16d184-95ad-4af7-bfc9-53e86f55f3a4",
+          "href": "https://portal.mmccool.net:8090/api/oic/a/led1red?di=8c2c6907-ed4a-4527-8f23-57df6999b8aa",
           "security": [
             "basic_sc"
           ],
           "op": "writeproperty",
-          "http:methodName": "POST"
+          "htv:methodName": "POST"
         },
         {
           "contentType": "application/json",
-          "href": "https://portal.mmccool.net:8090/api/oic/a/led0mosfet?di=ea16d184-95ad-4af7-bfc9-53e86f55f3a4",
+          "href": "https://tiktok.mmccool.org:8091/api/oic/a/led1red?di=8c2c6907-ed4a-4527-8f23-57df6999b8aa",
+          "security": [
+            "basic_sc"
+          ],
+          "op": "readproperty"
+        },
+        {
+          "contentType": "application/json",
+          "href": "https://tiktok.mmccool.org:8091/api/oic/a/led1red?di=8c2c6907-ed4a-4527-8f23-57df6999b8aa",
+          "security": [
+            "basic_sc"
+          ],
+          "op": "writeproperty",
+          "htv:methodName": "POST"
+        },
+        {
+          "contentType": "application/json",
+          "href": "https://portal.mmccool.net:8090/api/oic/a/led1red?di=8c2c6907-ed4a-4527-8f23-57df6999b8aa",
           "security": [
             "digest_sc"
           ],
-          "op": "readproperty",
-          "http:methodName": "GET"
+          "op": "readproperty"
         },
         {
           "contentType": "application/json",
-          "href": "https://portal.mmccool.net:8090/api/oic/a/led0mosfet?di=ea16d184-95ad-4af7-bfc9-53e86f55f3a4",
+          "href": "https://portal.mmccool.net:8090/api/oic/a/led1red?di=8c2c6907-ed4a-4527-8f23-57df6999b8aa",
           "security": [
             "digest_sc"
           ],
           "op": "writeproperty",
-          "http:methodName": "POST"
+          "htv:methodName": "POST"
         },
         {
           "contentType": "application/json",
-          "href": "https://tiktok.mmccool.org:8091/api/oic/a/led0mosfet?di=ea16d184-95ad-4af7-bfc9-53e86f55f3a4",
+          "href": "https://tiktok.mmccool.org:8091/api/oic/a/led1red?di=8c2c6907-ed4a-4527-8f23-57df6999b8aa",
           "security": [
             "digest_sc"
           ],
-          "op": "readproperty",
-          "http:methodName": "GET"
+          "op": "readproperty"
         },
         {
           "contentType": "application/json",
-          "href": "https://tiktok.mmccool.org:8091/api/oic/a/led0mosfet?di=ea16d184-95ad-4af7-bfc9-53e86f55f3a4",
+          "href": "https://tiktok.mmccool.org:8091/api/oic/a/led1red?di=8c2c6907-ed4a-4527-8f23-57df6999b8aa",
           "security": [
             "digest_sc"
           ],
           "op": "writeproperty",
-          "http:methodName": "POST"
+          "htv:methodName": "POST"
         }
       ]
     }
@@ -180,32 +174,32 @@
       "forms": [
         {
           "contentType": "application/json",
-          "href": "http://upsq1c.local:8000/api/oic/a/led0mosfet?di=ea16d184-95ad-4af7-bfc9-53e86f55f3a4"
+          "href": "http://upsq1c.local:8000/api/oic/a/led1red?di=8c2c6907-ed4a-4527-8f23-57df6999b8aa"
         },
         {
           "contentType": "application/json",
-          "href": "https://portal.mmccool.net:8090/api/oic/a/led0mosfet?di=ea16d184-95ad-4af7-bfc9-53e86f55f3a4",
+          "href": "https://portal.mmccool.net:8090/api/oic/a/led1red?di=8c2c6907-ed4a-4527-8f23-57df6999b8aa",
           "security": [
             "basic_sc"
           ]
         },
         {
           "contentType": "application/json",
-          "href": "https://tiktok.mmccool.org:8091/api/oic/a/led0mosfet?di=ea16d184-95ad-4af7-bfc9-53e86f55f3a4",
+          "href": "https://tiktok.mmccool.org:8091/api/oic/a/led1red?di=8c2c6907-ed4a-4527-8f23-57df6999b8aa",
           "security": [
             "basic_sc"
           ]
         },
         {
           "contentType": "application/json",
-          "href": "https://portal.mmccool.net:8090/api/oic/a/led0mosfet?di=ea16d184-95ad-4af7-bfc9-53e86f55f3a4",
+          "href": "https://portal.mmccool.net:8090/api/oic/a/led1red?di=8c2c6907-ed4a-4527-8f23-57df6999b8aa",
           "security": [
             "digest_sc"
           ]
         },
         {
           "contentType": "application/json",
-          "href": "https://tiktok.mmccool.org:8091/api/oic/a/led0mosfet?di=ea16d184-95ad-4af7-bfc9-53e86f55f3a4",
+          "href": "https://tiktok.mmccool.org:8091/api/oic/a/led1red?di=8c2c6907-ed4a-4527-8f23-57df6999b8aa",
           "security": [
             "digest_sc"
           ]
@@ -238,32 +232,32 @@
       "forms": [
         {
           "contentType": "application/json",
-          "href": "http://upsq1c.local:8000/api/oic/a/led0mosfet?di=ea16d184-95ad-4af7-bfc9-53e86f55f3a4"
+          "href": "http://upsq1c.local:8000/api/oic/a/led1red?di=8c2c6907-ed4a-4527-8f23-57df6999b8aa"
         },
         {
           "contentType": "application/json",
-          "href": "https://portal.mmccool.net:8090/api/oic/a/led0mosfet?di=ea16d184-95ad-4af7-bfc9-53e86f55f3a4",
+          "href": "https://portal.mmccool.net:8090/api/oic/a/led1red?di=8c2c6907-ed4a-4527-8f23-57df6999b8aa",
           "security": [
             "basic_sc"
           ]
         },
         {
           "contentType": "application/json",
-          "href": "https://tiktok.mmccool.org:8091/api/oic/a/led0mosfet?di=ea16d184-95ad-4af7-bfc9-53e86f55f3a4",
+          "href": "https://tiktok.mmccool.org:8091/api/oic/a/led1red?di=8c2c6907-ed4a-4527-8f23-57df6999b8aa",
           "security": [
             "basic_sc"
           ]
         },
         {
           "contentType": "application/json",
-          "href": "https://portal.mmccool.net:8090/api/oic/a/led0mosfet?di=ea16d184-95ad-4af7-bfc9-53e86f55f3a4",
+          "href": "https://portal.mmccool.net:8090/api/oic/a/led1red?di=8c2c6907-ed4a-4527-8f23-57df6999b8aa",
           "security": [
             "digest_sc"
           ]
         },
         {
           "contentType": "application/json",
-          "href": "https://tiktok.mmccool.org:8091/api/oic/a/led0mosfet?di=ea16d184-95ad-4af7-bfc9-53e86f55f3a4",
+          "href": "https://tiktok.mmccool.org:8091/api/oic/a/led1red?di=8c2c6907-ed4a-4527-8f23-57df6999b8aa",
           "security": [
             "digest_sc"
           ]

--- a/workshop/ws2/demos-2019-Munich/TDs/Intel/intel-ocf/Intel-OCF-led1relay.jsonld
+++ b/workshop/ws2/demos-2019-Munich/TDs/Intel/intel-ocf/Intel-OCF-led1relay.jsonld
@@ -1,9 +1,8 @@
 {
   "@context": [
-    "http://www.w3.org/ns/td",
+    "https://www.w3.org/2019/wot/td/v1",
     {
-      "iot": "http://iotschema.org/",
-      "http": "http://www.w3.org/2011/http#"
+      "iot": "http://iotschema.org/"
     }
   ],
   "@type": [
@@ -13,7 +12,7 @@
     "iot:Actuator",
     "iot:BinarySwitch"
   ],
-  "id": "urn:uuid:8c2c6907-ed4a-4527-8f23-57df6999b8aa",
+  "id": "urn:uuid:5081db06-f405-4ecf-bcdd-2424bf5af1ca",
   "securityDefinitions": {
     "nosec_sc": {
       "scheme": "nosec"
@@ -28,13 +27,13 @@
   "security": [
     "nosec_sc"
   ],
-  "name": "Intel-OCF-8c2c6907-ed4a-4527-8f23-57df6999b8aa",
+  "title": "Intel-OCF-led1relay",
   "support": "mailto:michael.mccool@intel.com",
   "version": {
     "instance": "0.1.0"
   },
-  "created": "2018-09-10T06:30+00:00",
-  "lastModified": "2018-12-19T04:06:02.096Z",
+  "created": "2018-09-10T06:30:00Z",
+  "modified": "2019-05-28T05:43:02.357Z",
   "links": [
     {
       "href": "https://github.com/mmccool/ocf-wot-metadata-bridge",
@@ -68,87 +67,82 @@
       "forms": [
         {
           "contentType": "application/json",
-          "href": "http://upsq1c.local:8000/api/oic/a/led1red?di=8c2c6907-ed4a-4527-8f23-57df6999b8aa",
-          "op": "readproperty",
-          "http:methodName": "GET"
+          "href": "http://upsq1c.local:8000/api/oic/a/led1relay?di=5081db06-f405-4ecf-bcdd-2424bf5af1ca",
+          "op": "readproperty"
         },
         {
           "contentType": "application/json",
-          "href": "http://upsq1c.local:8000/api/oic/a/led1red?di=8c2c6907-ed4a-4527-8f23-57df6999b8aa",
+          "href": "http://upsq1c.local:8000/api/oic/a/led1relay?di=5081db06-f405-4ecf-bcdd-2424bf5af1ca",
           "op": "writeproperty",
-          "http:methodName": "POST"
+          "htv:methodName": "POST"
         },
         {
           "contentType": "application/json",
-          "href": "https://portal.mmccool.net:8090/api/oic/a/led1red?di=8c2c6907-ed4a-4527-8f23-57df6999b8aa",
+          "href": "https://portal.mmccool.net:8090/api/oic/a/led1relay?di=5081db06-f405-4ecf-bcdd-2424bf5af1ca",
           "security": [
             "basic_sc"
           ],
-          "op": "readproperty",
-          "http:methodName": "GET"
+          "op": "readproperty"
         },
         {
           "contentType": "application/json",
-          "href": "https://portal.mmccool.net:8090/api/oic/a/led1red?di=8c2c6907-ed4a-4527-8f23-57df6999b8aa",
-          "security": [
-            "basic_sc"
-          ],
-          "op": "writeproperty",
-          "http:methodName": "POST"
-        },
-        {
-          "contentType": "application/json",
-          "href": "https://tiktok.mmccool.org:8091/api/oic/a/led1red?di=8c2c6907-ed4a-4527-8f23-57df6999b8aa",
-          "security": [
-            "basic_sc"
-          ],
-          "op": "readproperty",
-          "http:methodName": "GET"
-        },
-        {
-          "contentType": "application/json",
-          "href": "https://tiktok.mmccool.org:8091/api/oic/a/led1red?di=8c2c6907-ed4a-4527-8f23-57df6999b8aa",
+          "href": "https://portal.mmccool.net:8090/api/oic/a/led1relay?di=5081db06-f405-4ecf-bcdd-2424bf5af1ca",
           "security": [
             "basic_sc"
           ],
           "op": "writeproperty",
-          "http:methodName": "POST"
+          "htv:methodName": "POST"
         },
         {
           "contentType": "application/json",
-          "href": "https://portal.mmccool.net:8090/api/oic/a/led1red?di=8c2c6907-ed4a-4527-8f23-57df6999b8aa",
+          "href": "https://tiktok.mmccool.org:8091/api/oic/a/led1relay?di=5081db06-f405-4ecf-bcdd-2424bf5af1ca",
+          "security": [
+            "basic_sc"
+          ],
+          "op": "readproperty"
+        },
+        {
+          "contentType": "application/json",
+          "href": "https://tiktok.mmccool.org:8091/api/oic/a/led1relay?di=5081db06-f405-4ecf-bcdd-2424bf5af1ca",
+          "security": [
+            "basic_sc"
+          ],
+          "op": "writeproperty",
+          "htv:methodName": "POST"
+        },
+        {
+          "contentType": "application/json",
+          "href": "https://portal.mmccool.net:8090/api/oic/a/led1relay?di=5081db06-f405-4ecf-bcdd-2424bf5af1ca",
           "security": [
             "digest_sc"
           ],
-          "op": "readproperty",
-          "http:methodName": "GET"
+          "op": "readproperty"
         },
         {
           "contentType": "application/json",
-          "href": "https://portal.mmccool.net:8090/api/oic/a/led1red?di=8c2c6907-ed4a-4527-8f23-57df6999b8aa",
+          "href": "https://portal.mmccool.net:8090/api/oic/a/led1relay?di=5081db06-f405-4ecf-bcdd-2424bf5af1ca",
           "security": [
             "digest_sc"
           ],
           "op": "writeproperty",
-          "http:methodName": "POST"
+          "htv:methodName": "POST"
         },
         {
           "contentType": "application/json",
-          "href": "https://tiktok.mmccool.org:8091/api/oic/a/led1red?di=8c2c6907-ed4a-4527-8f23-57df6999b8aa",
+          "href": "https://tiktok.mmccool.org:8091/api/oic/a/led1relay?di=5081db06-f405-4ecf-bcdd-2424bf5af1ca",
           "security": [
             "digest_sc"
           ],
-          "op": "readproperty",
-          "http:methodName": "GET"
+          "op": "readproperty"
         },
         {
           "contentType": "application/json",
-          "href": "https://tiktok.mmccool.org:8091/api/oic/a/led1red?di=8c2c6907-ed4a-4527-8f23-57df6999b8aa",
+          "href": "https://tiktok.mmccool.org:8091/api/oic/a/led1relay?di=5081db06-f405-4ecf-bcdd-2424bf5af1ca",
           "security": [
             "digest_sc"
           ],
           "op": "writeproperty",
-          "http:methodName": "POST"
+          "htv:methodName": "POST"
         }
       ]
     }
@@ -180,32 +174,32 @@
       "forms": [
         {
           "contentType": "application/json",
-          "href": "http://upsq1c.local:8000/api/oic/a/led1red?di=8c2c6907-ed4a-4527-8f23-57df6999b8aa"
+          "href": "http://upsq1c.local:8000/api/oic/a/led1relay?di=5081db06-f405-4ecf-bcdd-2424bf5af1ca"
         },
         {
           "contentType": "application/json",
-          "href": "https://portal.mmccool.net:8090/api/oic/a/led1red?di=8c2c6907-ed4a-4527-8f23-57df6999b8aa",
+          "href": "https://portal.mmccool.net:8090/api/oic/a/led1relay?di=5081db06-f405-4ecf-bcdd-2424bf5af1ca",
           "security": [
             "basic_sc"
           ]
         },
         {
           "contentType": "application/json",
-          "href": "https://tiktok.mmccool.org:8091/api/oic/a/led1red?di=8c2c6907-ed4a-4527-8f23-57df6999b8aa",
+          "href": "https://tiktok.mmccool.org:8091/api/oic/a/led1relay?di=5081db06-f405-4ecf-bcdd-2424bf5af1ca",
           "security": [
             "basic_sc"
           ]
         },
         {
           "contentType": "application/json",
-          "href": "https://portal.mmccool.net:8090/api/oic/a/led1red?di=8c2c6907-ed4a-4527-8f23-57df6999b8aa",
+          "href": "https://portal.mmccool.net:8090/api/oic/a/led1relay?di=5081db06-f405-4ecf-bcdd-2424bf5af1ca",
           "security": [
             "digest_sc"
           ]
         },
         {
           "contentType": "application/json",
-          "href": "https://tiktok.mmccool.org:8091/api/oic/a/led1red?di=8c2c6907-ed4a-4527-8f23-57df6999b8aa",
+          "href": "https://tiktok.mmccool.org:8091/api/oic/a/led1relay?di=5081db06-f405-4ecf-bcdd-2424bf5af1ca",
           "security": [
             "digest_sc"
           ]
@@ -238,32 +232,32 @@
       "forms": [
         {
           "contentType": "application/json",
-          "href": "http://upsq1c.local:8000/api/oic/a/led1red?di=8c2c6907-ed4a-4527-8f23-57df6999b8aa"
+          "href": "http://upsq1c.local:8000/api/oic/a/led1relay?di=5081db06-f405-4ecf-bcdd-2424bf5af1ca"
         },
         {
           "contentType": "application/json",
-          "href": "https://portal.mmccool.net:8090/api/oic/a/led1red?di=8c2c6907-ed4a-4527-8f23-57df6999b8aa",
+          "href": "https://portal.mmccool.net:8090/api/oic/a/led1relay?di=5081db06-f405-4ecf-bcdd-2424bf5af1ca",
           "security": [
             "basic_sc"
           ]
         },
         {
           "contentType": "application/json",
-          "href": "https://tiktok.mmccool.org:8091/api/oic/a/led1red?di=8c2c6907-ed4a-4527-8f23-57df6999b8aa",
+          "href": "https://tiktok.mmccool.org:8091/api/oic/a/led1relay?di=5081db06-f405-4ecf-bcdd-2424bf5af1ca",
           "security": [
             "basic_sc"
           ]
         },
         {
           "contentType": "application/json",
-          "href": "https://portal.mmccool.net:8090/api/oic/a/led1red?di=8c2c6907-ed4a-4527-8f23-57df6999b8aa",
+          "href": "https://portal.mmccool.net:8090/api/oic/a/led1relay?di=5081db06-f405-4ecf-bcdd-2424bf5af1ca",
           "security": [
             "digest_sc"
           ]
         },
         {
           "contentType": "application/json",
-          "href": "https://tiktok.mmccool.org:8091/api/oic/a/led1red?di=8c2c6907-ed4a-4527-8f23-57df6999b8aa",
+          "href": "https://tiktok.mmccool.org:8091/api/oic/a/led1relay?di=5081db06-f405-4ecf-bcdd-2424bf5af1ca",
           "security": [
             "digest_sc"
           ]

--- a/workshop/ws2/demos-2019-Munich/TDs/Intel/intel-ocf/Intel-OCF-led2mosfet.jsonld
+++ b/workshop/ws2/demos-2019-Munich/TDs/Intel/intel-ocf/Intel-OCF-led2mosfet.jsonld
@@ -1,9 +1,8 @@
 {
   "@context": [
-    "http://www.w3.org/ns/td",
+    "https://www.w3.org/2019/wot/td/v1",
     {
-      "iot": "http://iotschema.org/",
-      "http": "http://www.w3.org/2011/http#"
+      "iot": "http://iotschema.org/"
     }
   ],
   "@type": [
@@ -13,7 +12,7 @@
     "iot:Actuator",
     "iot:BinarySwitch"
   ],
-  "id": "urn:uuid:c331fb1b-8568-48be-9033-4aaaa95bf2cf",
+  "id": "urn:uuid:3ee85e44-7a56-4f0e-a8b8-b250c868e513",
   "securityDefinitions": {
     "nosec_sc": {
       "scheme": "nosec"
@@ -28,13 +27,13 @@
   "security": [
     "nosec_sc"
   ],
-  "name": "Intel-OCF-c331fb1b-8568-48be-9033-4aaaa95bf2cf",
+  "title": "Intel-OCF-led2mosfet",
   "support": "mailto:michael.mccool@intel.com",
   "version": {
     "instance": "0.1.0"
   },
-  "created": "2018-09-10T06:30+00:00",
-  "lastModified": "2018-12-19T04:06:02.096Z",
+  "created": "2018-09-10T06:30:00Z",
+  "modified": "2019-05-28T05:43:02.337Z",
   "links": [
     {
       "href": "https://github.com/mmccool/ocf-wot-metadata-bridge",
@@ -68,87 +67,82 @@
       "forms": [
         {
           "contentType": "application/json",
-          "href": "http://upsq1c.local:8000/api/oic/a/led0red?di=c331fb1b-8568-48be-9033-4aaaa95bf2cf",
-          "op": "readproperty",
-          "http:methodName": "GET"
+          "href": "http://upsq1c.local:8000/api/oic/a/led2mosfet?di=3ee85e44-7a56-4f0e-a8b8-b250c868e513",
+          "op": "readproperty"
         },
         {
           "contentType": "application/json",
-          "href": "http://upsq1c.local:8000/api/oic/a/led0red?di=c331fb1b-8568-48be-9033-4aaaa95bf2cf",
+          "href": "http://upsq1c.local:8000/api/oic/a/led2mosfet?di=3ee85e44-7a56-4f0e-a8b8-b250c868e513",
           "op": "writeproperty",
-          "http:methodName": "POST"
+          "htv:methodName": "POST"
         },
         {
           "contentType": "application/json",
-          "href": "https://portal.mmccool.net:8090/api/oic/a/led0red?di=c331fb1b-8568-48be-9033-4aaaa95bf2cf",
+          "href": "https://portal.mmccool.net:8090/api/oic/a/led2mosfet?di=3ee85e44-7a56-4f0e-a8b8-b250c868e513",
           "security": [
             "basic_sc"
           ],
-          "op": "readproperty",
-          "http:methodName": "GET"
+          "op": "readproperty"
         },
         {
           "contentType": "application/json",
-          "href": "https://portal.mmccool.net:8090/api/oic/a/led0red?di=c331fb1b-8568-48be-9033-4aaaa95bf2cf",
-          "security": [
-            "basic_sc"
-          ],
-          "op": "writeproperty",
-          "http:methodName": "POST"
-        },
-        {
-          "contentType": "application/json",
-          "href": "https://tiktok.mmccool.org:8091/api/oic/a/led0red?di=c331fb1b-8568-48be-9033-4aaaa95bf2cf",
-          "security": [
-            "basic_sc"
-          ],
-          "op": "readproperty",
-          "http:methodName": "GET"
-        },
-        {
-          "contentType": "application/json",
-          "href": "https://tiktok.mmccool.org:8091/api/oic/a/led0red?di=c331fb1b-8568-48be-9033-4aaaa95bf2cf",
+          "href": "https://portal.mmccool.net:8090/api/oic/a/led2mosfet?di=3ee85e44-7a56-4f0e-a8b8-b250c868e513",
           "security": [
             "basic_sc"
           ],
           "op": "writeproperty",
-          "http:methodName": "POST"
+          "htv:methodName": "POST"
         },
         {
           "contentType": "application/json",
-          "href": "https://portal.mmccool.net:8090/api/oic/a/led0red?di=c331fb1b-8568-48be-9033-4aaaa95bf2cf",
+          "href": "https://tiktok.mmccool.org:8091/api/oic/a/led2mosfet?di=3ee85e44-7a56-4f0e-a8b8-b250c868e513",
+          "security": [
+            "basic_sc"
+          ],
+          "op": "readproperty"
+        },
+        {
+          "contentType": "application/json",
+          "href": "https://tiktok.mmccool.org:8091/api/oic/a/led2mosfet?di=3ee85e44-7a56-4f0e-a8b8-b250c868e513",
+          "security": [
+            "basic_sc"
+          ],
+          "op": "writeproperty",
+          "htv:methodName": "POST"
+        },
+        {
+          "contentType": "application/json",
+          "href": "https://portal.mmccool.net:8090/api/oic/a/led2mosfet?di=3ee85e44-7a56-4f0e-a8b8-b250c868e513",
           "security": [
             "digest_sc"
           ],
-          "op": "readproperty",
-          "http:methodName": "GET"
+          "op": "readproperty"
         },
         {
           "contentType": "application/json",
-          "href": "https://portal.mmccool.net:8090/api/oic/a/led0red?di=c331fb1b-8568-48be-9033-4aaaa95bf2cf",
+          "href": "https://portal.mmccool.net:8090/api/oic/a/led2mosfet?di=3ee85e44-7a56-4f0e-a8b8-b250c868e513",
           "security": [
             "digest_sc"
           ],
           "op": "writeproperty",
-          "http:methodName": "POST"
+          "htv:methodName": "POST"
         },
         {
           "contentType": "application/json",
-          "href": "https://tiktok.mmccool.org:8091/api/oic/a/led0red?di=c331fb1b-8568-48be-9033-4aaaa95bf2cf",
+          "href": "https://tiktok.mmccool.org:8091/api/oic/a/led2mosfet?di=3ee85e44-7a56-4f0e-a8b8-b250c868e513",
           "security": [
             "digest_sc"
           ],
-          "op": "readproperty",
-          "http:methodName": "GET"
+          "op": "readproperty"
         },
         {
           "contentType": "application/json",
-          "href": "https://tiktok.mmccool.org:8091/api/oic/a/led0red?di=c331fb1b-8568-48be-9033-4aaaa95bf2cf",
+          "href": "https://tiktok.mmccool.org:8091/api/oic/a/led2mosfet?di=3ee85e44-7a56-4f0e-a8b8-b250c868e513",
           "security": [
             "digest_sc"
           ],
           "op": "writeproperty",
-          "http:methodName": "POST"
+          "htv:methodName": "POST"
         }
       ]
     }
@@ -180,32 +174,32 @@
       "forms": [
         {
           "contentType": "application/json",
-          "href": "http://upsq1c.local:8000/api/oic/a/led0red?di=c331fb1b-8568-48be-9033-4aaaa95bf2cf"
+          "href": "http://upsq1c.local:8000/api/oic/a/led2mosfet?di=3ee85e44-7a56-4f0e-a8b8-b250c868e513"
         },
         {
           "contentType": "application/json",
-          "href": "https://portal.mmccool.net:8090/api/oic/a/led0red?di=c331fb1b-8568-48be-9033-4aaaa95bf2cf",
+          "href": "https://portal.mmccool.net:8090/api/oic/a/led2mosfet?di=3ee85e44-7a56-4f0e-a8b8-b250c868e513",
           "security": [
             "basic_sc"
           ]
         },
         {
           "contentType": "application/json",
-          "href": "https://tiktok.mmccool.org:8091/api/oic/a/led0red?di=c331fb1b-8568-48be-9033-4aaaa95bf2cf",
+          "href": "https://tiktok.mmccool.org:8091/api/oic/a/led2mosfet?di=3ee85e44-7a56-4f0e-a8b8-b250c868e513",
           "security": [
             "basic_sc"
           ]
         },
         {
           "contentType": "application/json",
-          "href": "https://portal.mmccool.net:8090/api/oic/a/led0red?di=c331fb1b-8568-48be-9033-4aaaa95bf2cf",
+          "href": "https://portal.mmccool.net:8090/api/oic/a/led2mosfet?di=3ee85e44-7a56-4f0e-a8b8-b250c868e513",
           "security": [
             "digest_sc"
           ]
         },
         {
           "contentType": "application/json",
-          "href": "https://tiktok.mmccool.org:8091/api/oic/a/led0red?di=c331fb1b-8568-48be-9033-4aaaa95bf2cf",
+          "href": "https://tiktok.mmccool.org:8091/api/oic/a/led2mosfet?di=3ee85e44-7a56-4f0e-a8b8-b250c868e513",
           "security": [
             "digest_sc"
           ]
@@ -238,32 +232,32 @@
       "forms": [
         {
           "contentType": "application/json",
-          "href": "http://upsq1c.local:8000/api/oic/a/led0red?di=c331fb1b-8568-48be-9033-4aaaa95bf2cf"
+          "href": "http://upsq1c.local:8000/api/oic/a/led2mosfet?di=3ee85e44-7a56-4f0e-a8b8-b250c868e513"
         },
         {
           "contentType": "application/json",
-          "href": "https://portal.mmccool.net:8090/api/oic/a/led0red?di=c331fb1b-8568-48be-9033-4aaaa95bf2cf",
+          "href": "https://portal.mmccool.net:8090/api/oic/a/led2mosfet?di=3ee85e44-7a56-4f0e-a8b8-b250c868e513",
           "security": [
             "basic_sc"
           ]
         },
         {
           "contentType": "application/json",
-          "href": "https://tiktok.mmccool.org:8091/api/oic/a/led0red?di=c331fb1b-8568-48be-9033-4aaaa95bf2cf",
+          "href": "https://tiktok.mmccool.org:8091/api/oic/a/led2mosfet?di=3ee85e44-7a56-4f0e-a8b8-b250c868e513",
           "security": [
             "basic_sc"
           ]
         },
         {
           "contentType": "application/json",
-          "href": "https://portal.mmccool.net:8090/api/oic/a/led0red?di=c331fb1b-8568-48be-9033-4aaaa95bf2cf",
+          "href": "https://portal.mmccool.net:8090/api/oic/a/led2mosfet?di=3ee85e44-7a56-4f0e-a8b8-b250c868e513",
           "security": [
             "digest_sc"
           ]
         },
         {
           "contentType": "application/json",
-          "href": "https://tiktok.mmccool.org:8091/api/oic/a/led0red?di=c331fb1b-8568-48be-9033-4aaaa95bf2cf",
+          "href": "https://tiktok.mmccool.org:8091/api/oic/a/led2mosfet?di=3ee85e44-7a56-4f0e-a8b8-b250c868e513",
           "security": [
             "digest_sc"
           ]

--- a/workshop/ws2/demos-2019-Munich/TDs/Intel/intel-ocf/Intel-OCF-led2relay.jsonld
+++ b/workshop/ws2/demos-2019-Munich/TDs/Intel/intel-ocf/Intel-OCF-led2relay.jsonld
@@ -1,9 +1,8 @@
 {
   "@context": [
-    "http://www.w3.org/ns/td",
+    "https://www.w3.org/2019/wot/td/v1",
     {
-      "iot": "http://iotschema.org/",
-      "http": "http://www.w3.org/2011/http#"
+      "iot": "http://iotschema.org/"
     }
   ],
   "@type": [
@@ -13,7 +12,7 @@
     "iot:Actuator",
     "iot:BinarySwitch"
   ],
-  "id": "urn:uuid:336db92b-45f6-496b-997c-e196ba7b49fd",
+  "id": "urn:uuid:79683ab5-8df1-4b7a-b110-c1b8fe251e7d",
   "securityDefinitions": {
     "nosec_sc": {
       "scheme": "nosec"
@@ -28,13 +27,13 @@
   "security": [
     "nosec_sc"
   ],
-  "name": "Intel-OCF-336db92b-45f6-496b-997c-e196ba7b49fd",
+  "title": "Intel-OCF-led2relay",
   "support": "mailto:michael.mccool@intel.com",
   "version": {
     "instance": "0.1.0"
   },
-  "created": "2018-09-10T06:30+00:00",
-  "lastModified": "2018-12-19T04:06:02.096Z",
+  "created": "2018-09-10T06:30:00Z",
+  "modified": "2019-05-28T05:43:02.360Z",
   "links": [
     {
       "href": "https://github.com/mmccool/ocf-wot-metadata-bridge",
@@ -68,87 +67,82 @@
       "forms": [
         {
           "contentType": "application/json",
-          "href": "http://upsq1c.local:8000/api/oic/a/led1mosfet?di=336db92b-45f6-496b-997c-e196ba7b49fd",
-          "op": "readproperty",
-          "http:methodName": "GET"
+          "href": "http://upsq1c.local:8000/api/oic/a/led2relay?di=79683ab5-8df1-4b7a-b110-c1b8fe251e7d",
+          "op": "readproperty"
         },
         {
           "contentType": "application/json",
-          "href": "http://upsq1c.local:8000/api/oic/a/led1mosfet?di=336db92b-45f6-496b-997c-e196ba7b49fd",
+          "href": "http://upsq1c.local:8000/api/oic/a/led2relay?di=79683ab5-8df1-4b7a-b110-c1b8fe251e7d",
           "op": "writeproperty",
-          "http:methodName": "POST"
+          "htv:methodName": "POST"
         },
         {
           "contentType": "application/json",
-          "href": "https://portal.mmccool.net:8090/api/oic/a/led1mosfet?di=336db92b-45f6-496b-997c-e196ba7b49fd",
+          "href": "https://portal.mmccool.net:8090/api/oic/a/led2relay?di=79683ab5-8df1-4b7a-b110-c1b8fe251e7d",
           "security": [
             "basic_sc"
           ],
-          "op": "readproperty",
-          "http:methodName": "GET"
+          "op": "readproperty"
         },
         {
           "contentType": "application/json",
-          "href": "https://portal.mmccool.net:8090/api/oic/a/led1mosfet?di=336db92b-45f6-496b-997c-e196ba7b49fd",
-          "security": [
-            "basic_sc"
-          ],
-          "op": "writeproperty",
-          "http:methodName": "POST"
-        },
-        {
-          "contentType": "application/json",
-          "href": "https://tiktok.mmccool.org:8091/api/oic/a/led1mosfet?di=336db92b-45f6-496b-997c-e196ba7b49fd",
-          "security": [
-            "basic_sc"
-          ],
-          "op": "readproperty",
-          "http:methodName": "GET"
-        },
-        {
-          "contentType": "application/json",
-          "href": "https://tiktok.mmccool.org:8091/api/oic/a/led1mosfet?di=336db92b-45f6-496b-997c-e196ba7b49fd",
+          "href": "https://portal.mmccool.net:8090/api/oic/a/led2relay?di=79683ab5-8df1-4b7a-b110-c1b8fe251e7d",
           "security": [
             "basic_sc"
           ],
           "op": "writeproperty",
-          "http:methodName": "POST"
+          "htv:methodName": "POST"
         },
         {
           "contentType": "application/json",
-          "href": "https://portal.mmccool.net:8090/api/oic/a/led1mosfet?di=336db92b-45f6-496b-997c-e196ba7b49fd",
+          "href": "https://tiktok.mmccool.org:8091/api/oic/a/led2relay?di=79683ab5-8df1-4b7a-b110-c1b8fe251e7d",
+          "security": [
+            "basic_sc"
+          ],
+          "op": "readproperty"
+        },
+        {
+          "contentType": "application/json",
+          "href": "https://tiktok.mmccool.org:8091/api/oic/a/led2relay?di=79683ab5-8df1-4b7a-b110-c1b8fe251e7d",
+          "security": [
+            "basic_sc"
+          ],
+          "op": "writeproperty",
+          "htv:methodName": "POST"
+        },
+        {
+          "contentType": "application/json",
+          "href": "https://portal.mmccool.net:8090/api/oic/a/led2relay?di=79683ab5-8df1-4b7a-b110-c1b8fe251e7d",
           "security": [
             "digest_sc"
           ],
-          "op": "readproperty",
-          "http:methodName": "GET"
+          "op": "readproperty"
         },
         {
           "contentType": "application/json",
-          "href": "https://portal.mmccool.net:8090/api/oic/a/led1mosfet?di=336db92b-45f6-496b-997c-e196ba7b49fd",
+          "href": "https://portal.mmccool.net:8090/api/oic/a/led2relay?di=79683ab5-8df1-4b7a-b110-c1b8fe251e7d",
           "security": [
             "digest_sc"
           ],
           "op": "writeproperty",
-          "http:methodName": "POST"
+          "htv:methodName": "POST"
         },
         {
           "contentType": "application/json",
-          "href": "https://tiktok.mmccool.org:8091/api/oic/a/led1mosfet?di=336db92b-45f6-496b-997c-e196ba7b49fd",
+          "href": "https://tiktok.mmccool.org:8091/api/oic/a/led2relay?di=79683ab5-8df1-4b7a-b110-c1b8fe251e7d",
           "security": [
             "digest_sc"
           ],
-          "op": "readproperty",
-          "http:methodName": "GET"
+          "op": "readproperty"
         },
         {
           "contentType": "application/json",
-          "href": "https://tiktok.mmccool.org:8091/api/oic/a/led1mosfet?di=336db92b-45f6-496b-997c-e196ba7b49fd",
+          "href": "https://tiktok.mmccool.org:8091/api/oic/a/led2relay?di=79683ab5-8df1-4b7a-b110-c1b8fe251e7d",
           "security": [
             "digest_sc"
           ],
           "op": "writeproperty",
-          "http:methodName": "POST"
+          "htv:methodName": "POST"
         }
       ]
     }
@@ -180,32 +174,32 @@
       "forms": [
         {
           "contentType": "application/json",
-          "href": "http://upsq1c.local:8000/api/oic/a/led1mosfet?di=336db92b-45f6-496b-997c-e196ba7b49fd"
+          "href": "http://upsq1c.local:8000/api/oic/a/led2relay?di=79683ab5-8df1-4b7a-b110-c1b8fe251e7d"
         },
         {
           "contentType": "application/json",
-          "href": "https://portal.mmccool.net:8090/api/oic/a/led1mosfet?di=336db92b-45f6-496b-997c-e196ba7b49fd",
+          "href": "https://portal.mmccool.net:8090/api/oic/a/led2relay?di=79683ab5-8df1-4b7a-b110-c1b8fe251e7d",
           "security": [
             "basic_sc"
           ]
         },
         {
           "contentType": "application/json",
-          "href": "https://tiktok.mmccool.org:8091/api/oic/a/led1mosfet?di=336db92b-45f6-496b-997c-e196ba7b49fd",
+          "href": "https://tiktok.mmccool.org:8091/api/oic/a/led2relay?di=79683ab5-8df1-4b7a-b110-c1b8fe251e7d",
           "security": [
             "basic_sc"
           ]
         },
         {
           "contentType": "application/json",
-          "href": "https://portal.mmccool.net:8090/api/oic/a/led1mosfet?di=336db92b-45f6-496b-997c-e196ba7b49fd",
+          "href": "https://portal.mmccool.net:8090/api/oic/a/led2relay?di=79683ab5-8df1-4b7a-b110-c1b8fe251e7d",
           "security": [
             "digest_sc"
           ]
         },
         {
           "contentType": "application/json",
-          "href": "https://tiktok.mmccool.org:8091/api/oic/a/led1mosfet?di=336db92b-45f6-496b-997c-e196ba7b49fd",
+          "href": "https://tiktok.mmccool.org:8091/api/oic/a/led2relay?di=79683ab5-8df1-4b7a-b110-c1b8fe251e7d",
           "security": [
             "digest_sc"
           ]
@@ -238,32 +232,32 @@
       "forms": [
         {
           "contentType": "application/json",
-          "href": "http://upsq1c.local:8000/api/oic/a/led1mosfet?di=336db92b-45f6-496b-997c-e196ba7b49fd"
+          "href": "http://upsq1c.local:8000/api/oic/a/led2relay?di=79683ab5-8df1-4b7a-b110-c1b8fe251e7d"
         },
         {
           "contentType": "application/json",
-          "href": "https://portal.mmccool.net:8090/api/oic/a/led1mosfet?di=336db92b-45f6-496b-997c-e196ba7b49fd",
+          "href": "https://portal.mmccool.net:8090/api/oic/a/led2relay?di=79683ab5-8df1-4b7a-b110-c1b8fe251e7d",
           "security": [
             "basic_sc"
           ]
         },
         {
           "contentType": "application/json",
-          "href": "https://tiktok.mmccool.org:8091/api/oic/a/led1mosfet?di=336db92b-45f6-496b-997c-e196ba7b49fd",
+          "href": "https://tiktok.mmccool.org:8091/api/oic/a/led2relay?di=79683ab5-8df1-4b7a-b110-c1b8fe251e7d",
           "security": [
             "basic_sc"
           ]
         },
         {
           "contentType": "application/json",
-          "href": "https://portal.mmccool.net:8090/api/oic/a/led1mosfet?di=336db92b-45f6-496b-997c-e196ba7b49fd",
+          "href": "https://portal.mmccool.net:8090/api/oic/a/led2relay?di=79683ab5-8df1-4b7a-b110-c1b8fe251e7d",
           "security": [
             "digest_sc"
           ]
         },
         {
           "contentType": "application/json",
-          "href": "https://tiktok.mmccool.org:8091/api/oic/a/led1mosfet?di=336db92b-45f6-496b-997c-e196ba7b49fd",
+          "href": "https://tiktok.mmccool.org:8091/api/oic/a/led2relay?di=79683ab5-8df1-4b7a-b110-c1b8fe251e7d",
           "security": [
             "digest_sc"
           ]

--- a/workshop/ws2/demos-2019-Munich/TDs/Intel/intel-ocf/Intel-OCF-led2side.jsonld
+++ b/workshop/ws2/demos-2019-Munich/TDs/Intel/intel-ocf/Intel-OCF-led2side.jsonld
@@ -1,9 +1,8 @@
 {
   "@context": [
-    "http://www.w3.org/ns/td",
+    "https://www.w3.org/2019/wot/td/v1",
     {
-      "iot": "http://iotschema.org/",
-      "http": "http://www.w3.org/2011/http#"
+      "iot": "http://iotschema.org/"
     }
   ],
   "@type": [
@@ -28,13 +27,13 @@
   "security": [
     "nosec_sc"
   ],
-  "name": "Intel-OCF-594ee957-fd3e-4547-9430-5267bcdb3ed7",
+  "title": "Intel-OCF-led2side",
   "support": "mailto:michael.mccool@intel.com",
   "version": {
     "instance": "0.1.0"
   },
-  "created": "2018-09-10T06:30+00:00",
-  "lastModified": "2018-12-19T04:06:02.107Z",
+  "created": "2018-09-10T06:30:00Z",
+  "modified": "2019-05-28T05:43:02.343Z",
   "links": [
     {
       "href": "https://github.com/mmccool/ocf-wot-metadata-bridge",
@@ -69,14 +68,13 @@
         {
           "contentType": "application/json",
           "href": "http://upsq1c.local:8000/api/oic/a/led2side?di=594ee957-fd3e-4547-9430-5267bcdb3ed7",
-          "op": "readproperty",
-          "http:methodName": "GET"
+          "op": "readproperty"
         },
         {
           "contentType": "application/json",
           "href": "http://upsq1c.local:8000/api/oic/a/led2side?di=594ee957-fd3e-4547-9430-5267bcdb3ed7",
           "op": "writeproperty",
-          "http:methodName": "POST"
+          "htv:methodName": "POST"
         },
         {
           "contentType": "application/json",
@@ -84,8 +82,7 @@
           "security": [
             "basic_sc"
           ],
-          "op": "readproperty",
-          "http:methodName": "GET"
+          "op": "readproperty"
         },
         {
           "contentType": "application/json",
@@ -94,7 +91,7 @@
             "basic_sc"
           ],
           "op": "writeproperty",
-          "http:methodName": "POST"
+          "htv:methodName": "POST"
         },
         {
           "contentType": "application/json",
@@ -102,8 +99,7 @@
           "security": [
             "basic_sc"
           ],
-          "op": "readproperty",
-          "http:methodName": "GET"
+          "op": "readproperty"
         },
         {
           "contentType": "application/json",
@@ -112,7 +108,7 @@
             "basic_sc"
           ],
           "op": "writeproperty",
-          "http:methodName": "POST"
+          "htv:methodName": "POST"
         },
         {
           "contentType": "application/json",
@@ -120,8 +116,7 @@
           "security": [
             "digest_sc"
           ],
-          "op": "readproperty",
-          "http:methodName": "GET"
+          "op": "readproperty"
         },
         {
           "contentType": "application/json",
@@ -130,7 +125,7 @@
             "digest_sc"
           ],
           "op": "writeproperty",
-          "http:methodName": "POST"
+          "htv:methodName": "POST"
         },
         {
           "contentType": "application/json",
@@ -138,8 +133,7 @@
           "security": [
             "digest_sc"
           ],
-          "op": "readproperty",
-          "http:methodName": "GET"
+          "op": "readproperty"
         },
         {
           "contentType": "application/json",
@@ -148,7 +142,7 @@
             "digest_sc"
           ],
           "op": "writeproperty",
-          "http:methodName": "POST"
+          "htv:methodName": "POST"
         }
       ]
     }

--- a/workshop/ws2/demos-2019-Munich/TDs/Intel/intel-ocf/Intel-OCF-led2top.jsonld
+++ b/workshop/ws2/demos-2019-Munich/TDs/Intel/intel-ocf/Intel-OCF-led2top.jsonld
@@ -1,9 +1,8 @@
 {
   "@context": [
-    "http://www.w3.org/ns/td",
+    "https://www.w3.org/2019/wot/td/v1",
     {
-      "iot": "http://iotschema.org/",
-      "http": "http://www.w3.org/2011/http#"
+      "iot": "http://iotschema.org/"
     }
   ],
   "@type": [
@@ -13,7 +12,7 @@
     "iot:Actuator",
     "iot:BinarySwitch"
   ],
-  "id": "urn:uuid:6573313c-da1e-4068-beb1-884b0c4c3c5d",
+  "id": "urn:uuid:e6b060cf-dc10-4375-ae08-1f9e2de0aa2b",
   "securityDefinitions": {
     "nosec_sc": {
       "scheme": "nosec"
@@ -28,13 +27,13 @@
   "security": [
     "nosec_sc"
   ],
-  "name": "Intel-OCF-6573313c-da1e-4068-beb1-884b0c4c3c5d",
+  "title": "Intel-OCF-led2top",
   "support": "mailto:michael.mccool@intel.com",
   "version": {
     "instance": "0.1.0"
   },
-  "created": "2018-09-10T06:30+00:00",
-  "lastModified": "2018-12-19T04:06:02.096Z",
+  "created": "2018-09-10T06:30:00Z",
+  "modified": "2019-05-28T05:43:02.336Z",
   "links": [
     {
       "href": "https://github.com/mmccool/ocf-wot-metadata-bridge",
@@ -68,87 +67,82 @@
       "forms": [
         {
           "contentType": "application/json",
-          "href": "http://upsq1c.local:8000/api/oic/a/led0green?di=6573313c-da1e-4068-beb1-884b0c4c3c5d",
-          "op": "readproperty",
-          "http:methodName": "GET"
+          "href": "http://upsq1c.local:8000/api/oic/a/led2top?di=e6b060cf-dc10-4375-ae08-1f9e2de0aa2b",
+          "op": "readproperty"
         },
         {
           "contentType": "application/json",
-          "href": "http://upsq1c.local:8000/api/oic/a/led0green?di=6573313c-da1e-4068-beb1-884b0c4c3c5d",
+          "href": "http://upsq1c.local:8000/api/oic/a/led2top?di=e6b060cf-dc10-4375-ae08-1f9e2de0aa2b",
           "op": "writeproperty",
-          "http:methodName": "POST"
+          "htv:methodName": "POST"
         },
         {
           "contentType": "application/json",
-          "href": "https://portal.mmccool.net:8090/api/oic/a/led0green?di=6573313c-da1e-4068-beb1-884b0c4c3c5d",
+          "href": "https://portal.mmccool.net:8090/api/oic/a/led2top?di=e6b060cf-dc10-4375-ae08-1f9e2de0aa2b",
           "security": [
             "basic_sc"
           ],
-          "op": "readproperty",
-          "http:methodName": "GET"
+          "op": "readproperty"
         },
         {
           "contentType": "application/json",
-          "href": "https://portal.mmccool.net:8090/api/oic/a/led0green?di=6573313c-da1e-4068-beb1-884b0c4c3c5d",
-          "security": [
-            "basic_sc"
-          ],
-          "op": "writeproperty",
-          "http:methodName": "POST"
-        },
-        {
-          "contentType": "application/json",
-          "href": "https://tiktok.mmccool.org:8091/api/oic/a/led0green?di=6573313c-da1e-4068-beb1-884b0c4c3c5d",
-          "security": [
-            "basic_sc"
-          ],
-          "op": "readproperty",
-          "http:methodName": "GET"
-        },
-        {
-          "contentType": "application/json",
-          "href": "https://tiktok.mmccool.org:8091/api/oic/a/led0green?di=6573313c-da1e-4068-beb1-884b0c4c3c5d",
+          "href": "https://portal.mmccool.net:8090/api/oic/a/led2top?di=e6b060cf-dc10-4375-ae08-1f9e2de0aa2b",
           "security": [
             "basic_sc"
           ],
           "op": "writeproperty",
-          "http:methodName": "POST"
+          "htv:methodName": "POST"
         },
         {
           "contentType": "application/json",
-          "href": "https://portal.mmccool.net:8090/api/oic/a/led0green?di=6573313c-da1e-4068-beb1-884b0c4c3c5d",
+          "href": "https://tiktok.mmccool.org:8091/api/oic/a/led2top?di=e6b060cf-dc10-4375-ae08-1f9e2de0aa2b",
+          "security": [
+            "basic_sc"
+          ],
+          "op": "readproperty"
+        },
+        {
+          "contentType": "application/json",
+          "href": "https://tiktok.mmccool.org:8091/api/oic/a/led2top?di=e6b060cf-dc10-4375-ae08-1f9e2de0aa2b",
+          "security": [
+            "basic_sc"
+          ],
+          "op": "writeproperty",
+          "htv:methodName": "POST"
+        },
+        {
+          "contentType": "application/json",
+          "href": "https://portal.mmccool.net:8090/api/oic/a/led2top?di=e6b060cf-dc10-4375-ae08-1f9e2de0aa2b",
           "security": [
             "digest_sc"
           ],
-          "op": "readproperty",
-          "http:methodName": "GET"
+          "op": "readproperty"
         },
         {
           "contentType": "application/json",
-          "href": "https://portal.mmccool.net:8090/api/oic/a/led0green?di=6573313c-da1e-4068-beb1-884b0c4c3c5d",
+          "href": "https://portal.mmccool.net:8090/api/oic/a/led2top?di=e6b060cf-dc10-4375-ae08-1f9e2de0aa2b",
           "security": [
             "digest_sc"
           ],
           "op": "writeproperty",
-          "http:methodName": "POST"
+          "htv:methodName": "POST"
         },
         {
           "contentType": "application/json",
-          "href": "https://tiktok.mmccool.org:8091/api/oic/a/led0green?di=6573313c-da1e-4068-beb1-884b0c4c3c5d",
+          "href": "https://tiktok.mmccool.org:8091/api/oic/a/led2top?di=e6b060cf-dc10-4375-ae08-1f9e2de0aa2b",
           "security": [
             "digest_sc"
           ],
-          "op": "readproperty",
-          "http:methodName": "GET"
+          "op": "readproperty"
         },
         {
           "contentType": "application/json",
-          "href": "https://tiktok.mmccool.org:8091/api/oic/a/led0green?di=6573313c-da1e-4068-beb1-884b0c4c3c5d",
+          "href": "https://tiktok.mmccool.org:8091/api/oic/a/led2top?di=e6b060cf-dc10-4375-ae08-1f9e2de0aa2b",
           "security": [
             "digest_sc"
           ],
           "op": "writeproperty",
-          "http:methodName": "POST"
+          "htv:methodName": "POST"
         }
       ]
     }
@@ -180,32 +174,32 @@
       "forms": [
         {
           "contentType": "application/json",
-          "href": "http://upsq1c.local:8000/api/oic/a/led0green?di=6573313c-da1e-4068-beb1-884b0c4c3c5d"
+          "href": "http://upsq1c.local:8000/api/oic/a/led2top?di=e6b060cf-dc10-4375-ae08-1f9e2de0aa2b"
         },
         {
           "contentType": "application/json",
-          "href": "https://portal.mmccool.net:8090/api/oic/a/led0green?di=6573313c-da1e-4068-beb1-884b0c4c3c5d",
+          "href": "https://portal.mmccool.net:8090/api/oic/a/led2top?di=e6b060cf-dc10-4375-ae08-1f9e2de0aa2b",
           "security": [
             "basic_sc"
           ]
         },
         {
           "contentType": "application/json",
-          "href": "https://tiktok.mmccool.org:8091/api/oic/a/led0green?di=6573313c-da1e-4068-beb1-884b0c4c3c5d",
+          "href": "https://tiktok.mmccool.org:8091/api/oic/a/led2top?di=e6b060cf-dc10-4375-ae08-1f9e2de0aa2b",
           "security": [
             "basic_sc"
           ]
         },
         {
           "contentType": "application/json",
-          "href": "https://portal.mmccool.net:8090/api/oic/a/led0green?di=6573313c-da1e-4068-beb1-884b0c4c3c5d",
+          "href": "https://portal.mmccool.net:8090/api/oic/a/led2top?di=e6b060cf-dc10-4375-ae08-1f9e2de0aa2b",
           "security": [
             "digest_sc"
           ]
         },
         {
           "contentType": "application/json",
-          "href": "https://tiktok.mmccool.org:8091/api/oic/a/led0green?di=6573313c-da1e-4068-beb1-884b0c4c3c5d",
+          "href": "https://tiktok.mmccool.org:8091/api/oic/a/led2top?di=e6b060cf-dc10-4375-ae08-1f9e2de0aa2b",
           "security": [
             "digest_sc"
           ]
@@ -238,32 +232,32 @@
       "forms": [
         {
           "contentType": "application/json",
-          "href": "http://upsq1c.local:8000/api/oic/a/led0green?di=6573313c-da1e-4068-beb1-884b0c4c3c5d"
+          "href": "http://upsq1c.local:8000/api/oic/a/led2top?di=e6b060cf-dc10-4375-ae08-1f9e2de0aa2b"
         },
         {
           "contentType": "application/json",
-          "href": "https://portal.mmccool.net:8090/api/oic/a/led0green?di=6573313c-da1e-4068-beb1-884b0c4c3c5d",
+          "href": "https://portal.mmccool.net:8090/api/oic/a/led2top?di=e6b060cf-dc10-4375-ae08-1f9e2de0aa2b",
           "security": [
             "basic_sc"
           ]
         },
         {
           "contentType": "application/json",
-          "href": "https://tiktok.mmccool.org:8091/api/oic/a/led0green?di=6573313c-da1e-4068-beb1-884b0c4c3c5d",
+          "href": "https://tiktok.mmccool.org:8091/api/oic/a/led2top?di=e6b060cf-dc10-4375-ae08-1f9e2de0aa2b",
           "security": [
             "basic_sc"
           ]
         },
         {
           "contentType": "application/json",
-          "href": "https://portal.mmccool.net:8090/api/oic/a/led0green?di=6573313c-da1e-4068-beb1-884b0c4c3c5d",
+          "href": "https://portal.mmccool.net:8090/api/oic/a/led2top?di=e6b060cf-dc10-4375-ae08-1f9e2de0aa2b",
           "security": [
             "digest_sc"
           ]
         },
         {
           "contentType": "application/json",
-          "href": "https://tiktok.mmccool.org:8091/api/oic/a/led0green?di=6573313c-da1e-4068-beb1-884b0c4c3c5d",
+          "href": "https://tiktok.mmccool.org:8091/api/oic/a/led2top?di=e6b060cf-dc10-4375-ae08-1f9e2de0aa2b",
           "security": [
             "digest_sc"
           ]

--- a/workshop/ws2/demos-2019-Munich/TDs/Intel/intel-ocf/Intel-OCF-motion0.jsonld
+++ b/workshop/ws2/demos-2019-Munich/TDs/Intel/intel-ocf/Intel-OCF-motion0.jsonld
@@ -1,18 +1,17 @@
 {
   "@context": [
-    "http://www.w3.org/ns/td",
+    "https://www.w3.org/2019/wot/td/v1",
     {
-      "iot": "http://iotschema.org/",
-      "http": "http://www.w3.org/2011/http#"
+      "iot": "http://iotschema.org/"
     }
   ],
   "@type": [
     "Thing",
-    "Meter",
-    "iot:IlluminanceSensing",
+    "Motion",
+    "iot:MotionControl",
     "iot:Sensor"
   ],
-  "id": "urn:uuid:c75fe336-28d3-4b02-b52c-9a4daa9577f6",
+  "id": "urn:uuid:0800f07a-178d-48ec-9ddf-d8a941071298",
   "securityDefinitions": {
     "nosec_sc": {
       "scheme": "nosec"
@@ -27,13 +26,13 @@
   "security": [
     "nosec_sc"
   ],
-  "name": "Intel-OCF-c75fe336-28d3-4b02-b52c-9a4daa9577f6",
+  "title": "Intel-OCF-motion0",
   "support": "mailto:michael.mccool@intel.com",
   "version": {
     "instance": "0.1.0"
   },
-  "created": "2018-09-10T06:30+00:00",
-  "lastModified": "2018-12-19T04:06:02.096Z",
+  "created": "2018-09-10T06:30:00Z",
+  "modified": "2019-05-28T05:43:02.332Z",
   "links": [
     {
       "href": "https://github.com/mmccool/ocf-wot-metadata-bridge",
@@ -42,13 +41,13 @@
     }
   ],
   "properties": {
-    "illuminance": {
-      "title": "Illuminance",
+    "motion": {
+      "title": "Motion Sense Status",
       "readOnly": true,
       "observable": true,
       "@type": [
-        "MultiLevelState",
-        "iot:Illuminance"
+        "Occupancy",
+        "iot:MotionDetected"
       ],
       "type": "object",
       "properties": {
@@ -57,9 +56,9 @@
         },
         "value": {
           "@type": [
-            "iot:IlluminanceData"
+            "iot:StateData"
           ],
-          "type": "number"
+          "type": "boolean"
         }
       },
       "required": [
@@ -68,87 +67,82 @@
       "forms": [
         {
           "contentType": "application/json",
-          "href": "http://upsq1c.local:8000/api/oic/a/illuminance2?di=c75fe336-28d3-4b02-b52c-9a4daa9577f6",
-          "op": "readproperty",
-          "http:methodName": "GET"
+          "href": "http://upsq1c.local:8000/api/oic/a/motion0?di=0800f07a-178d-48ec-9ddf-d8a941071298",
+          "op": "readproperty"
         },
         {
           "contentType": "application/json",
-          "href": "http://upsq1c.local:8000/api/oic/a/illuminance2?di=c75fe336-28d3-4b02-b52c-9a4daa9577f6",
+          "href": "http://upsq1c.local:8000/api/oic/a/motion0?di=0800f07a-178d-48ec-9ddf-d8a941071298",
           "op": "writeproperty",
-          "http:methodName": "POST"
+          "htv:methodName": "POST"
         },
         {
           "contentType": "application/json",
-          "href": "https://portal.mmccool.net:8090/api/oic/a/illuminance2?di=c75fe336-28d3-4b02-b52c-9a4daa9577f6",
+          "href": "https://portal.mmccool.net:8090/api/oic/a/motion0?di=0800f07a-178d-48ec-9ddf-d8a941071298",
           "security": [
             "basic_sc"
           ],
-          "op": "readproperty",
-          "http:methodName": "GET"
+          "op": "readproperty"
         },
         {
           "contentType": "application/json",
-          "href": "https://portal.mmccool.net:8090/api/oic/a/illuminance2?di=c75fe336-28d3-4b02-b52c-9a4daa9577f6",
-          "security": [
-            "basic_sc"
-          ],
-          "op": "writeproperty",
-          "http:methodName": "POST"
-        },
-        {
-          "contentType": "application/json",
-          "href": "https://tiktok.mmccool.org:8091/api/oic/a/illuminance2?di=c75fe336-28d3-4b02-b52c-9a4daa9577f6",
-          "security": [
-            "basic_sc"
-          ],
-          "op": "readproperty",
-          "http:methodName": "GET"
-        },
-        {
-          "contentType": "application/json",
-          "href": "https://tiktok.mmccool.org:8091/api/oic/a/illuminance2?di=c75fe336-28d3-4b02-b52c-9a4daa9577f6",
+          "href": "https://portal.mmccool.net:8090/api/oic/a/motion0?di=0800f07a-178d-48ec-9ddf-d8a941071298",
           "security": [
             "basic_sc"
           ],
           "op": "writeproperty",
-          "http:methodName": "POST"
+          "htv:methodName": "POST"
         },
         {
           "contentType": "application/json",
-          "href": "https://portal.mmccool.net:8090/api/oic/a/illuminance2?di=c75fe336-28d3-4b02-b52c-9a4daa9577f6",
+          "href": "https://tiktok.mmccool.org:8091/api/oic/a/motion0?di=0800f07a-178d-48ec-9ddf-d8a941071298",
+          "security": [
+            "basic_sc"
+          ],
+          "op": "readproperty"
+        },
+        {
+          "contentType": "application/json",
+          "href": "https://tiktok.mmccool.org:8091/api/oic/a/motion0?di=0800f07a-178d-48ec-9ddf-d8a941071298",
+          "security": [
+            "basic_sc"
+          ],
+          "op": "writeproperty",
+          "htv:methodName": "POST"
+        },
+        {
+          "contentType": "application/json",
+          "href": "https://portal.mmccool.net:8090/api/oic/a/motion0?di=0800f07a-178d-48ec-9ddf-d8a941071298",
           "security": [
             "digest_sc"
           ],
-          "op": "readproperty",
-          "http:methodName": "GET"
+          "op": "readproperty"
         },
         {
           "contentType": "application/json",
-          "href": "https://portal.mmccool.net:8090/api/oic/a/illuminance2?di=c75fe336-28d3-4b02-b52c-9a4daa9577f6",
+          "href": "https://portal.mmccool.net:8090/api/oic/a/motion0?di=0800f07a-178d-48ec-9ddf-d8a941071298",
           "security": [
             "digest_sc"
           ],
           "op": "writeproperty",
-          "http:methodName": "POST"
+          "htv:methodName": "POST"
         },
         {
           "contentType": "application/json",
-          "href": "https://tiktok.mmccool.org:8091/api/oic/a/illuminance2?di=c75fe336-28d3-4b02-b52c-9a4daa9577f6",
+          "href": "https://tiktok.mmccool.org:8091/api/oic/a/motion0?di=0800f07a-178d-48ec-9ddf-d8a941071298",
           "security": [
             "digest_sc"
           ],
-          "op": "readproperty",
-          "http:methodName": "GET"
+          "op": "readproperty"
         },
         {
           "contentType": "application/json",
-          "href": "https://tiktok.mmccool.org:8091/api/oic/a/illuminance2?di=c75fe336-28d3-4b02-b52c-9a4daa9577f6",
+          "href": "https://tiktok.mmccool.org:8091/api/oic/a/motion0?di=0800f07a-178d-48ec-9ddf-d8a941071298",
           "security": [
             "digest_sc"
           ],
           "op": "writeproperty",
-          "http:methodName": "POST"
+          "htv:methodName": "POST"
         }
       ]
     }

--- a/workshop/ws2/demos-2019-Munich/TDs/Intel/intel-ocf/Intel-OCF-motion1.jsonld
+++ b/workshop/ws2/demos-2019-Munich/TDs/Intel/intel-ocf/Intel-OCF-motion1.jsonld
@@ -1,18 +1,17 @@
 {
   "@context": [
-    "http://www.w3.org/ns/td",
+    "https://www.w3.org/2019/wot/td/v1",
     {
-      "iot": "http://iotschema.org/",
-      "http": "http://www.w3.org/2011/http#"
+      "iot": "http://iotschema.org/"
     }
   ],
   "@type": [
     "Thing",
-    "Temperature",
-    "iot:TemperatureSensing",
+    "Motion",
+    "iot:MotionControl",
     "iot:Sensor"
   ],
-  "id": "urn:uuid:086d490d-90c6-4785-a677-c911bd2af919",
+  "id": "urn:uuid:5dc3f14e-4976-44d4-bfe8-57838db97ab5",
   "securityDefinitions": {
     "nosec_sc": {
       "scheme": "nosec"
@@ -27,13 +26,13 @@
   "security": [
     "nosec_sc"
   ],
-  "name": "Intel-OCF-086d490d-90c6-4785-a677-c911bd2af919",
+  "title": "Intel-OCF-motion1",
   "support": "mailto:michael.mccool@intel.com",
   "version": {
     "instance": "0.1.0"
   },
-  "created": "2018-09-10T06:30+00:00",
-  "lastModified": "2018-12-19T04:06:02.096Z",
+  "created": "2018-09-10T06:30:00Z",
+  "modified": "2019-05-28T05:43:02.361Z",
   "links": [
     {
       "href": "https://github.com/mmccool/ocf-wot-metadata-bridge",
@@ -42,13 +41,13 @@
     }
   ],
   "properties": {
-    "temperature": {
-      "title": "Room Temperature",
+    "motion": {
+      "title": "Motion Sense Status",
       "readOnly": true,
       "observable": true,
       "@type": [
-        "MultiLevelState",
-        "iot:Temperature"
+        "Occupancy",
+        "iot:MotionDetected"
       ],
       "type": "object",
       "properties": {
@@ -57,9 +56,9 @@
         },
         "value": {
           "@type": [
-            "iot:TemperatureData"
+            "iot:StateData"
           ],
-          "type": "number"
+          "type": "boolean"
         }
       },
       "required": [
@@ -68,87 +67,82 @@
       "forms": [
         {
           "contentType": "application/json",
-          "href": "http://upsq1c.local:8000/api/oic/a/temperature1?di=086d490d-90c6-4785-a677-c911bd2af919",
-          "op": "readproperty",
-          "http:methodName": "GET"
+          "href": "http://upsq1c.local:8000/api/oic/a/motion1?di=5dc3f14e-4976-44d4-bfe8-57838db97ab5",
+          "op": "readproperty"
         },
         {
           "contentType": "application/json",
-          "href": "http://upsq1c.local:8000/api/oic/a/temperature1?di=086d490d-90c6-4785-a677-c911bd2af919",
+          "href": "http://upsq1c.local:8000/api/oic/a/motion1?di=5dc3f14e-4976-44d4-bfe8-57838db97ab5",
           "op": "writeproperty",
-          "http:methodName": "POST"
+          "htv:methodName": "POST"
         },
         {
           "contentType": "application/json",
-          "href": "https://portal.mmccool.net:8090/api/oic/a/temperature1?di=086d490d-90c6-4785-a677-c911bd2af919",
+          "href": "https://portal.mmccool.net:8090/api/oic/a/motion1?di=5dc3f14e-4976-44d4-bfe8-57838db97ab5",
           "security": [
             "basic_sc"
           ],
-          "op": "readproperty",
-          "http:methodName": "GET"
+          "op": "readproperty"
         },
         {
           "contentType": "application/json",
-          "href": "https://portal.mmccool.net:8090/api/oic/a/temperature1?di=086d490d-90c6-4785-a677-c911bd2af919",
-          "security": [
-            "basic_sc"
-          ],
-          "op": "writeproperty",
-          "http:methodName": "POST"
-        },
-        {
-          "contentType": "application/json",
-          "href": "https://tiktok.mmccool.org:8091/api/oic/a/temperature1?di=086d490d-90c6-4785-a677-c911bd2af919",
-          "security": [
-            "basic_sc"
-          ],
-          "op": "readproperty",
-          "http:methodName": "GET"
-        },
-        {
-          "contentType": "application/json",
-          "href": "https://tiktok.mmccool.org:8091/api/oic/a/temperature1?di=086d490d-90c6-4785-a677-c911bd2af919",
+          "href": "https://portal.mmccool.net:8090/api/oic/a/motion1?di=5dc3f14e-4976-44d4-bfe8-57838db97ab5",
           "security": [
             "basic_sc"
           ],
           "op": "writeproperty",
-          "http:methodName": "POST"
+          "htv:methodName": "POST"
         },
         {
           "contentType": "application/json",
-          "href": "https://portal.mmccool.net:8090/api/oic/a/temperature1?di=086d490d-90c6-4785-a677-c911bd2af919",
+          "href": "https://tiktok.mmccool.org:8091/api/oic/a/motion1?di=5dc3f14e-4976-44d4-bfe8-57838db97ab5",
+          "security": [
+            "basic_sc"
+          ],
+          "op": "readproperty"
+        },
+        {
+          "contentType": "application/json",
+          "href": "https://tiktok.mmccool.org:8091/api/oic/a/motion1?di=5dc3f14e-4976-44d4-bfe8-57838db97ab5",
+          "security": [
+            "basic_sc"
+          ],
+          "op": "writeproperty",
+          "htv:methodName": "POST"
+        },
+        {
+          "contentType": "application/json",
+          "href": "https://portal.mmccool.net:8090/api/oic/a/motion1?di=5dc3f14e-4976-44d4-bfe8-57838db97ab5",
           "security": [
             "digest_sc"
           ],
-          "op": "readproperty",
-          "http:methodName": "GET"
+          "op": "readproperty"
         },
         {
           "contentType": "application/json",
-          "href": "https://portal.mmccool.net:8090/api/oic/a/temperature1?di=086d490d-90c6-4785-a677-c911bd2af919",
+          "href": "https://portal.mmccool.net:8090/api/oic/a/motion1?di=5dc3f14e-4976-44d4-bfe8-57838db97ab5",
           "security": [
             "digest_sc"
           ],
           "op": "writeproperty",
-          "http:methodName": "POST"
+          "htv:methodName": "POST"
         },
         {
           "contentType": "application/json",
-          "href": "https://tiktok.mmccool.org:8091/api/oic/a/temperature1?di=086d490d-90c6-4785-a677-c911bd2af919",
+          "href": "https://tiktok.mmccool.org:8091/api/oic/a/motion1?di=5dc3f14e-4976-44d4-bfe8-57838db97ab5",
           "security": [
             "digest_sc"
           ],
-          "op": "readproperty",
-          "http:methodName": "GET"
+          "op": "readproperty"
         },
         {
           "contentType": "application/json",
-          "href": "https://tiktok.mmccool.org:8091/api/oic/a/temperature1?di=086d490d-90c6-4785-a677-c911bd2af919",
+          "href": "https://tiktok.mmccool.org:8091/api/oic/a/motion1?di=5dc3f14e-4976-44d4-bfe8-57838db97ab5",
           "security": [
             "digest_sc"
           ],
           "op": "writeproperty",
-          "http:methodName": "POST"
+          "htv:methodName": "POST"
         }
       ]
     }

--- a/workshop/ws2/demos-2019-Munich/TDs/Intel/intel-ocf/Intel-OCF-motion2.jsonld
+++ b/workshop/ws2/demos-2019-Munich/TDs/Intel/intel-ocf/Intel-OCF-motion2.jsonld
@@ -1,18 +1,17 @@
 {
   "@context": [
-    "http://www.w3.org/ns/td",
+    "https://www.w3.org/2019/wot/td/v1",
     {
-      "iot": "http://iotschema.org/",
-      "http": "http://www.w3.org/2011/http#"
+      "iot": "http://iotschema.org/"
     }
   ],
   "@type": [
     "Thing",
-    "Temperature",
-    "iot:TemperatureSensing",
+    "Motion",
+    "iot:MotionControl",
     "iot:Sensor"
   ],
-  "id": "urn:uuid:f2305852-4f82-47ce-871d-a0af237932c1",
+  "id": "urn:uuid:c440e5ef-a02f-49cf-b036-00b0738b0d86",
   "securityDefinitions": {
     "nosec_sc": {
       "scheme": "nosec"
@@ -27,13 +26,13 @@
   "security": [
     "nosec_sc"
   ],
-  "name": "Intel-OCF-f2305852-4f82-47ce-871d-a0af237932c1",
+  "title": "Intel-OCF-motion2",
   "support": "mailto:michael.mccool@intel.com",
   "version": {
     "instance": "0.1.0"
   },
-  "created": "2018-09-10T06:30+00:00",
-  "lastModified": "2018-12-19T04:06:02.096Z",
+  "created": "2018-09-10T06:30:00Z",
+  "modified": "2019-05-28T05:43:02.343Z",
   "links": [
     {
       "href": "https://github.com/mmccool/ocf-wot-metadata-bridge",
@@ -42,13 +41,13 @@
     }
   ],
   "properties": {
-    "temperature": {
-      "title": "Room Temperature",
+    "motion": {
+      "title": "Motion Sense Status",
       "readOnly": true,
       "observable": true,
       "@type": [
-        "MultiLevelState",
-        "iot:Temperature"
+        "Occupancy",
+        "iot:MotionDetected"
       ],
       "type": "object",
       "properties": {
@@ -57,9 +56,9 @@
         },
         "value": {
           "@type": [
-            "iot:TemperatureData"
+            "iot:StateData"
           ],
-          "type": "number"
+          "type": "boolean"
         }
       },
       "required": [
@@ -68,87 +67,82 @@
       "forms": [
         {
           "contentType": "application/json",
-          "href": "http://upsq1c.local:8000/api/oic/a/temperature0?di=f2305852-4f82-47ce-871d-a0af237932c1",
-          "op": "readproperty",
-          "http:methodName": "GET"
+          "href": "http://upsq1c.local:8000/api/oic/a/motion2?di=c440e5ef-a02f-49cf-b036-00b0738b0d86",
+          "op": "readproperty"
         },
         {
           "contentType": "application/json",
-          "href": "http://upsq1c.local:8000/api/oic/a/temperature0?di=f2305852-4f82-47ce-871d-a0af237932c1",
+          "href": "http://upsq1c.local:8000/api/oic/a/motion2?di=c440e5ef-a02f-49cf-b036-00b0738b0d86",
           "op": "writeproperty",
-          "http:methodName": "POST"
+          "htv:methodName": "POST"
         },
         {
           "contentType": "application/json",
-          "href": "https://portal.mmccool.net:8090/api/oic/a/temperature0?di=f2305852-4f82-47ce-871d-a0af237932c1",
+          "href": "https://portal.mmccool.net:8090/api/oic/a/motion2?di=c440e5ef-a02f-49cf-b036-00b0738b0d86",
           "security": [
             "basic_sc"
           ],
-          "op": "readproperty",
-          "http:methodName": "GET"
+          "op": "readproperty"
         },
         {
           "contentType": "application/json",
-          "href": "https://portal.mmccool.net:8090/api/oic/a/temperature0?di=f2305852-4f82-47ce-871d-a0af237932c1",
-          "security": [
-            "basic_sc"
-          ],
-          "op": "writeproperty",
-          "http:methodName": "POST"
-        },
-        {
-          "contentType": "application/json",
-          "href": "https://tiktok.mmccool.org:8091/api/oic/a/temperature0?di=f2305852-4f82-47ce-871d-a0af237932c1",
-          "security": [
-            "basic_sc"
-          ],
-          "op": "readproperty",
-          "http:methodName": "GET"
-        },
-        {
-          "contentType": "application/json",
-          "href": "https://tiktok.mmccool.org:8091/api/oic/a/temperature0?di=f2305852-4f82-47ce-871d-a0af237932c1",
+          "href": "https://portal.mmccool.net:8090/api/oic/a/motion2?di=c440e5ef-a02f-49cf-b036-00b0738b0d86",
           "security": [
             "basic_sc"
           ],
           "op": "writeproperty",
-          "http:methodName": "POST"
+          "htv:methodName": "POST"
         },
         {
           "contentType": "application/json",
-          "href": "https://portal.mmccool.net:8090/api/oic/a/temperature0?di=f2305852-4f82-47ce-871d-a0af237932c1",
+          "href": "https://tiktok.mmccool.org:8091/api/oic/a/motion2?di=c440e5ef-a02f-49cf-b036-00b0738b0d86",
+          "security": [
+            "basic_sc"
+          ],
+          "op": "readproperty"
+        },
+        {
+          "contentType": "application/json",
+          "href": "https://tiktok.mmccool.org:8091/api/oic/a/motion2?di=c440e5ef-a02f-49cf-b036-00b0738b0d86",
+          "security": [
+            "basic_sc"
+          ],
+          "op": "writeproperty",
+          "htv:methodName": "POST"
+        },
+        {
+          "contentType": "application/json",
+          "href": "https://portal.mmccool.net:8090/api/oic/a/motion2?di=c440e5ef-a02f-49cf-b036-00b0738b0d86",
           "security": [
             "digest_sc"
           ],
-          "op": "readproperty",
-          "http:methodName": "GET"
+          "op": "readproperty"
         },
         {
           "contentType": "application/json",
-          "href": "https://portal.mmccool.net:8090/api/oic/a/temperature0?di=f2305852-4f82-47ce-871d-a0af237932c1",
+          "href": "https://portal.mmccool.net:8090/api/oic/a/motion2?di=c440e5ef-a02f-49cf-b036-00b0738b0d86",
           "security": [
             "digest_sc"
           ],
           "op": "writeproperty",
-          "http:methodName": "POST"
+          "htv:methodName": "POST"
         },
         {
           "contentType": "application/json",
-          "href": "https://tiktok.mmccool.org:8091/api/oic/a/temperature0?di=f2305852-4f82-47ce-871d-a0af237932c1",
+          "href": "https://tiktok.mmccool.org:8091/api/oic/a/motion2?di=c440e5ef-a02f-49cf-b036-00b0738b0d86",
           "security": [
             "digest_sc"
           ],
-          "op": "readproperty",
-          "http:methodName": "GET"
+          "op": "readproperty"
         },
         {
           "contentType": "application/json",
-          "href": "https://tiktok.mmccool.org:8091/api/oic/a/temperature0?di=f2305852-4f82-47ce-871d-a0af237932c1",
+          "href": "https://tiktok.mmccool.org:8091/api/oic/a/motion2?di=c440e5ef-a02f-49cf-b036-00b0738b0d86",
           "security": [
             "digest_sc"
           ],
           "op": "writeproperty",
-          "http:methodName": "POST"
+          "htv:methodName": "POST"
         }
       ]
     }

--- a/workshop/ws2/demos-2019-Munich/TDs/Intel/intel-ocf/Intel-OCF-rgbled1.jsonld
+++ b/workshop/ws2/demos-2019-Munich/TDs/Intel/intel-ocf/Intel-OCF-rgbled1.jsonld
@@ -1,9 +1,8 @@
 {
   "@context": [
-    "http://www.w3.org/ns/td",
+    "https://www.w3.org/2019/wot/td/v1",
     {
-      "iot": "http://iotschema.org/",
-      "http": "http://www.w3.org/2011/http#"
+      "iot": "http://iotschema.org/"
     }
   ],
   "@type": [
@@ -27,13 +26,13 @@
   "security": [
     "nosec_sc"
   ],
-  "name": "Intel-OCF-ae9b3aa5-1476-4fcb-9908-dd96a293572d",
+  "title": "Intel-OCF-rgbled1",
   "support": "mailto:michael.mccool@intel.com",
   "version": {
     "instance": "0.1.0"
   },
-  "created": "2018-09-10T06:30+00:00",
-  "lastModified": "2018-12-19T04:06:02.096Z",
+  "created": "2018-09-10T06:30:00Z",
+  "modified": "2019-05-28T05:43:02.358Z",
   "links": [
     {
       "href": "https://github.com/mmccool/ocf-wot-metadata-bridge",
@@ -93,14 +92,13 @@
         {
           "contentType": "application/json",
           "href": "http://upsq1c.local:8000/api/oic/a/rgbled1?di=ae9b3aa5-1476-4fcb-9908-dd96a293572d",
-          "op": "readproperty",
-          "http:methodName": "GET"
+          "op": "readproperty"
         },
         {
           "contentType": "application/json",
           "href": "http://upsq1c.local:8000/api/oic/a/rgbled1?di=ae9b3aa5-1476-4fcb-9908-dd96a293572d",
           "op": "writeproperty",
-          "http:methodName": "POST"
+          "htv:methodName": "POST"
         },
         {
           "contentType": "application/json",
@@ -108,8 +106,7 @@
           "security": [
             "basic_sc"
           ],
-          "op": "readproperty",
-          "http:methodName": "GET"
+          "op": "readproperty"
         },
         {
           "contentType": "application/json",
@@ -118,7 +115,7 @@
             "basic_sc"
           ],
           "op": "writeproperty",
-          "http:methodName": "POST"
+          "htv:methodName": "POST"
         },
         {
           "contentType": "application/json",
@@ -126,8 +123,7 @@
           "security": [
             "basic_sc"
           ],
-          "op": "readproperty",
-          "http:methodName": "GET"
+          "op": "readproperty"
         },
         {
           "contentType": "application/json",
@@ -136,7 +132,7 @@
             "basic_sc"
           ],
           "op": "writeproperty",
-          "http:methodName": "POST"
+          "htv:methodName": "POST"
         },
         {
           "contentType": "application/json",
@@ -144,8 +140,7 @@
           "security": [
             "digest_sc"
           ],
-          "op": "readproperty",
-          "http:methodName": "GET"
+          "op": "readproperty"
         },
         {
           "contentType": "application/json",
@@ -154,7 +149,7 @@
             "digest_sc"
           ],
           "op": "writeproperty",
-          "http:methodName": "POST"
+          "htv:methodName": "POST"
         },
         {
           "contentType": "application/json",
@@ -162,8 +157,7 @@
           "security": [
             "digest_sc"
           ],
-          "op": "readproperty",
-          "http:methodName": "GET"
+          "op": "readproperty"
         },
         {
           "contentType": "application/json",
@@ -172,7 +166,7 @@
             "digest_sc"
           ],
           "op": "writeproperty",
-          "http:methodName": "POST"
+          "htv:methodName": "POST"
         }
       ]
     }

--- a/workshop/ws2/demos-2019-Munich/TDs/Intel/intel-ocf/Intel-OCF-temperature0.jsonld
+++ b/workshop/ws2/demos-2019-Munich/TDs/Intel/intel-ocf/Intel-OCF-temperature0.jsonld
@@ -1,18 +1,17 @@
 {
   "@context": [
-    "http://www.w3.org/ns/td",
+    "https://www.w3.org/2019/wot/td/v1",
     {
-      "iot": "http://iotschema.org/",
-      "http": "http://www.w3.org/2011/http#"
+      "iot": "http://iotschema.org/"
     }
   ],
   "@type": [
     "Thing",
-    "Motion",
-    "iot:MotionControl",
+    "Temperature",
+    "iot:TemperatureSensing",
     "iot:Sensor"
   ],
-  "id": "urn:uuid:0800f07a-178d-48ec-9ddf-d8a941071298",
+  "id": "urn:uuid:f2305852-4f82-47ce-871d-a0af237932c1",
   "securityDefinitions": {
     "nosec_sc": {
       "scheme": "nosec"
@@ -27,13 +26,13 @@
   "security": [
     "nosec_sc"
   ],
-  "name": "Intel-OCF-0800f07a-178d-48ec-9ddf-d8a941071298",
+  "title": "Intel-OCF-temperature0",
   "support": "mailto:michael.mccool@intel.com",
   "version": {
     "instance": "0.1.0"
   },
-  "created": "2018-09-10T06:30+00:00",
-  "lastModified": "2018-12-19T04:06:02.096Z",
+  "created": "2018-09-10T06:30:00Z",
+  "modified": "2019-05-28T05:43:02.345Z",
   "links": [
     {
       "href": "https://github.com/mmccool/ocf-wot-metadata-bridge",
@@ -42,13 +41,13 @@
     }
   ],
   "properties": {
-    "motion": {
-      "title": "Motion Sense Status",
+    "temperature": {
+      "title": "Room Temperature",
       "readOnly": true,
       "observable": true,
       "@type": [
-        "Occupancy",
-        "iot:MotionDetected"
+        "MultiLevelState",
+        "iot:Temperature"
       ],
       "type": "object",
       "properties": {
@@ -57,9 +56,9 @@
         },
         "value": {
           "@type": [
-            "iot:StateData"
+            "iot:TemperatureData"
           ],
-          "type": "boolean"
+          "type": "number"
         }
       },
       "required": [
@@ -68,87 +67,82 @@
       "forms": [
         {
           "contentType": "application/json",
-          "href": "http://upsq1c.local:8000/api/oic/a/motion0?di=0800f07a-178d-48ec-9ddf-d8a941071298",
-          "op": "readproperty",
-          "http:methodName": "GET"
+          "href": "http://upsq1c.local:8000/api/oic/a/temperature0?di=f2305852-4f82-47ce-871d-a0af237932c1",
+          "op": "readproperty"
         },
         {
           "contentType": "application/json",
-          "href": "http://upsq1c.local:8000/api/oic/a/motion0?di=0800f07a-178d-48ec-9ddf-d8a941071298",
+          "href": "http://upsq1c.local:8000/api/oic/a/temperature0?di=f2305852-4f82-47ce-871d-a0af237932c1",
           "op": "writeproperty",
-          "http:methodName": "POST"
+          "htv:methodName": "POST"
         },
         {
           "contentType": "application/json",
-          "href": "https://portal.mmccool.net:8090/api/oic/a/motion0?di=0800f07a-178d-48ec-9ddf-d8a941071298",
+          "href": "https://portal.mmccool.net:8090/api/oic/a/temperature0?di=f2305852-4f82-47ce-871d-a0af237932c1",
           "security": [
             "basic_sc"
           ],
-          "op": "readproperty",
-          "http:methodName": "GET"
+          "op": "readproperty"
         },
         {
           "contentType": "application/json",
-          "href": "https://portal.mmccool.net:8090/api/oic/a/motion0?di=0800f07a-178d-48ec-9ddf-d8a941071298",
-          "security": [
-            "basic_sc"
-          ],
-          "op": "writeproperty",
-          "http:methodName": "POST"
-        },
-        {
-          "contentType": "application/json",
-          "href": "https://tiktok.mmccool.org:8091/api/oic/a/motion0?di=0800f07a-178d-48ec-9ddf-d8a941071298",
-          "security": [
-            "basic_sc"
-          ],
-          "op": "readproperty",
-          "http:methodName": "GET"
-        },
-        {
-          "contentType": "application/json",
-          "href": "https://tiktok.mmccool.org:8091/api/oic/a/motion0?di=0800f07a-178d-48ec-9ddf-d8a941071298",
+          "href": "https://portal.mmccool.net:8090/api/oic/a/temperature0?di=f2305852-4f82-47ce-871d-a0af237932c1",
           "security": [
             "basic_sc"
           ],
           "op": "writeproperty",
-          "http:methodName": "POST"
+          "htv:methodName": "POST"
         },
         {
           "contentType": "application/json",
-          "href": "https://portal.mmccool.net:8090/api/oic/a/motion0?di=0800f07a-178d-48ec-9ddf-d8a941071298",
+          "href": "https://tiktok.mmccool.org:8091/api/oic/a/temperature0?di=f2305852-4f82-47ce-871d-a0af237932c1",
+          "security": [
+            "basic_sc"
+          ],
+          "op": "readproperty"
+        },
+        {
+          "contentType": "application/json",
+          "href": "https://tiktok.mmccool.org:8091/api/oic/a/temperature0?di=f2305852-4f82-47ce-871d-a0af237932c1",
+          "security": [
+            "basic_sc"
+          ],
+          "op": "writeproperty",
+          "htv:methodName": "POST"
+        },
+        {
+          "contentType": "application/json",
+          "href": "https://portal.mmccool.net:8090/api/oic/a/temperature0?di=f2305852-4f82-47ce-871d-a0af237932c1",
           "security": [
             "digest_sc"
           ],
-          "op": "readproperty",
-          "http:methodName": "GET"
+          "op": "readproperty"
         },
         {
           "contentType": "application/json",
-          "href": "https://portal.mmccool.net:8090/api/oic/a/motion0?di=0800f07a-178d-48ec-9ddf-d8a941071298",
+          "href": "https://portal.mmccool.net:8090/api/oic/a/temperature0?di=f2305852-4f82-47ce-871d-a0af237932c1",
           "security": [
             "digest_sc"
           ],
           "op": "writeproperty",
-          "http:methodName": "POST"
+          "htv:methodName": "POST"
         },
         {
           "contentType": "application/json",
-          "href": "https://tiktok.mmccool.org:8091/api/oic/a/motion0?di=0800f07a-178d-48ec-9ddf-d8a941071298",
+          "href": "https://tiktok.mmccool.org:8091/api/oic/a/temperature0?di=f2305852-4f82-47ce-871d-a0af237932c1",
           "security": [
             "digest_sc"
           ],
-          "op": "readproperty",
-          "http:methodName": "GET"
+          "op": "readproperty"
         },
         {
           "contentType": "application/json",
-          "href": "https://tiktok.mmccool.org:8091/api/oic/a/motion0?di=0800f07a-178d-48ec-9ddf-d8a941071298",
+          "href": "https://tiktok.mmccool.org:8091/api/oic/a/temperature0?di=f2305852-4f82-47ce-871d-a0af237932c1",
           "security": [
             "digest_sc"
           ],
           "op": "writeproperty",
-          "http:methodName": "POST"
+          "htv:methodName": "POST"
         }
       ]
     }

--- a/workshop/ws2/demos-2019-Munich/TDs/Intel/intel-ocf/Intel-OCF-temperature1.jsonld
+++ b/workshop/ws2/demos-2019-Munich/TDs/Intel/intel-ocf/Intel-OCF-temperature1.jsonld
@@ -1,18 +1,17 @@
 {
   "@context": [
-    "http://www.w3.org/ns/td",
+    "https://www.w3.org/2019/wot/td/v1",
     {
-      "iot": "http://iotschema.org/",
-      "http": "http://www.w3.org/2011/http#"
+      "iot": "http://iotschema.org/"
     }
   ],
   "@type": [
     "Thing",
-    "Switch",
-    "iot:Sensor",
-    "iot:BinarySwitch"
+    "Temperature",
+    "iot:TemperatureSensing",
+    "iot:Sensor"
   ],
-  "id": "urn:uuid:f057c263-58db-4cb1-9470-bba9344e1ba8",
+  "id": "urn:uuid:086d490d-90c6-4785-a677-c911bd2af919",
   "securityDefinitions": {
     "nosec_sc": {
       "scheme": "nosec"
@@ -27,13 +26,13 @@
   "security": [
     "nosec_sc"
   ],
-  "name": "Intel-OCF-f057c263-58db-4cb1-9470-bba9344e1ba8",
+  "title": "Intel-OCF-temperature1",
   "support": "mailto:michael.mccool@intel.com",
   "version": {
     "instance": "0.1.0"
   },
-  "created": "2018-09-10T06:30+00:00",
-  "lastModified": "2018-12-19T04:06:02.096Z",
+  "created": "2018-09-10T06:30:00Z",
+  "modified": "2019-05-28T05:43:02.358Z",
   "links": [
     {
       "href": "https://github.com/mmccool/ocf-wot-metadata-bridge",
@@ -42,13 +41,13 @@
     }
   ],
   "properties": {
-    "status": {
-      "title": "On/Off Status",
+    "temperature": {
+      "title": "Room Temperature",
       "readOnly": true,
       "observable": true,
       "@type": [
-        "OnOffState",
-        "iot:SwitchStatus"
+        "MultiLevelState",
+        "iot:Temperature"
       ],
       "type": "object",
       "properties": {
@@ -57,9 +56,9 @@
         },
         "value": {
           "@type": [
-            "iot:Toggle"
+            "iot:TemperatureData"
           ],
-          "type": "boolean"
+          "type": "number"
         }
       },
       "required": [
@@ -68,87 +67,82 @@
       "forms": [
         {
           "contentType": "application/json",
-          "href": "http://upsq1c.local:8000/api/oic/a/toggle1?di=f057c263-58db-4cb1-9470-bba9344e1ba8",
-          "op": "readproperty",
-          "http:methodName": "GET"
+          "href": "http://upsq1c.local:8000/api/oic/a/temperature1?di=086d490d-90c6-4785-a677-c911bd2af919",
+          "op": "readproperty"
         },
         {
           "contentType": "application/json",
-          "href": "http://upsq1c.local:8000/api/oic/a/toggle1?di=f057c263-58db-4cb1-9470-bba9344e1ba8",
+          "href": "http://upsq1c.local:8000/api/oic/a/temperature1?di=086d490d-90c6-4785-a677-c911bd2af919",
           "op": "writeproperty",
-          "http:methodName": "POST"
+          "htv:methodName": "POST"
         },
         {
           "contentType": "application/json",
-          "href": "https://portal.mmccool.net:8090/api/oic/a/toggle1?di=f057c263-58db-4cb1-9470-bba9344e1ba8",
+          "href": "https://portal.mmccool.net:8090/api/oic/a/temperature1?di=086d490d-90c6-4785-a677-c911bd2af919",
           "security": [
             "basic_sc"
           ],
-          "op": "readproperty",
-          "http:methodName": "GET"
+          "op": "readproperty"
         },
         {
           "contentType": "application/json",
-          "href": "https://portal.mmccool.net:8090/api/oic/a/toggle1?di=f057c263-58db-4cb1-9470-bba9344e1ba8",
-          "security": [
-            "basic_sc"
-          ],
-          "op": "writeproperty",
-          "http:methodName": "POST"
-        },
-        {
-          "contentType": "application/json",
-          "href": "https://tiktok.mmccool.org:8091/api/oic/a/toggle1?di=f057c263-58db-4cb1-9470-bba9344e1ba8",
-          "security": [
-            "basic_sc"
-          ],
-          "op": "readproperty",
-          "http:methodName": "GET"
-        },
-        {
-          "contentType": "application/json",
-          "href": "https://tiktok.mmccool.org:8091/api/oic/a/toggle1?di=f057c263-58db-4cb1-9470-bba9344e1ba8",
+          "href": "https://portal.mmccool.net:8090/api/oic/a/temperature1?di=086d490d-90c6-4785-a677-c911bd2af919",
           "security": [
             "basic_sc"
           ],
           "op": "writeproperty",
-          "http:methodName": "POST"
+          "htv:methodName": "POST"
         },
         {
           "contentType": "application/json",
-          "href": "https://portal.mmccool.net:8090/api/oic/a/toggle1?di=f057c263-58db-4cb1-9470-bba9344e1ba8",
+          "href": "https://tiktok.mmccool.org:8091/api/oic/a/temperature1?di=086d490d-90c6-4785-a677-c911bd2af919",
+          "security": [
+            "basic_sc"
+          ],
+          "op": "readproperty"
+        },
+        {
+          "contentType": "application/json",
+          "href": "https://tiktok.mmccool.org:8091/api/oic/a/temperature1?di=086d490d-90c6-4785-a677-c911bd2af919",
+          "security": [
+            "basic_sc"
+          ],
+          "op": "writeproperty",
+          "htv:methodName": "POST"
+        },
+        {
+          "contentType": "application/json",
+          "href": "https://portal.mmccool.net:8090/api/oic/a/temperature1?di=086d490d-90c6-4785-a677-c911bd2af919",
           "security": [
             "digest_sc"
           ],
-          "op": "readproperty",
-          "http:methodName": "GET"
+          "op": "readproperty"
         },
         {
           "contentType": "application/json",
-          "href": "https://portal.mmccool.net:8090/api/oic/a/toggle1?di=f057c263-58db-4cb1-9470-bba9344e1ba8",
+          "href": "https://portal.mmccool.net:8090/api/oic/a/temperature1?di=086d490d-90c6-4785-a677-c911bd2af919",
           "security": [
             "digest_sc"
           ],
           "op": "writeproperty",
-          "http:methodName": "POST"
+          "htv:methodName": "POST"
         },
         {
           "contentType": "application/json",
-          "href": "https://tiktok.mmccool.org:8091/api/oic/a/toggle1?di=f057c263-58db-4cb1-9470-bba9344e1ba8",
+          "href": "https://tiktok.mmccool.org:8091/api/oic/a/temperature1?di=086d490d-90c6-4785-a677-c911bd2af919",
           "security": [
             "digest_sc"
           ],
-          "op": "readproperty",
-          "http:methodName": "GET"
+          "op": "readproperty"
         },
         {
           "contentType": "application/json",
-          "href": "https://tiktok.mmccool.org:8091/api/oic/a/toggle1?di=f057c263-58db-4cb1-9470-bba9344e1ba8",
+          "href": "https://tiktok.mmccool.org:8091/api/oic/a/temperature1?di=086d490d-90c6-4785-a677-c911bd2af919",
           "security": [
             "digest_sc"
           ],
           "op": "writeproperty",
-          "http:methodName": "POST"
+          "htv:methodName": "POST"
         }
       ]
     }

--- a/workshop/ws2/demos-2019-Munich/TDs/Intel/intel-ocf/Intel-OCF-temperature2.jsonld
+++ b/workshop/ws2/demos-2019-Munich/TDs/Intel/intel-ocf/Intel-OCF-temperature2.jsonld
@@ -1,9 +1,8 @@
 {
   "@context": [
-    "http://www.w3.org/ns/td",
+    "https://www.w3.org/2019/wot/td/v1",
     {
-      "iot": "http://iotschema.org/",
-      "http": "http://www.w3.org/2011/http#"
+      "iot": "http://iotschema.org/"
     }
   ],
   "@type": [
@@ -27,13 +26,13 @@
   "security": [
     "nosec_sc"
   ],
-  "name": "Intel-OCF-e855ad80-c435-4614-a4b7-01d63afc712e",
+  "title": "Intel-OCF-temperature2",
   "support": "mailto:michael.mccool@intel.com",
   "version": {
     "instance": "0.1.0"
   },
-  "created": "2018-09-10T06:30+00:00",
-  "lastModified": "2018-12-19T04:06:02.096Z",
+  "created": "2018-09-10T06:30:00Z",
+  "modified": "2019-05-28T05:43:02.342Z",
   "links": [
     {
       "href": "https://github.com/mmccool/ocf-wot-metadata-bridge",
@@ -69,14 +68,13 @@
         {
           "contentType": "application/json",
           "href": "http://upsq1c.local:8000/api/oic/a/temperature2?di=e855ad80-c435-4614-a4b7-01d63afc712e",
-          "op": "readproperty",
-          "http:methodName": "GET"
+          "op": "readproperty"
         },
         {
           "contentType": "application/json",
           "href": "http://upsq1c.local:8000/api/oic/a/temperature2?di=e855ad80-c435-4614-a4b7-01d63afc712e",
           "op": "writeproperty",
-          "http:methodName": "POST"
+          "htv:methodName": "POST"
         },
         {
           "contentType": "application/json",
@@ -84,8 +82,7 @@
           "security": [
             "basic_sc"
           ],
-          "op": "readproperty",
-          "http:methodName": "GET"
+          "op": "readproperty"
         },
         {
           "contentType": "application/json",
@@ -94,7 +91,7 @@
             "basic_sc"
           ],
           "op": "writeproperty",
-          "http:methodName": "POST"
+          "htv:methodName": "POST"
         },
         {
           "contentType": "application/json",
@@ -102,8 +99,7 @@
           "security": [
             "basic_sc"
           ],
-          "op": "readproperty",
-          "http:methodName": "GET"
+          "op": "readproperty"
         },
         {
           "contentType": "application/json",
@@ -112,7 +108,7 @@
             "basic_sc"
           ],
           "op": "writeproperty",
-          "http:methodName": "POST"
+          "htv:methodName": "POST"
         },
         {
           "contentType": "application/json",
@@ -120,8 +116,7 @@
           "security": [
             "digest_sc"
           ],
-          "op": "readproperty",
-          "http:methodName": "GET"
+          "op": "readproperty"
         },
         {
           "contentType": "application/json",
@@ -130,7 +125,7 @@
             "digest_sc"
           ],
           "op": "writeproperty",
-          "http:methodName": "POST"
+          "htv:methodName": "POST"
         },
         {
           "contentType": "application/json",
@@ -138,8 +133,7 @@
           "security": [
             "digest_sc"
           ],
-          "op": "readproperty",
-          "http:methodName": "GET"
+          "op": "readproperty"
         },
         {
           "contentType": "application/json",
@@ -148,7 +142,7 @@
             "digest_sc"
           ],
           "op": "writeproperty",
-          "http:methodName": "POST"
+          "htv:methodName": "POST"
         }
       ]
     }

--- a/workshop/ws2/demos-2019-Munich/TDs/Intel/intel-ocf/Intel-OCF-toggle0.jsonld
+++ b/workshop/ws2/demos-2019-Munich/TDs/Intel/intel-ocf/Intel-OCF-toggle0.jsonld
@@ -1,9 +1,8 @@
 {
   "@context": [
-    "http://www.w3.org/ns/td",
+    "https://www.w3.org/2019/wot/td/v1",
     {
-      "iot": "http://iotschema.org/",
-      "http": "http://www.w3.org/2011/http#"
+      "iot": "http://iotschema.org/"
     }
   ],
   "@type": [
@@ -12,7 +11,7 @@
     "iot:Sensor",
     "iot:BinarySwitch"
   ],
-  "id": "urn:uuid:3932ae08-31b4-4882-b299-5d488ec8775c",
+  "id": "urn:uuid:4b74842c-8bfe-4f14-8bc5-31b4c79658a4",
   "securityDefinitions": {
     "nosec_sc": {
       "scheme": "nosec"
@@ -27,13 +26,13 @@
   "security": [
     "nosec_sc"
   ],
-  "name": "Intel-OCF-3932ae08-31b4-4882-b299-5d488ec8775c",
+  "title": "Intel-OCF-toggle0",
   "support": "mailto:michael.mccool@intel.com",
   "version": {
     "instance": "0.1.0"
   },
-  "created": "2018-09-10T06:30+00:00",
-  "lastModified": "2018-12-19T04:06:02.096Z",
+  "created": "2018-09-10T06:30:00Z",
+  "modified": "2019-05-28T05:43:02.348Z",
   "links": [
     {
       "href": "https://github.com/mmccool/ocf-wot-metadata-bridge",
@@ -68,87 +67,82 @@
       "forms": [
         {
           "contentType": "application/json",
-          "href": "http://upsq1c.local:8000/api/oic/a/button1touch?di=3932ae08-31b4-4882-b299-5d488ec8775c",
-          "op": "readproperty",
-          "http:methodName": "GET"
+          "href": "http://upsq1c.local:8000/api/oic/a/toggle0?di=4b74842c-8bfe-4f14-8bc5-31b4c79658a4",
+          "op": "readproperty"
         },
         {
           "contentType": "application/json",
-          "href": "http://upsq1c.local:8000/api/oic/a/button1touch?di=3932ae08-31b4-4882-b299-5d488ec8775c",
+          "href": "http://upsq1c.local:8000/api/oic/a/toggle0?di=4b74842c-8bfe-4f14-8bc5-31b4c79658a4",
           "op": "writeproperty",
-          "http:methodName": "POST"
+          "htv:methodName": "POST"
         },
         {
           "contentType": "application/json",
-          "href": "https://portal.mmccool.net:8090/api/oic/a/button1touch?di=3932ae08-31b4-4882-b299-5d488ec8775c",
+          "href": "https://portal.mmccool.net:8090/api/oic/a/toggle0?di=4b74842c-8bfe-4f14-8bc5-31b4c79658a4",
           "security": [
             "basic_sc"
           ],
-          "op": "readproperty",
-          "http:methodName": "GET"
+          "op": "readproperty"
         },
         {
           "contentType": "application/json",
-          "href": "https://portal.mmccool.net:8090/api/oic/a/button1touch?di=3932ae08-31b4-4882-b299-5d488ec8775c",
-          "security": [
-            "basic_sc"
-          ],
-          "op": "writeproperty",
-          "http:methodName": "POST"
-        },
-        {
-          "contentType": "application/json",
-          "href": "https://tiktok.mmccool.org:8091/api/oic/a/button1touch?di=3932ae08-31b4-4882-b299-5d488ec8775c",
-          "security": [
-            "basic_sc"
-          ],
-          "op": "readproperty",
-          "http:methodName": "GET"
-        },
-        {
-          "contentType": "application/json",
-          "href": "https://tiktok.mmccool.org:8091/api/oic/a/button1touch?di=3932ae08-31b4-4882-b299-5d488ec8775c",
+          "href": "https://portal.mmccool.net:8090/api/oic/a/toggle0?di=4b74842c-8bfe-4f14-8bc5-31b4c79658a4",
           "security": [
             "basic_sc"
           ],
           "op": "writeproperty",
-          "http:methodName": "POST"
+          "htv:methodName": "POST"
         },
         {
           "contentType": "application/json",
-          "href": "https://portal.mmccool.net:8090/api/oic/a/button1touch?di=3932ae08-31b4-4882-b299-5d488ec8775c",
+          "href": "https://tiktok.mmccool.org:8091/api/oic/a/toggle0?di=4b74842c-8bfe-4f14-8bc5-31b4c79658a4",
+          "security": [
+            "basic_sc"
+          ],
+          "op": "readproperty"
+        },
+        {
+          "contentType": "application/json",
+          "href": "https://tiktok.mmccool.org:8091/api/oic/a/toggle0?di=4b74842c-8bfe-4f14-8bc5-31b4c79658a4",
+          "security": [
+            "basic_sc"
+          ],
+          "op": "writeproperty",
+          "htv:methodName": "POST"
+        },
+        {
+          "contentType": "application/json",
+          "href": "https://portal.mmccool.net:8090/api/oic/a/toggle0?di=4b74842c-8bfe-4f14-8bc5-31b4c79658a4",
           "security": [
             "digest_sc"
           ],
-          "op": "readproperty",
-          "http:methodName": "GET"
+          "op": "readproperty"
         },
         {
           "contentType": "application/json",
-          "href": "https://portal.mmccool.net:8090/api/oic/a/button1touch?di=3932ae08-31b4-4882-b299-5d488ec8775c",
+          "href": "https://portal.mmccool.net:8090/api/oic/a/toggle0?di=4b74842c-8bfe-4f14-8bc5-31b4c79658a4",
           "security": [
             "digest_sc"
           ],
           "op": "writeproperty",
-          "http:methodName": "POST"
+          "htv:methodName": "POST"
         },
         {
           "contentType": "application/json",
-          "href": "https://tiktok.mmccool.org:8091/api/oic/a/button1touch?di=3932ae08-31b4-4882-b299-5d488ec8775c",
+          "href": "https://tiktok.mmccool.org:8091/api/oic/a/toggle0?di=4b74842c-8bfe-4f14-8bc5-31b4c79658a4",
           "security": [
             "digest_sc"
           ],
-          "op": "readproperty",
-          "http:methodName": "GET"
+          "op": "readproperty"
         },
         {
           "contentType": "application/json",
-          "href": "https://tiktok.mmccool.org:8091/api/oic/a/button1touch?di=3932ae08-31b4-4882-b299-5d488ec8775c",
+          "href": "https://tiktok.mmccool.org:8091/api/oic/a/toggle0?di=4b74842c-8bfe-4f14-8bc5-31b4c79658a4",
           "security": [
             "digest_sc"
           ],
           "op": "writeproperty",
-          "http:methodName": "POST"
+          "htv:methodName": "POST"
         }
       ]
     }

--- a/workshop/ws2/demos-2019-Munich/TDs/Intel/intel-ocf/Intel-OCF-toggle1.jsonld
+++ b/workshop/ws2/demos-2019-Munich/TDs/Intel/intel-ocf/Intel-OCF-toggle1.jsonld
@@ -1,9 +1,8 @@
 {
   "@context": [
-    "http://www.w3.org/ns/td",
+    "https://www.w3.org/2019/wot/td/v1",
     {
-      "iot": "http://iotschema.org/",
-      "http": "http://www.w3.org/2011/http#"
+      "iot": "http://iotschema.org/"
     }
   ],
   "@type": [
@@ -12,7 +11,7 @@
     "iot:Sensor",
     "iot:BinarySwitch"
   ],
-  "id": "urn:uuid:e7678d50-6a14-426b-a1f0-fb1b8ade4cd5",
+  "id": "urn:uuid:f057c263-58db-4cb1-9470-bba9344e1ba8",
   "securityDefinitions": {
     "nosec_sc": {
       "scheme": "nosec"
@@ -27,13 +26,13 @@
   "security": [
     "nosec_sc"
   ],
-  "name": "Intel-OCF-e7678d50-6a14-426b-a1f0-fb1b8ade4cd5",
+  "title": "Intel-OCF-toggle1",
   "support": "mailto:michael.mccool@intel.com",
   "version": {
     "instance": "0.1.0"
   },
-  "created": "2018-09-10T06:30+00:00",
-  "lastModified": "2018-12-19T04:06:02.096Z",
+  "created": "2018-09-10T06:30:00Z",
+  "modified": "2019-05-28T05:43:02.355Z",
   "links": [
     {
       "href": "https://github.com/mmccool/ocf-wot-metadata-bridge",
@@ -68,87 +67,82 @@
       "forms": [
         {
           "contentType": "application/json",
-          "href": "http://upsq1c.local:8000/api/oic/a/toggle2?di=e7678d50-6a14-426b-a1f0-fb1b8ade4cd5",
-          "op": "readproperty",
-          "http:methodName": "GET"
+          "href": "http://upsq1c.local:8000/api/oic/a/toggle1?di=f057c263-58db-4cb1-9470-bba9344e1ba8",
+          "op": "readproperty"
         },
         {
           "contentType": "application/json",
-          "href": "http://upsq1c.local:8000/api/oic/a/toggle2?di=e7678d50-6a14-426b-a1f0-fb1b8ade4cd5",
+          "href": "http://upsq1c.local:8000/api/oic/a/toggle1?di=f057c263-58db-4cb1-9470-bba9344e1ba8",
           "op": "writeproperty",
-          "http:methodName": "POST"
+          "htv:methodName": "POST"
         },
         {
           "contentType": "application/json",
-          "href": "https://portal.mmccool.net:8090/api/oic/a/toggle2?di=e7678d50-6a14-426b-a1f0-fb1b8ade4cd5",
+          "href": "https://portal.mmccool.net:8090/api/oic/a/toggle1?di=f057c263-58db-4cb1-9470-bba9344e1ba8",
           "security": [
             "basic_sc"
           ],
-          "op": "readproperty",
-          "http:methodName": "GET"
+          "op": "readproperty"
         },
         {
           "contentType": "application/json",
-          "href": "https://portal.mmccool.net:8090/api/oic/a/toggle2?di=e7678d50-6a14-426b-a1f0-fb1b8ade4cd5",
-          "security": [
-            "basic_sc"
-          ],
-          "op": "writeproperty",
-          "http:methodName": "POST"
-        },
-        {
-          "contentType": "application/json",
-          "href": "https://tiktok.mmccool.org:8091/api/oic/a/toggle2?di=e7678d50-6a14-426b-a1f0-fb1b8ade4cd5",
-          "security": [
-            "basic_sc"
-          ],
-          "op": "readproperty",
-          "http:methodName": "GET"
-        },
-        {
-          "contentType": "application/json",
-          "href": "https://tiktok.mmccool.org:8091/api/oic/a/toggle2?di=e7678d50-6a14-426b-a1f0-fb1b8ade4cd5",
+          "href": "https://portal.mmccool.net:8090/api/oic/a/toggle1?di=f057c263-58db-4cb1-9470-bba9344e1ba8",
           "security": [
             "basic_sc"
           ],
           "op": "writeproperty",
-          "http:methodName": "POST"
+          "htv:methodName": "POST"
         },
         {
           "contentType": "application/json",
-          "href": "https://portal.mmccool.net:8090/api/oic/a/toggle2?di=e7678d50-6a14-426b-a1f0-fb1b8ade4cd5",
+          "href": "https://tiktok.mmccool.org:8091/api/oic/a/toggle1?di=f057c263-58db-4cb1-9470-bba9344e1ba8",
+          "security": [
+            "basic_sc"
+          ],
+          "op": "readproperty"
+        },
+        {
+          "contentType": "application/json",
+          "href": "https://tiktok.mmccool.org:8091/api/oic/a/toggle1?di=f057c263-58db-4cb1-9470-bba9344e1ba8",
+          "security": [
+            "basic_sc"
+          ],
+          "op": "writeproperty",
+          "htv:methodName": "POST"
+        },
+        {
+          "contentType": "application/json",
+          "href": "https://portal.mmccool.net:8090/api/oic/a/toggle1?di=f057c263-58db-4cb1-9470-bba9344e1ba8",
           "security": [
             "digest_sc"
           ],
-          "op": "readproperty",
-          "http:methodName": "GET"
+          "op": "readproperty"
         },
         {
           "contentType": "application/json",
-          "href": "https://portal.mmccool.net:8090/api/oic/a/toggle2?di=e7678d50-6a14-426b-a1f0-fb1b8ade4cd5",
+          "href": "https://portal.mmccool.net:8090/api/oic/a/toggle1?di=f057c263-58db-4cb1-9470-bba9344e1ba8",
           "security": [
             "digest_sc"
           ],
           "op": "writeproperty",
-          "http:methodName": "POST"
+          "htv:methodName": "POST"
         },
         {
           "contentType": "application/json",
-          "href": "https://tiktok.mmccool.org:8091/api/oic/a/toggle2?di=e7678d50-6a14-426b-a1f0-fb1b8ade4cd5",
+          "href": "https://tiktok.mmccool.org:8091/api/oic/a/toggle1?di=f057c263-58db-4cb1-9470-bba9344e1ba8",
           "security": [
             "digest_sc"
           ],
-          "op": "readproperty",
-          "http:methodName": "GET"
+          "op": "readproperty"
         },
         {
           "contentType": "application/json",
-          "href": "https://tiktok.mmccool.org:8091/api/oic/a/toggle2?di=e7678d50-6a14-426b-a1f0-fb1b8ade4cd5",
+          "href": "https://tiktok.mmccool.org:8091/api/oic/a/toggle1?di=f057c263-58db-4cb1-9470-bba9344e1ba8",
           "security": [
             "digest_sc"
           ],
           "op": "writeproperty",
-          "http:methodName": "POST"
+          "htv:methodName": "POST"
         }
       ]
     }

--- a/workshop/ws2/demos-2019-Munich/TDs/Intel/intel-ocf/Intel-OCF-toggle2.jsonld
+++ b/workshop/ws2/demos-2019-Munich/TDs/Intel/intel-ocf/Intel-OCF-toggle2.jsonld
@@ -1,18 +1,17 @@
 {
   "@context": [
-    "http://www.w3.org/ns/td",
+    "https://www.w3.org/2019/wot/td/v1",
     {
-      "iot": "http://iotschema.org/",
-      "http": "http://www.w3.org/2011/http#"
+      "iot": "http://iotschema.org/"
     }
   ],
   "@type": [
     "Thing",
-    "Motion",
-    "iot:MotionControl",
-    "iot:Sensor"
+    "Switch",
+    "iot:Sensor",
+    "iot:BinarySwitch"
   ],
-  "id": "urn:uuid:5dc3f14e-4976-44d4-bfe8-57838db97ab5",
+  "id": "urn:uuid:e7678d50-6a14-426b-a1f0-fb1b8ade4cd5",
   "securityDefinitions": {
     "nosec_sc": {
       "scheme": "nosec"
@@ -27,13 +26,13 @@
   "security": [
     "nosec_sc"
   ],
-  "name": "Intel-OCF-5dc3f14e-4976-44d4-bfe8-57838db97ab5",
+  "title": "Intel-OCF-toggle2",
   "support": "mailto:michael.mccool@intel.com",
   "version": {
     "instance": "0.1.0"
   },
-  "created": "2018-09-10T06:30+00:00",
-  "lastModified": "2018-12-19T04:06:02.096Z",
+  "created": "2018-09-10T06:30:00Z",
+  "modified": "2019-05-28T05:43:02.338Z",
   "links": [
     {
       "href": "https://github.com/mmccool/ocf-wot-metadata-bridge",
@@ -42,13 +41,13 @@
     }
   ],
   "properties": {
-    "motion": {
-      "title": "Motion Sense Status",
+    "status": {
+      "title": "On/Off Status",
       "readOnly": true,
       "observable": true,
       "@type": [
-        "Occupancy",
-        "iot:MotionDetected"
+        "OnOffState",
+        "iot:SwitchStatus"
       ],
       "type": "object",
       "properties": {
@@ -57,7 +56,7 @@
         },
         "value": {
           "@type": [
-            "iot:StateData"
+            "iot:Toggle"
           ],
           "type": "boolean"
         }
@@ -68,87 +67,82 @@
       "forms": [
         {
           "contentType": "application/json",
-          "href": "http://upsq1c.local:8000/api/oic/a/motion1?di=5dc3f14e-4976-44d4-bfe8-57838db97ab5",
-          "op": "readproperty",
-          "http:methodName": "GET"
+          "href": "http://upsq1c.local:8000/api/oic/a/toggle2?di=e7678d50-6a14-426b-a1f0-fb1b8ade4cd5",
+          "op": "readproperty"
         },
         {
           "contentType": "application/json",
-          "href": "http://upsq1c.local:8000/api/oic/a/motion1?di=5dc3f14e-4976-44d4-bfe8-57838db97ab5",
+          "href": "http://upsq1c.local:8000/api/oic/a/toggle2?di=e7678d50-6a14-426b-a1f0-fb1b8ade4cd5",
           "op": "writeproperty",
-          "http:methodName": "POST"
+          "htv:methodName": "POST"
         },
         {
           "contentType": "application/json",
-          "href": "https://portal.mmccool.net:8090/api/oic/a/motion1?di=5dc3f14e-4976-44d4-bfe8-57838db97ab5",
+          "href": "https://portal.mmccool.net:8090/api/oic/a/toggle2?di=e7678d50-6a14-426b-a1f0-fb1b8ade4cd5",
           "security": [
             "basic_sc"
           ],
-          "op": "readproperty",
-          "http:methodName": "GET"
+          "op": "readproperty"
         },
         {
           "contentType": "application/json",
-          "href": "https://portal.mmccool.net:8090/api/oic/a/motion1?di=5dc3f14e-4976-44d4-bfe8-57838db97ab5",
-          "security": [
-            "basic_sc"
-          ],
-          "op": "writeproperty",
-          "http:methodName": "POST"
-        },
-        {
-          "contentType": "application/json",
-          "href": "https://tiktok.mmccool.org:8091/api/oic/a/motion1?di=5dc3f14e-4976-44d4-bfe8-57838db97ab5",
-          "security": [
-            "basic_sc"
-          ],
-          "op": "readproperty",
-          "http:methodName": "GET"
-        },
-        {
-          "contentType": "application/json",
-          "href": "https://tiktok.mmccool.org:8091/api/oic/a/motion1?di=5dc3f14e-4976-44d4-bfe8-57838db97ab5",
+          "href": "https://portal.mmccool.net:8090/api/oic/a/toggle2?di=e7678d50-6a14-426b-a1f0-fb1b8ade4cd5",
           "security": [
             "basic_sc"
           ],
           "op": "writeproperty",
-          "http:methodName": "POST"
+          "htv:methodName": "POST"
         },
         {
           "contentType": "application/json",
-          "href": "https://portal.mmccool.net:8090/api/oic/a/motion1?di=5dc3f14e-4976-44d4-bfe8-57838db97ab5",
+          "href": "https://tiktok.mmccool.org:8091/api/oic/a/toggle2?di=e7678d50-6a14-426b-a1f0-fb1b8ade4cd5",
+          "security": [
+            "basic_sc"
+          ],
+          "op": "readproperty"
+        },
+        {
+          "contentType": "application/json",
+          "href": "https://tiktok.mmccool.org:8091/api/oic/a/toggle2?di=e7678d50-6a14-426b-a1f0-fb1b8ade4cd5",
+          "security": [
+            "basic_sc"
+          ],
+          "op": "writeproperty",
+          "htv:methodName": "POST"
+        },
+        {
+          "contentType": "application/json",
+          "href": "https://portal.mmccool.net:8090/api/oic/a/toggle2?di=e7678d50-6a14-426b-a1f0-fb1b8ade4cd5",
           "security": [
             "digest_sc"
           ],
-          "op": "readproperty",
-          "http:methodName": "GET"
+          "op": "readproperty"
         },
         {
           "contentType": "application/json",
-          "href": "https://portal.mmccool.net:8090/api/oic/a/motion1?di=5dc3f14e-4976-44d4-bfe8-57838db97ab5",
+          "href": "https://portal.mmccool.net:8090/api/oic/a/toggle2?di=e7678d50-6a14-426b-a1f0-fb1b8ade4cd5",
           "security": [
             "digest_sc"
           ],
           "op": "writeproperty",
-          "http:methodName": "POST"
+          "htv:methodName": "POST"
         },
         {
           "contentType": "application/json",
-          "href": "https://tiktok.mmccool.org:8091/api/oic/a/motion1?di=5dc3f14e-4976-44d4-bfe8-57838db97ab5",
+          "href": "https://tiktok.mmccool.org:8091/api/oic/a/toggle2?di=e7678d50-6a14-426b-a1f0-fb1b8ade4cd5",
           "security": [
             "digest_sc"
           ],
-          "op": "readproperty",
-          "http:methodName": "GET"
+          "op": "readproperty"
         },
         {
           "contentType": "application/json",
-          "href": "https://tiktok.mmccool.org:8091/api/oic/a/motion1?di=5dc3f14e-4976-44d4-bfe8-57838db97ab5",
+          "href": "https://tiktok.mmccool.org:8091/api/oic/a/toggle2?di=e7678d50-6a14-426b-a1f0-fb1b8ade4cd5",
           "security": [
             "digest_sc"
           ],
           "op": "writeproperty",
-          "http:methodName": "POST"
+          "htv:methodName": "POST"
         }
       ]
     }

--- a/workshop/ws2/demos-2019-Munich/TDs/Intel/intel-speak.jsonld
+++ b/workshop/ws2/demos-2019-Munich/TDs/Intel/intel-speak.jsonld
@@ -1,91 +1,62 @@
 {
-  "@context": [
-    "http://www.w3.org/ns/td",
-    {
-      "iot": "http://iotschema.org/",
-      "http": "http://www.w3.org/2011/http#"
-    }
+  "@context": ["https://www.w3.org/2019/wot/td/v1",
+               {
+                   "iot": "http://iotschema.org/"
+               }
   ],
-  "@type": [
-    "Thing"
-  ],
-  "name": "Intel-WebSpeak-sky",
+  "@type": ["Thing"],
+  "title": "Intel-WebSpeak-upsq1c",
   "description": "A simple text to speech service",
   "support": "mailto:michael.mccool@intel.com",
-  "version": {
-    "instance": "0.1.0"
-  },
-  "created": "2018-09-10T06:30+00:00",
-  "lastModified": "2018-12-19T03:14+00:00",
-  "links": [
-    {
-      "href": "https://github.com/mmccool/web-speak",
-      "rel": "repository",
-      "type": "application/vnd.github.v3+json"
-    }
-  ],
-  "id": "urn:uuid:ac04e086-abca-565f-a083-d1059c6fa868",
+  "version": {"instance":"0.1.0"},
+  "created": "2018-09-10T06:30:00Z",
+  "modified": "2019-05-28T03:14:00Z",
+  "links": [{
+        "href": "https://github.com/mmccool/web-speak",
+        "rel": "repository",
+        "type": "application/vnd.github.v3+json"
+  }],
+  "id": "urn:uuid:6f3775aa-9790-5b5d-99bb-fb354a63dc0f",
   "securityDefinitions": {
-    "nosec_sc": {
-      "scheme": "nosec"
-    },
-    "basic_sc": {
-      "scheme": "basic"
-    },
-    "digest_sc": {
-      "scheme": "digest"
-    }
+    "nosec_sc": {"scheme":"nosec"},
+    "basic_sc": {"scheme":"basic"},
+    "digest_sc": {"scheme":"digest"}
   },
-  "security": [
-    "nosec_sc"
-  ],
+  "security": ["nosec_sc"],
   "actions": {
     "say": {
       "input": {
-        "type": "string"
-      },
+          "type": "string"
+      }, 
       "forms": [
         {
-          "href": "http://sky.local:8085/api/say",
+          "href": "http://upsq1c.local:8085/api/say",
           "contentType": "application/json",
-          "op": "invokeaction",
-          "http:methodName": "POST"
+          "op":"invokeaction"
         },
         {
           "href": "https://portal.mmccool.net:8096/api/say",
           "contentType": "application/json",
-          "op": "invokeaction",
-          "http:methodName": "POST",
-          "security": [
-            "basic_sc"
-          ]
+          "op":"invokeaction",
+          "security": ["basic_sc"]
         },
         {
           "href": "https://portal.mmccool.net:8097/api/say",
           "contentType": "application/json",
-          "op": "invokeaction",
-          "http:methodName": "POST",
-          "security": [
-            "digest_sc"
-          ]
+          "op":"invokeaction",
+          "security": ["digest_sc"]
         },
         {
           "href": "https://tiktok.mmccool.org:8096/api/say",
           "contentType": "application/json",
-          "op": "invokeaction",
-          "http:methodName": "POST",
-          "security": [
-            "basic_sc"
-          ]
+          "op":"invokeaction",
+          "security": ["basic_sc"]
         },
         {
           "href": "https://tiktok.mmccool.org:8097/api/say",
           "contentType": "application/json",
-          "op": "invokeaction",
-          "http:methodName": "POST",
-          "security": [
-            "digest_sc"
-          ]
+          "op":"invokeaction",
+          "security": ["digest_sc"]
         }
       ]
     }


### PR DESCRIPTION
For 2019 workshop, update Intel TDs to reflect (a) real implementations (b) current and validated TDs (against the current CR spec).

Includes OCF, camera, and speak Things.

Note the OCF TDs now include nicer names (well, titles) rather than the ugly DI-based names that were there before.