### PR TITLE
Update privacy.md

### DIFF
--- a/proposals/privacy.md
+++ b/proposals/privacy.md
@@ -7,8 +7,7 @@ optional so that they can be filtered out in privacy-sensitive contexts.
 
 This document summarizes the proposed changes so that they can be reviewed in joint meetings between the WoT WG and the Privacy IG.
 
-We will focus on the TD specification, as we are currently discussing making the Architecture document informative.
-Therefore we propose consolidating the privacy and security considerations (and new normative statements) into
+We propose consolidating the privacy and security considerations (and new normative statements) into
 a single normative specification, the *Web of Things (WoT) Thing Description*.
 Changes to the TD specification will include changes to existing assertions and normative content
 and new assertions in a new normative "Privacy Mitigations" section.
@@ -103,23 +102,28 @@ a particular person.  We will call these "privacy sensitive contexts".
 
 ### TDs MUST not contain PII.
 For example, a TD must not contain the email of a person with which it is associated or embed their name, address, or other PII 
-in a description or title field.
+in a description or title field, unless specifically required by the use cases. 
+ML: It must be under the descretion of the owner of the thing to chose to whom to expose which PII.
+There are cases where a TD without PII is useless.
 
 ### TDs MUST be transmitted only to Authenticated and Authorized consumers.
 Services providing TDs must require authentication (for example, using OAuth or PKI) of the requester to ensure they
 are who they say they are.  In addition, the system needs to ensure that the requester is authorized to receive TDs.
 
 ### Consumers MUST accept TDs only from Authenticated producers
-In other words, communication of TDs between producers and consumers must be over mutually authenticated channels.
+In other words, communication of TDs between producers and consumers must be over mutually authenticated channels,
+or the authenticity of a producer is validated by some other means (e.g. cryptographic signatures).
 
 ### TDs provided to a Consumer MUST be filtered to remove any optional information not required by that Consumer.
 For example, if a Consumer does not need human-readable titles or descriptions in a TD, these should be removed.
+ML: How does a producer know about the capabilities / requirements of a consumer? We don't have a mechanism to convey this information. In many scenarios a TD producer does not know about the potential consumers. This comment applies also o the points below.
 If a Consumer does not need to maintain state related to the consumed device, then an ID is not necessary and should be omitted.
 If a Consumer does not do semantic processing, then all semantic annotations can be omitted.
+ML: It still is useful for documentation purposes and should be preserved.
 If a Consumer does not do link processing then links should be omitted.
 Metadata (such as TD creation time) should be omitted if the Consumer does not need it.
 If the Consumer already "knows" the Data Schema or does not process the data (for example, if it only caches it) then data schemas can
-be omitted; likewise for URI templates.
+be omitted; likewise for URI templates. ML: How is this "knowledge" conveyed to the consumer?
 
 ### Mechanisms to request TDs MUST include query parameters to specify the information provided.
 The mechanism to request a TD should include query parameters to state the kinds of information necessary and the delivered
@@ -132,14 +136,18 @@ links (identified by relation type);
 metadata (creation time, modification time, support, and version information);
 data schemas;
 and URI templates.
+ML: This mechanism is not part of the current specs.
 
 ### TDs MUST be protected by encryption when at rest.
 TDs must be stored in an encrypted data store, and access to this store should be limited to authorized users.
+ML: This goes a bit far - We should constrain it to "TDs containing PII"
 
 ### TDs MUST be protected by encryption when transmitted.
+ML: again constrain to "TDs with PII"
 TDs must not be transmitted in plaintext.
 
 ### TDs MUST be stored in Consumers for only a limited time appropriate to the application.
+ML: again constrain to "TDs with PII"
 Note that this rule does not apply to Producers or system inventory managers, which may need to store
 TDs for the lifetime of the device.
 
@@ -166,6 +174,7 @@ if the data is protected by another layer of authentication and encryption, for 
 carried on a private network (for example, an encrypted VLAN).
 
 ### Context files MUST NOT be dereferenced if these dereferences can be associated with specific Things
+ML: This is a requirement for a consumer that cannot be enforced.
 Context file dereferences can cause a privacy issue similar to a DNS leak.
 Therefore Consumers should use the URLs given in the context field of a TD only to 
 identify vocabularies already "known" (built-in) to the Consumer.


### PR DESCRIPTION
This is a great draft.
A couple of comments:

1. Most of these "Mandatory privacy mitigations" only are applicable to devices containing PII.
I understand your goal of minimizing the exposed information, however this requires a communication mechanism about the capabilities / information needs of the consumer. Even if such mechanism would be in place, you can still write a malicious client that just asks "give me everything you can provide".

2. It does not make sense to remove all ids, titles, other data from devices that are not critical, e.g. in home scenarios you may want to clearly identify all Hue lamps and associate them to specific rooms. In the home we make some "trust" assumptions about what devices may expose. However we might want to revisit that and also recommend to assume an "untrusted" relationship and require authentication/authorisation. 

3. I would not communicate outside the WG about the discussion wrt normative/informative architecture spec.
This conversation just started within the WoT group and has not reached consensus.