### PR TITLE
Adjust dates for first two quarters in WG Charter Draft assuming Dec 1 start

### DIFF
--- a/charters/wot-wg-charter-draft-2019.html
+++ b/charters/wot-wg-charter-draft-2019.html
@@ -674,7 +674,7 @@ associated Call for Exclusion on 14 December 2017 ended on 11 February 2018.<br/
               </p>
 
               <p class="draft-status"><b>Draft state:</b> <a href="#">Editor's Draft</a></p>
-              <p class="milestone"><b>Expected completion:</b> Q2 2020</p>
+              <p class="milestone"><b>Expected completion:</b> Q3 2020</p>
               <p><b>Editor's Draft:</b> 
                  <a href="https://w3c.github.io/wot-profile/">https://w3c.github.io/wot-profile/</a> 
 

--- a/charters/wot-wg-charter-draft-2019.html
+++ b/charters/wot-wg-charter-draft-2019.html
@@ -748,33 +748,28 @@ associated Call for Exclusion on 14 December 2017 ended on 11 February 2018.<br/
             This has been aligned with publication process requirements and deliverable targets, above.
 	    <br/>
             <em><strong>NOTE: Dates will be adjusted once the starting date has been defined.   The below dates were
-		    computed from a November 1 starting date.</strong></em>
+		    computed from a December 1 starting date.</strong></em>
             </p>
             <dl>
-            <dt><b>Q4 2019</b></dt>
-            <dd>
-            <ul>
-              <li>December 2019: Requirements and Use Cases for <a href="#wot-profiles">WoT Interoperability Profiles</a></li>
-              <li>December 2019: Requirements and Use Cases for <a href="#wot-discovery">WoT Discovery</a></li>
-              <li>December 2019: Requirements and Use Cases for <a href="#wot-architecture-update">WoT Architecture (Update)</a></li>
-              <li>December 2019: Requirements and Use Cases for <a href="#wot-thing-description-update">WoT Thing Description (Update)</a></li>
-            </ul>
-            </dd>
             <dt><b>Q1 2020</b></dt>
             <dd>
             <ul>
-              <li>January 2020: FPWD for <a href="#wot-profiles">WoT Interoperability Profiles</a></li>
-              <li>February 2020: FPWD for <a href="#wot-discovery">WoT Discovery</a></li>
+              <li>January 2020: Requirements and Use Cases for <a href="#wot-profiles">WoT Interoperability Profiles</a></li>
+              <li>January 2020: Requirements and Use Cases for <a href="#wot-discovery">WoT Discovery</a></li>
+              <li>January 2020: Requirements and Use Cases for <a href="#wot-architecture-update">WoT Architecture (Update)</a></li>
+              <li>January 2020: Requirements and Use Cases for <a href="#wot-thing-description-update">WoT Thing Description (Update)</a></li>
+              <li>February 2020: FPWD for <a href="#wot-profiles">WoT Interoperability Profiles</a></li>
+              <li>March 2020: FPWD for <a href="#wot-discovery">WoT Discovery</a></li>
               <li>March 2020: Face-to-face meeting and plugfest</li>
-              <li>March 2020: CR for <a href="#wot-profiles">WoT Interoperability Profiles</a></li>
             </ul>
             </dd>
             <dt><b>Q2 2020</b></dt>
             <dd>
             <ul>
-              <li>April 2020: FPWD for <a href="#wot-architecture-update">WoT Architecture (Update)</a></li>
-              <li>April 2020: FPWD for <a href="#wot-thing-description-update">WoT Thing Description (Update)</a></li>
-              <li><b>May 2020:</b> PR for <a href="#wot-profiles">WoT Interoperability Profiles</a></li>
+              <li>April 2020: CR for <a href="#wot-profiles">WoT Interoperability Profiles</a></li>
+              <li>May 2020: FPWD for <a href="#wot-architecture-update">WoT Architecture (Update)</a></li>
+              <li>May 2020: FPWD for <a href="#wot-thing-description-update">WoT Thing Description (Update)</a></li>
+              <li><b>June 2020:</b> PR for <a href="#wot-profiles">WoT Interoperability Profiles</a></li>
             </ul>
             </dd>
             <dt><b>Q3 2020</b></dt>

--- a/charters/wot-wg-charter-draft-2019.html
+++ b/charters/wot-wg-charter-draft-2019.html
@@ -770,12 +770,12 @@ associated Call for Exclusion on 14 December 2017 ended on 11 February 2018.<br/
               <li>May 2020: FPWD for <a href="#wot-architecture-update">WoT Architecture (Update)</a></li>
               <li>May 2020: FPWD for <a href="#wot-thing-description-update">WoT Thing Description (Update)</a></li>
               <li><b>June 2020:</b> PR for <a href="#wot-profiles">WoT Interoperability Profiles</a></li>
+	      <li>June 2020: Face-to-face meeting and plugfest</li>
             </ul>
             </dd>
             <dt><b>Q3 2020</b></dt>
             <dd>
             <ul>
-              <li>July 2020: Face-to-face meeting and plugfest</li>
               <li>July 2020: CR for <a href="#wot-architecture-update">WoT Architecture (Update)</a></li>
               <li>July 2020: CR for <a href="#wot-thing-description-update">WoT Thing Description (Update)</a></li>
               <li>September 2020: Face-to-face meeting and plugfest (TPAC)</li>

--- a/charters/wot-wg-charter-draft-2019.html
+++ b/charters/wot-wg-charter-draft-2019.html
@@ -766,28 +766,28 @@ associated Call for Exclusion on 14 December 2017 ended on 11 February 2018.<br/
             <dt><b>Q2 2020</b></dt>
             <dd>
             <ul>
-              <li>April 2020: CR for <a href="#wot-profiles">WoT Interoperability Profiles</a></li>
+              <li>May 2020: CR for <a href="#wot-profiles">WoT Interoperability Profiles</a></li>
               <li>May 2020: FPWD for <a href="#wot-architecture-update">WoT Architecture (Update)</a></li>
               <li>May 2020: FPWD for <a href="#wot-thing-description-update">WoT Thing Description (Update)</a></li>
-              <li><b>June 2020:</b> PR for <a href="#wot-profiles">WoT Interoperability Profiles</a></li>
 	      <li>June 2020: Face-to-face meeting and plugfest</li>
             </ul>
             </dd>
             <dt><b>Q3 2020</b></dt>
             <dd>
             <ul>
-              <li>July 2020: CR for <a href="#wot-architecture-update">WoT Architecture (Update)</a></li>
-              <li>July 2020: CR for <a href="#wot-thing-description-update">WoT Thing Description (Update)</a></li>
-              <li>September 2020: Face-to-face meeting and plugfest (TPAC)</li>
+              <li><b>July 2020:</b> PR for <a href="#wot-profiles">WoT Interoperability Profiles</a></li>
+              <li>September 2020: CR for <a href="#wot-architecture-update">WoT Architecture (Update)</a></li>
+              <li>September 2020: CR for <a href="#wot-thing-description-update">WoT Thing Description (Update)</a></li>
               <li>September 2020: Requirements and Use Cases for <a href="#wot-thing-description-next">WoT Thing Description (Next)</a></li>
             </ul>
             </dd>
             <dt><b>Q4 2020</b></dt>
             <dd>
             <ul>
+	      <li>October 2020: Face-to-face meeting and plugfest (TPAC)</li>
               <li>October 2020: CR for <a href="#wot-discovery">WoT Discovery</a></li>
-              <li><b>October 2020:</b> PR for <a href="#wot-architecture-update">WoT Architecture (Update)</a></li>
-              <li><b>October 2020:</b> PR for <a href="#wot-thing-description-update">WoT Thing Description (Update)</a></li>
+              <li><b>November 2020:</b> PR for <a href="#wot-architecture-update">WoT Architecture (Update)</a></li>
+              <li><b>November 2020:</b> PR for <a href="#wot-thing-description-update">WoT Thing Description (Update)</a></li>
             </ul>
             </dd>
             <dt><b>Q1 2021</b></dt>
@@ -807,14 +807,14 @@ associated Call for Exclusion on 14 December 2017 ended on 11 February 2018.<br/
             <dt><b>Q3 2021</b></dt>
             <dd>
             <ul>
-              <li>July 2021: CR for <a href="#wot-thing-description-next">WoT Thing Description (Next)</a></li>
+              <li>September 2021: CR for <a href="#wot-thing-description-next">WoT Thing Description (Next)</a></li>
               <li>September 2021: Face-to-face meeting and plugfest (TPAC)</li>
             </ul>
             </dd>
             <dt><b>Q4 2021</b></dt>
             <dd>
             <ul>
-              <li><b>October 2021:</b> PR for <a href="#wot-thing-description-next">WoT Thing Description (Next)</a></li>
+              <li><b>November 2021:</b> PR for <a href="#wot-thing-description-next">WoT Thing Description (Next)</a></li>
             </ul>
             </dd>
            </dl>

--- a/charters/wot-wg-charter-draft-2019.html
+++ b/charters/wot-wg-charter-draft-2019.html
@@ -604,7 +604,7 @@
             The Working Group will deliver the following W3C normative specifications:
           </p>
           <dl>
-            <dt id="wot-arch-next" class="spec">Web of Things (WoT) Architecture (Update)</dt>
+            <dt id="wot-arch-update" class="spec">Web of Things (WoT) Architecture (Update)</dt>
             <dd>
               <p>This specification defines the Web of Things architecture, including 
                  its use cases and terminology.
@@ -756,8 +756,8 @@ associated Call for Exclusion on 14 December 2017 ended on 11 February 2018.<br/
             <ul>
               <li>January 2020: Requirements and Use Cases for <a href="#wot-profiles">WoT Interoperability Profiles</a></li>
               <li>January 2020: Requirements and Use Cases for <a href="#wot-discovery">WoT Discovery</a></li>
-              <li>January 2020: Requirements and Use Cases for <a href="#wot-architecture-update">WoT Architecture (Update)</a></li>
-              <li>January 2020: Requirements and Use Cases for <a href="#wot-thing-description-update">WoT Thing Description (Update)</a></li>
+              <li>January 2020: Requirements and Use Cases for <a href="#wot-arch-update">WoT Architecture (Update)</a></li>
+              <li>January 2020: Requirements and Use Cases for <a href="#wot-td-update">WoT Thing Description (Update)</a></li>
               <li>February 2020: FPWD for <a href="#wot-profiles">WoT Interoperability Profiles</a></li>
               <li>March 2020: FPWD for <a href="#wot-discovery">WoT Discovery</a></li>
               <li>March 2020: Face-to-face meeting and plugfest</li>
@@ -767,8 +767,8 @@ associated Call for Exclusion on 14 December 2017 ended on 11 February 2018.<br/
             <dd>
             <ul>
               <li>May 2020: CR for <a href="#wot-profiles">WoT Interoperability Profiles</a></li>
-              <li>May 2020: FPWD for <a href="#wot-architecture-update">WoT Architecture (Update)</a></li>
-              <li>May 2020: FPWD for <a href="#wot-thing-description-update">WoT Thing Description (Update)</a></li>
+              <li>May 2020: FPWD for <a href="#wot-arch-update">WoT Architecture (Update)</a></li>
+              <li>May 2020: FPWD for <a href="#wot-td-update">WoT Thing Description (Update)</a></li>
 	      <li>June 2020: Face-to-face meeting and plugfest</li>
             </ul>
             </dd>
@@ -776,9 +776,9 @@ associated Call for Exclusion on 14 December 2017 ended on 11 February 2018.<br/
             <dd>
             <ul>
               <li><b>July 2020:</b> PR for <a href="#wot-profiles">WoT Interoperability Profiles</a></li>
-              <li>September 2020: CR for <a href="#wot-architecture-update">WoT Architecture (Update)</a></li>
-              <li>September 2020: CR for <a href="#wot-thing-description-update">WoT Thing Description (Update)</a></li>
-              <li>September 2020: Requirements and Use Cases for <a href="#wot-thing-description-next">WoT Thing Description (Next)</a></li>
+              <li>September 2020: CR for <a href="#wot-arch-update">WoT Architecture (Update)</a></li>
+              <li>September 2020: CR for <a href="#wot-td-update">WoT Thing Description (Update)</a></li>
+              <li>September 2020: Requirements and Use Cases for <a href="#wot-td-next">WoT Thing Description (Next)</a></li>
             </ul>
             </dd>
             <dt><b>Q4 2020</b></dt>
@@ -786,8 +786,8 @@ associated Call for Exclusion on 14 December 2017 ended on 11 February 2018.<br/
             <ul>
 	      <li>October 2020: Face-to-face meeting and plugfest (TPAC)</li>
               <li>October 2020: CR for <a href="#wot-discovery">WoT Discovery</a></li>
-              <li><b>November 2020:</b> PR for <a href="#wot-architecture-update">WoT Architecture (Update)</a></li>
-              <li><b>November 2020:</b> PR for <a href="#wot-thing-description-update">WoT Thing Description (Update)</a></li>
+              <li><b>November 2020:</b> PR for <a href="#wot-arch-update">WoT Architecture (Update)</a></li>
+              <li><b>November 2020:</b> PR for <a href="#wot-td-update">WoT Thing Description (Update)</a></li>
             </ul>
             </dd>
             <dt><b>Q1 2021</b></dt>
@@ -795,7 +795,7 @@ associated Call for Exclusion on 14 December 2017 ended on 11 February 2018.<br/
             <ul>
               <li>February 2021: Face-to-face meeting and plugfest</li>
               <li><b>March 2021:</b> PR for <a href="#wot-discovery">WoT Discovery</a></li>
-              <li>March 2021: FPWD for <a href="#wot-thing-description-next">WoT Thing Description (Next)</a></li>
+              <li>March 2021: FPWD for <a href="#wot-td-next">WoT Thing Description (Next)</a></li>
             </ul>
             </dd>
             <dt><b>Q2 2021</b></dt>
@@ -807,14 +807,14 @@ associated Call for Exclusion on 14 December 2017 ended on 11 February 2018.<br/
             <dt><b>Q3 2021</b></dt>
             <dd>
             <ul>
-              <li>September 2021: CR for <a href="#wot-thing-description-next">WoT Thing Description (Next)</a></li>
+              <li>September 2021: CR for <a href="#wot-td-next">WoT Thing Description (Next)</a></li>
               <li>September 2021: Face-to-face meeting and plugfest (TPAC)</li>
             </ul>
             </dd>
             <dt><b>Q4 2021</b></dt>
             <dd>
             <ul>
-              <li><b>November 2021:</b> PR for <a href="#wot-thing-description-next">WoT Thing Description (Next)</a></li>
+              <li><b>November 2021:</b> PR for <a href="#wot-td-next">WoT Thing Description (Next)</a></li>
             </ul>
             </dd>
            </dl>

--- a/charters/wot-wg-charter-draft-2019.html
+++ b/charters/wot-wg-charter-draft-2019.html
@@ -498,7 +498,7 @@
 	<h3>Thing Description Vocabulary</h3>
 	<p>
           The
-          <a href="http://www.w3.org/TR/wot-thing-description">WoT Thing Description (TD)</a>
+          <a href="https://www.w3.org/TR/wot-thing-description">WoT Thing Description (TD)</a>
           context includes a core set of vocabulary.
           This vocabulary can be extended by including additional context files.
           However, to support new use cases and protocols in a consistent (interoperable) way,
@@ -517,9 +517,9 @@
         <h3>Protocol Vocabulary and Bindings</h3>
 	<p>
           The
-          <a href="http://www.w3.org/TR/wot-thing-description">WoT Thing Description (TD)</a>
+          <a href="https://www.w3.org/TR/wot-thing-description">WoT Thing Description (TD)</a>
           specification is augmented by a 
-          <a href="http://www.w3.org/TR/wot-protocol-binding">WoT Protocol Binding</a>
+          <a href="https://www.w3.org/TR/wot-binding-templates/">WoT Protocol Binding</a>
           document which defines templates for how to use a TD to describe Things
           using specific concrete protocols.
           However, individual concrete protocols may require additional vocabulary
@@ -866,9 +866,9 @@ associated Call for Exclusion on 14 December 2017 ended on 11 February 2018.<br/
             <dd>For collaboration on JSON-LD features and WoT use cases.</dd>
             <dt><a href="https://www.w3.org/community/exi-next/">Efficient Extensible Interchange Community Group</a></dt>
             <dd>In relation to efficient interchange for Thing Descriptions.</dd>
-            <dt><a href="http://www.w3.org/auto/">Web and Automotive Business &amp; Working Groups</a></dt>
+            <dt><a href="https://www.w3.org/auto/">Web and Automotive Business &amp; Working Groups</a></dt>
             <dd>For collaboration on technologies and requirements relating to connected cars and the Web of Things.</dd>
-            <dt><a href="http://www.w3.org/2009/dap/">Device and Sensors Working Group</a></dt>
+            <dt><a href="https://www.w3.org/2009/dap/">Device and Sensors Working Group</a></dt>
             <dd>For coordination on APIs for sensors and actuators.</dd>
             <dt><a href="">Decentralized Identifier Working Group</a></dt>
             <dd>For coordination on identity management and information lifecycle.</dd>
@@ -876,7 +876,7 @@ associated Call for Exclusion on 14 December 2017 ended on 11 February 2018.<br/
             <dd>For collaboration on networking technologies on the edge and in the cloud when exposing interactions between Things.</dd>
             <dt><a href="https://www.w3.org/WAI/APA/">Accessible Platform Architectures Working Group</a></dt>
             <dd>For coordination on impacts of Web of Things technologies on accessibility to users with disabilities.</dd>
-            <dt><a href="http://www.w3.org/Privacy/">Privacy Interest Group</a></dt>
+            <dt><a href="https://www.w3.org/Privacy/">Privacy Interest Group</a></dt>
             <dd>In addition to horizontal review, during development of deliverables such
                 as discovery and information lifecycle that
                 require the development of a privacy-preserving architecture,
@@ -900,7 +900,7 @@ associated Call for Exclusion on 14 December 2017 ended on 11 February 2018.<br/
           <dl>
             <dt><a href="https://datatracker.ietf.org/doc/charter-irtf-t2trg/">IRTF Thing to Thing Research Group</a></dt>
             <dd>For coordination of matters of mutual interest in relation to the Web of Things, such as data modelling, discovery, directory services, and IoT semantics.</dd>
-            <dt><a href="http://openconnectivity.org">Open Connectivity Foundation</a></dt>
+            <dt><a href="https://openconnectivity.org">Open Connectivity Foundation</a></dt>
             <dd>For collaboration on integrating OCF based platforms within the Web of Things, including platform metadata and approaches for enabling semantic interoperability, and end to end security across platforms.</dd>
             <dt><a href="https://echonet.jp/english/">ECHONET Consortium</a></dt>
             <dd>For collaboration on integrating ECHONET Consortium based platforms within the Web of Things, including platform metadata and approaches for enabling semantic interoperability, and end to end security across platforms.</dd>


### PR DESCRIPTION
Update timeline dates assuming a Dec 1 start date.   Only the first two quarters were shifted; I am assuming we will strive to get caught up.   I also did not change the quarters for any deliverables (although one got delayed a month) nor the proposed dates and quarters for F2F meetings (in case people have budgeted these already by quarter...).   I also avoided shifting anything into August to avoid vacations.