### PR TITLE
Remove normative 'Architecture Update' deliverable from WG Charter draft

### DIFF
--- a/charters/wot-wg-charter-draft-2019.html
+++ b/charters/wot-wg-charter-draft-2019.html
@@ -191,8 +191,6 @@
           <p style="text-align:left;font-style:italic">Scope Summary</p>
           
           <dl>
-	    <dt><strong>Architectural Requirements, Use Cases, and Vocabulary</strong></dt>
-            <dd>Understand and describe requirements of new use cases, architectural patterns, and concepts.</dd>
             <dt><strong>Link Relation Types:</strong></dt>
             <dd>Define link relation types for specific relationships.</dd>
             <dt><strong>Interoperability Profiles:</strong></dt>
@@ -222,26 +220,6 @@
         </div>
 	    
         <p>Details for each of these are given below.</p>
-
-	<h3>Architectural Requirements, Use Cases, and Vocabulary</h3>
-        <p>
-          The <a href="https://www.w3.org/TR/wot-architecture">WoT Architecture</a>
-          specification includes the definitions of several terms and concepts used to
-          define WoT specifications.  These are often related closely to use cases
-          and architectural patterns.  As WoT implementations mature, it will be 
-          necessary to understand and describe the requirements for new use cases, 
-          architectural patterns, and associated concepts and vocabulary.  
-          In addition, descriptions of existing use cases and
-          architectural patterns may need to be revisited to include
-          these new concepts.
-        </p>
-	<p>
-          Candidates for architectural vocabulary extension include a 
-          TD Producer concept and definition and description of states and transitions 
-          for device and information lifecycles.
-          The information lifecycle is especially relevant to the protection
-          of privacy.
-        </p>
 
 	<h3>Link Relation Types</h3>
 	<p>
@@ -652,30 +630,6 @@
             The Working Group will deliver the following W3C normative specifications:
           </p>
           <dl>
-            <dt id="wot-arch-next" class="spec"><a href="#">Web of Things (WoT) Architecture (Update)</a></dt>
-            <dd>
-              <p>This specification defines the Web of Things architecture, including 
-                 its use cases and terminology.
-                 This deliverable extends the current Web of Things Architecture document to
-                 address new requirements and use cases,
-                 and to clarify existing definitions.
-              </p>
-
-              <p class="draft-status"><b>Draft state:</b> <a href="#">Adopted from Web of Things Working Group</a></p>
-              <p class="milestone"><b>Expected completion:</b> Q4 2020</p>
-              <dl><dt>
-                <p><b>Reference Draft:</b><br/> 
-                        Web of Things (WoT) Architecture,<br/>
-                        Latest publication: 16 May 2019,<br/>
-                        <a href="https://www.w3.org/TR/2019/CR-wot-architecture-20190516/">https://www.w3.org/TR/2019/CR-wot-architecture-20190516/</a>,</br> 
-                <!-- The <span class="todo">title, stable URL, and publication date of the most recent <a href='https://github.com/w3c/charter-drafts/blob/gh-pages/draft-states.md#reference-draft'>Reference Draft</a> or Candidate Recommendation</span> which triggered an Exclusion Opportunity per the Patent Process.
-        <span class="todo">Exclusion period <b>began</b>; Exclusion period <b>ended</b>.</span> <span class='todo'>(this <a href="https://www.w3.org/2004/01/pp-impl/charter-assistant?wgid=95969">charter assistant</a> helps in producing the list.)</span>
--->
-associated Call for Exclusion on 14 December 2017 ended on 11 February 2018.<br/>
-      <p>Produced under <b>Working Group Charter:</b> <a href="https://www.w3.org/2016/12/wot-wg-2016.html">https://www.w3.org/2016/12/wot-wg-2016.html</a>
-    </dd>
-              </dl>
-
             <dt id="wot-td-update" class="spec"><a href="#">Web of Things (WoT) Thing Description (Update)</a></dt>
             <dd>
               <p>This specification defines the Web of Things Thing Description information model
@@ -742,11 +696,12 @@ associated Call for Exclusion on 14 December 2017 ended on 11 February 2018.<br/
             Other Deliverables
           </h3>
           <p>
-            Other non-normative documents may be created such as:
+            Other non-normative documents may be created or updated such as:
           </p>
           <ul>
             <li>Use case and requirement documents;</li>
             <li>Test suites and implementation reports for the specifications;</li>
+            <li>WoT Architecture (W3C Note);</li>
             <li>WoT Security and Privacy Guidelines (W3C Note);</li>
             <li>WoT Security and Privacy Best Practices (W3C Note);</li>
             <li>WoT Protocol Bindings (W3C Note);</li>
@@ -769,7 +724,6 @@ associated Call for Exclusion on 14 December 2017 ended on 11 February 2018.<br/
             <ul>
               <li>November 2019: Requirements and Use Cases for <a href="#wot-profiles">WoT Interoperability Profiles</a></li>
               <li>November 2019: Requirements and Use Cases for <a href="#wot-discovery">WoT Discovery</a></li>
-              <li>November 2019: Requirements and Use Cases for <a href="#wot-architecture-update">WoT Architecture (Update)</a></li>
               <li>November 2019: Requirements and Use Cases for <a href="#wot-thing-description-update">WoT Thing Description (Update)</a></li>
               <li>November 2019: Face-to-face meeting and plugfest (Singapore)</li>
             </ul>
@@ -786,7 +740,6 @@ associated Call for Exclusion on 14 December 2017 ended on 11 February 2018.<br/
             <dt><b>Q2 2020</b></dt>
             <dd>
             <ul>
-              <li>April 2020: FPWD for <a href="#wot-architecture-update">WoT Architecture (Update)</a></li>
               <li>April 2020: FPWD for <a href="#wot-thing-description-update">WoT Thing Description (Update)</a></li>
               <li><b>May 2020:</b> PR for <a href="#wot-profiles">WoT Interoperability Profiles</a></li>
             </ul>
@@ -795,7 +748,6 @@ associated Call for Exclusion on 14 December 2017 ended on 11 February 2018.<br/
             <dd>
             <ul>
               <li>July 2020: Face-to-face meeting and plugfest</li>
-              <li>July 2020: CR for <a href="#wot-architecture-update">WoT Architecture (Update)</a></li>
               <li>July 2020: CR for <a href="#wot-thing-description-update">WoT Thing Description (Update)</a></li>
               <li>September 2020: Face-to-face meeting and plugfest (TPAC)</li>
               <li>September 2020: Requirements and Use Cases for <a href="#wot-thing-description-next">WoT Thing Description (Next)</a></li>
@@ -805,7 +757,6 @@ associated Call for Exclusion on 14 December 2017 ended on 11 February 2018.<br/
             <dd>
             <ul>
               <li>October 2020: CR for <a href="#wot-discovery">WoT Discovery</a></li>
-              <li><b>October 2020:</b> PR for <a href="#wot-architecture-update">WoT Architecture (Update)</a></li>
               <li><b>October 2020:</b> PR for <a href="#wot-thing-description-update">WoT Thing Description (Update)</a></li>
             </ul>
             </dd>


### PR DESCRIPTION
**WIP: Do not merge!** This proposed change to the new WG charter is based on an upstream change to our specification strategy under our *current* charter and *definitely* needs more discussion before merging.

This is in response to feedback given in issue https://github.com/w3c/wot/issues/873 proposing that the current Architecture document should be informative, not normative.

Arguments in support of making the current Architecture document informative (and publishing it as a W3C Note) include the fact that it does not include (significant) normative content that could not be included in the TD specification, and does not have an implementation report.

If we do make this change in then it means we can focus on the TD spec for the next PR/CR transition, and can place all normative content there, simplifying the review process.  If we do this, however, then the next WG charter should not, of course, talk about a normative deliverable that updates the Architecture document.   This PR therefore removes that deliverable, work items related to it, and mentions of this deliverable in the timeline.

One thing we do have to discuss is whether definitions of special terms (Consumer, etc) can be given in the Architecture document and referenced by the TD document if the Architecture document is merely informative.   On the other hand, the TD document uses relatively few of the terms defined in the Architecture document and the ones that it does use can be defined in the TD spec.