### PR TITLE
[wg-charter] update the text on the "horizontal review" at the Coordination section based on the updated Charter template

### DIFF
--- a/charters/wot-wg-charter-draft-2019.html
+++ b/charters/wot-wg-charter-draft-2019.html
@@ -844,21 +844,23 @@ associated Call for Exclusion on 14 December 2017 ended on 11 February 2018.<br/
 
       <section id="coordination">
         <h2>Coordination</h2>
-        <p>For all deliverables, this Working Group will seek 
-	<a href="https://www.w3.org/Guide/process/charter.html#horizontal-review">horizontal review</a> 
-	for accessibility, internationalization, performance, privacy, and security 
-        with the relevant Working and Interest Groups,
-	and with the <a href="https://www.w3.org/2001/tag/" title="Technical Architecture Group">TAG</a>. 
-	Invitation for review must be issued during each major standards-track document transition,
-	including <a href="https://www.w3.org/Consortium/Process/#RecsWD" title="First Public Working Draft">FPWD</a> 
-	and at least 3 months before 
-        <a href="https://www.w3.org/Consortium/Process/#RecsCR" title="Candidate Recommendation">CR</a>,
-        and should be issued when major changes occur in a specification.
-        Throughout the spec development process, 
-        the Working Group will also make a concerted effort to consider whether there 
-        are any ramifications to the group's deliverables from the viewpoint of accessibility, 
-        internationalization, performance, privacy, and security.
-	</p>
+
+        <p>For all specifications, this Working Group will seek
+	<a href="https://www.w3.org/Guide/process/charter.html#horizontal-review">horizontal review</a>
+	for accessibility, internationalization, performance, privacy, and security
+	with the relevant Working and Interest Groups,
+	and with the <a href="https://www.w3.org/2001/tag/" title="Technical Architecture Group">TAG</a>.
+        Invitation for review must be issued during each major standards-track document transition,
+	including <a href="https://www.w3.org/Consortium/Process/#RecsWD" title="First Public Working Draft">FPWD</a>.
+	The Working Group is encouraged to engage collaboratively with
+        the horizontal review groups throughout development of each
+        specification.
+	The Working Group is advised to seek a review at least 3
+        months before first entering <a
+        href="https://www.w3.org/Consortium/Process/#RecsCR"
+        title="Candidate Recommendation">CR</a> and is encouraged to
+        proactively notify the horizontal review groups when major
+        changes occur in a specification following a review.</p>
 
         <p>Additional technical coordination with the following Groups will be made, per the <a href="https://www.w3.org/Consortium/Process/#WGCharter">W3C Process Document</a>:</p>
 


### PR DESCRIPTION
The [Charter template](https://w3c.github.io/charter-drafts/charter-template.html#coordination) was updated recently for the "horizontal review" at the "[Coordination](https://w3c.github.io/charter-drafts/charter-template.html#coordination)" section, and the WoT WG was encouraged to use the updated template text for the draft [WG Charter](https://www.w3.org/2019/11/proposed-wot-wg-charter-2019.html#coordination) which is now under the AC Review.

The Working Group agree it would be better to use the updated text from the Charter template, and would like to apply that to the draft WG Charter on the GitHub using this Pullrequest (and also apply the change to the draft Charter under the AC Review as well).

Please note that this Pullrequest should be merged after [PR910](https://github.com/w3c/wot/pull/910).