### PR TITLE
Changed "This is important" to "This mechanism is important".

### DIFF
--- a/charters/wot-wg-charter-draft-2019.html
+++ b/charters/wot-wg-charter-draft-2019.html
@@ -391,7 +391,7 @@
           the metadata required to access a Thing was defined: the
           <a href="http://www.w3.org/TR/wot-thing-description">WoT Thing Description (TD)</a>.
           However, no mechanism was defined for the distribution of TDs.
-          This is important since to preserve privacy, TDs should only
+          This mechanism is important since to preserve privacy, TDs should only
           be distributed to parties with permission to access the data.
           However, we also wish to support flexible discovery of the services
           and devices described by WoT TDs.


### PR DESCRIPTION
The phrase "This mechanism is important" is clearer.

With "This is important", what this "this" points to is subject to interpretation.