### PR TITLE
update manual test result for Hitachi

### DIFF
--- a/testing/tests/2019-05/inputs/Hitachi/hitachi.csv
+++ b/testing/tests/2019-05/inputs/Hitachi/hitachi.csv
@@ -37,3 +37,10 @@
 "td-title-description_titles","pass",
 "td-vocabulary-defaults","pass",
 "td-json-open_accept-byte-order","pass",
+"td-ns-multilanguage-content-negotiation","pass","Consumer-side.  Because Nodegen supports a Accept-Language request header."
+"td-ns-multilanguage-content-negotiation-no-multi","not-impl",
+"td-context-default-language-direction-heuristic","pass","If a direction is not inferred by cldr module, Nodegen uses dir=auto"
+"td-context-default-language-direction-independence","pass","Added a dir attribute for each element"
+"td-context-default-language-direction-inference","pass","Use cldr module for inference"
+"td-context-default-language-direction-script","pass","cldr module use script subtag (but not yet support az-arab. currently hardcoded)"
+"iana-security-alter","pass","Nodegen doesn't retrieve remote contexts"


### PR DESCRIPTION
Additional report for following assertions:
- td-ns-multilanguage-content-negotiation (https://github.com/w3c/wot-thing-description/issues/741)
- td-context-default-language-direction-heuristic (https://github.com/w3c/wot-thing-description/issues/738)
- td-context-default-language-direction-independence (https://github.com/w3c/wot-thing-description/issues/738)
- td-context-default-language-direction-inference (https://github.com/w3c/wot-thing-description/issues/738)
- td-context-default-language-direction-script (https://github.com/w3c/wot-thing-description/issues/738)
- iana-security-alter (https://github.com/w3c/wot-thing-description/issues/737)