### PR TITLE
Add GS1 to external liaisons in WG charter

### DIFF
--- a/charters/wot-wg-charter-draft-2019.html
+++ b/charters/wot-wg-charter-draft-2019.html
@@ -927,6 +927,8 @@ associated Call for Exclusion on 6 November 2019 ending on 5 January 2020.<br/>
             <dd>For coordination on the OGC SensorThings API and location metadata.</dd>
             <dt><a href="http://www.gsma.com">GSMA</a></dt>
             <dd>For coordination in respect to the interests of Network Operators.</dd>
+            <dt><a href="https://www.gs1.org/">GS1</a></dt>
+            <dd>For coordination on identifiers and discovery.</dd>
             <dt><a href="https://www.eclass.eu/en.html">eCl@ss</a></dt>
             <dd>For collaboration and coordination of the technical realization of the use of eCl@ss in the W3C Thing Description.</dd>
             <dt><a href="https://aioti.eu/">AIOTI WG03</a></dt>


### PR DESCRIPTION
As agreed upon in the main call on Dec 11, 2019.