### PR TITLE
[IG charter] remove reference to spec editing

### DIFF
--- a/charters/wot-ig-2019.html
+++ b/charters/wot-ig-2019.html
@@ -390,7 +390,7 @@
           Participation
         </h2>
         <p>
-          To be successful, this Interest Group is expected to have 6 or more active participants for its duration, including representatives from the key implementors of this specification, and active Editors and Test Leads for each specification. The Chairs, specification Editors, and Test Leads are expected to contribute half of a working day per week towards the (Working|Interest) Group. There is no minimum requirement for other Participants.
+          To be successful, this Interest Group is expected to have 6 or more active participants for its duration, including representatives from the key implementors of this specification, and active Editors and Test Leads for each specification. The Chairs, Editors, and Test Leads are expected to contribute half of a working day per week towards the (Working|Interest) Group. There is no minimum requirement for other Participants.
         </p>
         <p>
           The group encourages questions, comments and issues on its public mailing lists and document repositories, as described in <a href='#communication'>Communication</a>.
@@ -405,7 +405,7 @@
       <section id="communication">
         <h2>Communication</h2>
 
-        <p id="public">Technical discussions for this Interest Group are conducted in <a href="https://www.w3.org/2019/Process-20190301/#confidentiality-levels">public</a>. Meeting minutes from teleconference and face-to-face meetings will be archived for public review, and technical discussions and issue tracking will be conducted in a manner that can be both read and written to by the general public. Working Drafts and Editor's Drafts of specifications will be developed on a public repository and may permit direct public contribution requests.</p>
+        <p id="public">Technical discussions for this Interest Group are conducted in <a href="https://www.w3.org/2019/Process-20190301/#confidentiality-levels">public</a>. Meeting minutes from teleconference and face-to-face meetings will be archived for public review, and technical discussions and issue tracking will be conducted in a manner that can be both read and written to by the general public.</p>
 
         <p>Information about the group (including details about deliverables, issues, actions, status, participants, and meetings) will be available from the <a href="http://www.w3.org/WoT/IG/">Web of Things Interest Group home page.</a></p>
 


### PR DESCRIPTION
remove reference to spec editing, as the charter says IG won't work on specs