### PR TITLE
[wg-charter] update URLs for wot-arch and wot-thing-description based on the AC Review version draft

### DIFF
--- a/charters/wot-wg-charter-draft-2019.html
+++ b/charters/wot-wg-charter-draft-2019.html
@@ -618,12 +618,12 @@
               <dl><dt>
                 <p><b>Reference Draft:</b><br/> 
                         Web of Things (WoT) Architecture,<br/>
-                        Latest publication: 16 May 2019,<br/>
-                        <a href="https://www.w3.org/TR/2019/CR-wot-architecture-20190516/">https://www.w3.org/TR/2019/CR-wot-architecture-20190516/</a>,</br> 
+                        Latest publication: 6 November 2019,<br/>
+                        <a href="https://www.w3.org/TR/2019/CR-wot-architecture-20191106/">https://www.w3.org/TR/2019/CR-wot-architecture-20191106/</a>,</br> 
                 <!-- The <span class="todo">title, stable URL, and publication date of the most recent <a href='https://github.com/w3c/charter-drafts/blob/gh-pages/draft-states.md#reference-draft'>Reference Draft</a> or Candidate Recommendation</span> which triggered an Exclusion Opportunity per the Patent Process.
         <span class="todo">Exclusion period <b>began</b>; Exclusion period <b>ended</b>.</span> <span class='todo'>(this <a href="https://www.w3.org/2004/01/pp-impl/charter-assistant?wgid=95969">charter assistant</a> helps in producing the list.)</span>
 -->
-associated Call for Exclusion on 14 December 2017 ended on 11 February 2018.<br/>
+associated Call for Exclusion on 6 November 2019 ending on 5 January 2020.<br/>
       <p>Produced under <b>Working Group Charter:</b> <a href="https://www.w3.org/2016/12/wot-wg-2016.html">https://www.w3.org/2016/12/wot-wg-2016.html</a>
     </dd>
               </dl>
@@ -641,9 +641,9 @@ associated Call for Exclusion on 14 December 2017 ended on 11 February 2018.<br/
               <dl><dt>
                 <p><b>Reference Draft:</b><br/> 
                         Web of Things (WoT) Thing Description,<br/>
-                        Latest publication: 16 May 2019,<br/>
-                        <a href="https://www.w3.org/TR/2019/CR-wot-thing-description-20190516/">https://www.w3.org/TR/2019/CR-wot-thing-description-20190516/</a>,</br> 
-associated Call for Exclusion on 14 December 2017 ended on 11 February 2018.<br/>
+                        Latest publication: 6 November 2019,<br/>
+                        <a href="https://www.w3.org/TR/2019/CR-wot-thing-description-20191106/">https://www.w3.org/TR/2019/CR-wot-thing-description-20191106/</a>,</br> 
+associated Call for Exclusion on 6 November 2019 ending on 5 January 2020.<br/>
       <p>Produced under <b>Working Group Charter:</b> <a href="https://www.w3.org/2016/12/wot-wg-2016.html">https://www.w3.org/2016/12/wot-wg-2016.html</a>
     </dd>
               </dl>
@@ -661,9 +661,9 @@ associated Call for Exclusion on 14 December 2017 ended on 11 February 2018.<br/
               <dl><dt>
                 <p><b>Reference Draft:</b><br/> 
                         Web of Things (WoT) Thing Description,<br/>
-                        Latest publication: 16 May 2019,<br/>
-                        <a href="https://www.w3.org/TR/2019/CR-wot-thing-description-20190516/">https://www.w3.org/TR/2019/CR-wot-thing-description-20190516/</a>,</br> 
-associated Call for Exclusion on 14 December 2017 ended on 11 February 2018.<br/>
+                        Latest publication: 6 November 2019,<br/>
+                        <a href="https://www.w3.org/TR/2019/CR-wot-thing-description-20191106/">https://www.w3.org/TR/2019/CR-wot-thing-description-20191106/</a>,</br> 
+associated Call for Exclusion on 6 November 2019 ending on 5 January 2020.<br/>
       <p>Produced under <b>Working Group Charter:</b> <a href="https://www.w3.org/2016/12/wot-wg-2016.html">https://www.w3.org/2016/12/wot-wg-2016.html</a>
     </dd>
               </dl>


### PR DESCRIPTION
The "Reference Draft" URLs of the WoT Architecture and the WoT Thing Description within the "[Normative Specification](http://w3c.github.io/wot/charters/wot-wg-charter-draft-2019.html#normative)" section are to be updated for the recently published CR2 drafts like the [AC review version of the WG Charter draft](https://www.w3.org/2019/11/proposed-wot-wg-charter-2019.html#normative).

In addition, the AC Review version had a typo for the CR2 URL of the WoT Architecture draft, so this Pull Request fixes that typo as well.