### PR TITLE
A few editorial change suggestions.

### DIFF
--- a/charters/wot-wg-charter-draft-2019.html
+++ b/charters/wot-wg-charter-draft-2019.html
@@ -262,7 +262,7 @@
         </p>
 	<p>
           Candidates for link relation type specification include part-of and subtype-of 
-          relationships to support Templates and Components, respectively.
+          relationships to support Components and Templates, respectively.
           Other link types may be used to identify location or controller-controlled 
           relationships.
         </p>
@@ -382,7 +382,7 @@
           the metadata required to access a Thing was defined: the
           <a href="http://www.w3.org/TR/wot-thing-description">WoT Thing Description (TD)</a>.
           However, no mechanism was defined for the distribution of TDs.
-          This is important since to preserve privacy, TDs should only
+          To preserve privacy, TDs should only
           be distributed to parties with a permission to access the data.
           However, we also wish to support flexible discovery of the services
           and devices described by WoT TDs.


### PR DESCRIPTION
> Candidates for link relation type specification include part-of and subtype-of relationships to support Templates and Components, respectively. Other link types may be used to identify location or controller-controlled relationships. 

"part-of" relation is about Components, and "subtype-of" relations is about Templates.

> During the previous charter a format for the storage of the metadata required to access a Thing was defined: the WoT Thing Description (TD). However, no mechanism was defined for the distribution of TDs. This is important since...

I am not sure if it is wise to stress that it was important not to define access mechanisms.