### PR TITLE
add Web&Networks IG

### DIFF
--- a/charters/wot-ig-2019.html
+++ b/charters/wot-ig-2019.html
@@ -347,16 +347,18 @@
             <dd>For collaboration on JSON-LD features and WoT use cases.</dd>
             <dt><a href="https://www.w3.org/community/exi-next/">Efficient Extensible Interchange Community Group</a></dt>
             <dd>In relation to efficient interchange for Thing Descriptions.</dd>
-            <dt><a href="http://www.w3.org/auto/">Web and Automotive Business &amp; Working Groups</a></dt>
+            <dt><a href="https://www.w3.org/auto/">Web and Automotive Business &amp; Working Groups</a></dt>
             <dd>For collaboration on technologies and requirements relating to connected cars and the Web of Things.</dd>
-            <dt><a href="http://www.w3.org/2009/dap/">Device and Sensors Working Group</a></dt>
+            <dt><a href="https://www.w3.org/2009/dap/">Device and Sensors Working Group</a></dt>
             <dd>For coordination on APIs for sensors and actuators.</dd>
             <dt><a href="https://www.w3.org/WAI/APA/">Accessible Platform Architectures Working Group</a></dt>
             <dd>For coordination on development of use cases and requirements, and impact of Web of Things technologies on accessibility for users with disabilities.</dd>
-            <dt><a href="http://www.w3.org/Privacy/">Privacy Interest Group</a></dt>
+            <dt><a href="https://www.w3.org/Privacy/">Privacy Interest Group</a></dt>
             <dd>For collaboration on privacy considerations for the Web of Things.</dd>
-            <dt><a href="http://www.w3.org/International/">Internationalization Interest Group</a></dt>
+            <dt><a href="https://www.w3.org/International/">Internationalization Interest Group</a></dt>
             <dd>For collaboration on internationalization considerations for the Web of Things.</dd>
+            <dt><a href="https://www.w3.org/web-networks/">Web &amp; Networks Interest Group</a></dt>
+            <dd>For collaboration on networking technologies on the edge and in the cloud when exposing interactions between Things.</dd>
           </dl>
         
         </section>
@@ -423,7 +425,7 @@
 
         <p id="public">Technical discussions for this Interest Group are conducted in <a href="https://www.w3.org/2019/Process-20190301/#confidentiality-levels">public</a>. Meeting minutes from teleconference and face-to-face meetings will be archived for public review, and technical discussions and issue tracking will be conducted in a manner that can be both read and written to by the general public.</p>
 
-        <p>Information about the group (including details about deliverables, issues, actions, status, participants, and meetings) will be available from the <a href="http://www.w3.org/WoT/IG/">Web of Things Interest Group home page.</a></p>
+        <p>Information about the group (including details about deliverables, issues, actions, status, participants, and meetings) will be available from the <a href="https://www.w3.org/WoT/IG/">Web of Things Interest Group home page.</a></p>
 
         <p>Most Web of Things Interest Group teleconferences will focus on discussion of particular specifications and will be conducted on an as-needed basis.</p>
 


### PR DESCRIPTION
adding the Web&Networks IG to the section "4.1 W3C Groups" of the proposed WoT IG Charter based on the feedback from the AC Review.

FYI, the
<a href="https://cdn.statically.io/gh/w3c/wot/add-web%2Bnetworks-ig/charters/wot-ig-2019.html?env=dev">HTML rendered version</a> with the proposed update is available.