### PR TITLE
Update External Organizations Section for new IG Charter

### DIFF
--- a/charters/wot-ig-2019.html
+++ b/charters/wot-ig-2019.html
@@ -368,7 +368,7 @@
             <dt><a href="http://www.iiconsortium.org">Industrial Internet Consortium</a></dt>
             <dd>For collaboration on a testbed and gathering user requirements for the Web of Things.</dd>
             <dt><a href="https://opcfoundation.org">OPC Foundation</a></dt>
-            <dd>For collaboration on semantic interoperability and end to end security across platforms.</dd>
+            <dd>For collaboration on semantic interoperability in terms of information model and protocol binding.</dd>
             <dt><a href="http://www.plattform-i40.de/I40/Navigation/EN/Home/home.html">Plattform Industrie 4.0</a></dt>
             <dd>For collaboration on use cases and requirements for smart manufacturing, including semantic interoperability and end to end security across platforms.</dd>
             <dt><a href="http://www.onem2m.org">oneM2M</a></dt>
@@ -381,6 +381,8 @@
             <dd>For coordination on the OGC SensorThings API and location metadata.</dd>
             <dt><a href="http://www.gsma.com">GSMA</a></dt>
             <dd>For coordination in respect to the interests of Network Operators.</dd>
+            <dt><a href="https://www.eclass.eu/en.html">eCl@ss</a></dt>
+            <dd>For collaboration and coordination of the technical realization of the use of eCl@ss in the W3C Thing Description.</dd>
           </dl>
         </section>
       </section>

--- a/charters/wot-ig-2019.html
+++ b/charters/wot-ig-2019.html
@@ -383,6 +383,8 @@
             <dd>For coordination in respect to the interests of Network Operators.</dd>
             <dt><a href="https://www.eclass.eu/en.html">eCl@ss</a></dt>
             <dd>For collaboration and coordination of the technical realization of the use of eCl@ss in the W3C Thing Description.</dd>
+            <dt><a href="https://aioti.eu/">AIOTI WG03</a></dt>
+            <dd>For coordination with the Alliance for Internet of Things Innovation, Working Group 3 (standardisation), in respect to use cases, requirements, and semantic interoperability.</dd>
           </dl>
         </section>
       </section>

--- a/charters/wot-ig-2019.html
+++ b/charters/wot-ig-2019.html
@@ -368,7 +368,7 @@
             <dt><a href="http://www.iiconsortium.org">Industrial Internet Consortium</a></dt>
             <dd>For collaboration on a testbed and gathering user requirements for the Web of Things.</dd>
             <dt><a href="https://opcfoundation.org">OPC Foundation</a></dt>
-            <dd>For collaboration on semantic interoperability in terms of information model and protocol binding.</dd>
+            <dd>For collaboration on semantic interoperability in terms of information model, protocol binding, and security.</dd>
             <dt><a href="http://www.plattform-i40.de/I40/Navigation/EN/Home/home.html">Plattform Industrie 4.0</a></dt>
             <dd>For collaboration on use cases and requirements for smart manufacturing, including semantic interoperability and end to end security across platforms.</dd>
             <dt><a href="http://www.onem2m.org">oneM2M</a></dt>


### PR DESCRIPTION
I updated the text for OPC UA + add eCl@ss as new cooperation partner for the Web of Things.

In general, we should check whether the text is still valid and makes sense for all other organizations.