### PR TITLE
Remove remaining reference to profiles for different application domains in WG Charter draft

### DIFF
--- a/charters/wot-wg-charter-draft-2019.html
+++ b/charters/wot-wg-charter-draft-2019.html
@@ -698,7 +698,7 @@ associated Call for Exclusion on 14 December 2017 ended on 11 February 2018.<br/
 
             <dt id="wot-profiles" class="spec"><a href="#">Web of Things (WoT) Interoperability Profiles</a></dt>
             <dd>
-              <p>This specification defines profiles for using the Web of Things in specific application domains and use cases.
+              <p>This specification defines profiles for subsets of TDs to enable plug-and-play interoperability.
               </p>
 
               <p class="draft-status"><b>Draft state:</b> <a href="#">Editor's Draft</a></p>


### PR DESCRIPTION
@mmccool I think in https://github.com/w3c/wot/pull/885 you missed one reference to profiles for different "application domains".

This PR changes the wording to be as close as possible to the wording elsewhere in the charter.