### PR TITLE
Remove implementation view specification work item from WG Charter draft

### DIFF
--- a/charters/wot-wg-charter-draft-2019.html
+++ b/charters/wot-wg-charter-draft-2019.html
@@ -216,8 +216,6 @@
             <dd>Extensions to protocol vocabulary definitions and protocol bindings.</dd> 
             <dt><strong>Observe Defaults:</strong></dt>
             <dd>For protocols such as HTTP where multiple ways to implement "observe" is possible, define a default.</dd>
-            <dt><strong>Implementation View Spec:</strong></dt>
-            <dd>More fully define details of implementations.</dd>
           </dl>
         </div>
 	    
@@ -588,22 +586,6 @@
           but most especially HTTP.
         </p>
 
-        <h3>Implementation View Specification</h3>
-        <p>The
-          <a href="http://www.w3.org/TR/wot-thing-description">WoT Thing Description (TD)</a>
-          specification describes a data format but is currently silent on several aspects of
-          implementations that produce or consume TDs.
-          In order to better support interoperability,
-          more guidance on particular details of implementation is needed.
-        </p>
-        <p>
-          This work item would more fully specify implementation details 
-          such as error responses, common features, and
-          consistency between JSON and JSON-LD implementations.
-          These implementation details might be relative to specific profiles or protocols.
-        </p>
-
-          
         <section id="section-out-of-scope">
           <h3 id="out-of-scope">Out of Scope</h3>
             <p>The following features are out of scope,


### PR DESCRIPTION
WIP: Do not merge. This is one of two possible resolutions to the same issue and needs to be discussed before merging.

This addresses one of the feedback points raised in Issue #873, which noted that the "Implementation View Spec" seemed redundant with other work items and also seemed to imply another deliverable.

This PR removes the "Implementation View Specification" work item completely.

See also PR https://github.com/w3c/wot/pull/887, which renames this section instead of removing it.  These are mutually exclusive options.