### PR TITLE
Add concrete protocol bindings to IG topics

### DIFF
--- a/charters/wot-ig-2019.html
+++ b/charters/wot-ig-2019.html
@@ -258,6 +258,7 @@
           <li>WoT Scripting API and possible simplifications</li>
           <li>hypermedia-driven interactions for complex/multi-step Actions and Events</li>
           <li>community-driven, bottom-up vocabulary to enable semantic interoperability</li>
+          <li>Concrete protocol bindings (e.g. for HTTP, WebSockets, CoAP)</li>
         </ul>
 
         <p>


### PR DESCRIPTION
I hope to discuss this further at the workshop in Munich next week, but I understand there is time pressure to finalise the new Interest Group Charter so I'm proposing adding the following to the list of exploration tasks for the Interest Group:

"Concrete protocol bindings (e.g. for HTTP, WebSockets, CoAP)"