### PR TITLE
[Charter] Add a note on the WG's effort to the horizontal review description at the Coordination section

### DIFF
--- a/charters/wot-wg-charter-draft-2019.html
+++ b/charters/wot-wg-charter-draft-2019.html
@@ -853,7 +853,9 @@ associated Call for Exclusion on 14 December 2017 ended on 11 February 2018.<br/
 	including <a href="https://www.w3.org/Consortium/Process/#RecsWD" title="First Public Working Draft">FPWD</a> 
 	and at least 3 months before 
         <a href="https://www.w3.org/Consortium/Process/#RecsCR" title="Candidate Recommendation">CR</a>,
-        and should be issued when major changes occur in a specification.</p>
+        and should be issued when major changes occur in a specification.
+        Prior to the horizontal review, the Working Group will also make a concerted effort to consider whether there are any ramifications to the group's deliverables from the viewpoint of accessibility, internationalization, performance, privacy, and security.
+	</p>
 
         <p>Additional technical coordination with the following Groups will be made, per the <a href="https://www.w3.org/Consortium/Process/#WGCharter">W3C Process Document</a>:</p>
 


### PR DESCRIPTION
Based on the discussion on [pr904](https://github.com/w3c/wot/pull/904) add some more supplementary email exchanges, I'm creating this PR to handle the comment from [I18N](https://github.com/w3c/strategy/issues/192#issuecomment-553531041) to the draft WoT WG Charter.

The proposed change is adding a note on the WoT WG's effort to consider possible ramifications to the group's deliverables from the viewpoint of horizontal review to the "5. Coordination" section.

Please see also the [Statically rendered version](https://cdn.statically.io/gh/w3c/wot/add-wide-review-note/charters/wot-wg-charter-draft-2019.html).