### PR TITLE
Up-level description of profiles in WG Charter draft

### DIFF
--- a/charters/wot-wg-charter-draft-2019.html
+++ b/charters/wot-wg-charter-draft-2019.html
@@ -196,7 +196,7 @@
             <dt><strong>Link Relation Types:</strong></dt>
             <dd>Define link relation types for specific relationships.</dd>
             <dt><strong>Interoperability Profiles:</strong></dt>
-            <dd>Support plug-and-play interoperabilty via a profile mechanism and define profiles for specific application domains and use cases.</dd>
+            <dd>Support plug-and-play interoperabilty via a profile mechanism that defines specific subsets of TDs.</dd>
             <dt><strong>Thing Description Templates:</strong></dt>
             <dd>Define a mechanism to describe classes of things and an inheritance mechanism.
             and define how Thing Descriptions can defined in a modular way.</dd>
@@ -296,8 +296,7 @@
         </p>
         <p>
           To resolve this problem this work item will define "profiles" which
-          define subsets of TDs supporting only the features
-          suitable for a given context.  
+          define subsets of TDs supporting only specific technologies.
           This work item will include the following:
           <ol>
             <li>
@@ -305,8 +304,7 @@
                or profiles that a given TD is conformant to.
             </li>
             <li>
-               Definition of profiles for specific application domains
-               and use cases.
+               Definition of specific profiles.
             </li>
           </ol>
         </p>


### PR DESCRIPTION
As discussed in the WG Charter call on Oct 3, 2019, modify the description of the "Interoperability Profiles" work item to remove "applications and use cases" from the specific deliverables, since this has not been decided, and we may (for example) just focus profiles on mechanisms (eg protocols) rather than contexts.

This modification makes the description more general to give us more room to discuss and decide these issues as a group.

This is in response to feedback on the definition of profiles raised in issue https://github.com/w3c/wot/issues/873

NOTE: the version we looked at in the call was not the head version, so the modifications are not exactly what we discussed but are in the same spirit.   For this reason I am not merging immediately but will wait for feedback and confirmation.