### PR TITLE
Rename 'Implementation View Spec' to 'Implementation Details' in WG Charter draft

### DIFF
--- a/charters/wot-wg-charter-draft-2019.html
+++ b/charters/wot-wg-charter-draft-2019.html
@@ -216,7 +216,7 @@
             <dd>Extensions to protocol vocabulary definitions and protocol bindings.</dd> 
             <dt><strong>Observe Defaults:</strong></dt>
             <dd>For protocols such as HTTP where multiple ways to implement "observe" is possible, define a default.</dd>
-            <dt><strong>Implementation View Spec:</strong></dt>
+            <dt><strong>Implementation Details:</strong></dt>
             <dd>More fully define details of implementations.</dd>
           </dl>
         </div>
@@ -588,7 +588,7 @@
           but most especially HTTP.
         </p>
 
-        <h3>Implementation View Specification</h3>
+        <h3>Implementation Details</h3>
         <p>The
           <a href="http://www.w3.org/TR/wot-thing-description">WoT Thing Description (TD)</a>
           specification describes a data format but is currently silent on several aspects of


### PR DESCRIPTION
WIP: Do not merge.  This is one of two possible resolutions to the same issue and needs to be discussed before merging.

This addresses one of the feedback points raised in Issue https://github.com/w3c/wot/issues/873, which noted that the "Implementation View Spec" seemed redundant with other work items and also seemed to imply another deliverable.

This PR renames this section to "Implementation Details" since it is in fact a work item, not a separate specification, and these intent was just to add implementation details where appropriate to other specifications, not to create another deliverable.  

See also PR https://github.com/w3c/wot/pull/886, which removes this section instead of renaming it. These are mutually exclusive options.