### PR TITLE
IG charter updates addressing W3M comments

### DIFF
--- a/charters/wot-ig-2021-proposed.html
+++ b/charters/wot-ig-2021-proposed.html
@@ -455,7 +455,7 @@
 		including representatives from the key implementors of this specification, 
 		and active Editors and Test Leads for each specification. 
 		The Chairs, Editors, 
-		and Test Leads are expected to contribute half of a working day per week towards the (Working|Interest) Group. 
+		and Test Leads are expected to contribute half of a working day per week towards the Interest Group. 
 		There is no minimum requirement for other Participants.
         </p>
         <p>

--- a/charters/wot-ig-2021-proposed.html
+++ b/charters/wot-ig-2021-proposed.html
@@ -383,7 +383,7 @@
 
           <dl>
             <dt><a href="https://www.w3.org/WoT/WG/">Web of Things Working Group</a></dt>
-            <dd>For collaboration as outlined in <a href="#scope"></a>.</dd>
+            <dd>For collaboration as outlined under <a href="#scope">Scope</a>.</dd>
             <dt><a href="https://www.w3.org/2018/json-ld-wg/">JSON-LD Working Group</a></dt>
             <dd>For collaboration on JSON-LD features and WoT use cases.</dd>
             <dt><a href="https://www.w3.org/community/exi-next/">Efficient Extensible Interchange Community Group</a></dt>

--- a/charters/wot-ig-2021-proposed.html
+++ b/charters/wot-ig-2021-proposed.html
@@ -198,7 +198,7 @@
         </p>
         <p>
           To achieve this goal for cross-platform and cross-domain interoperability,
-          the <a href="https://www.w3.org/WoT/WG/">Web of Things Working Group</a> is developing a first set of standardized building blocks.
+          the <a href="https://www.w3.org/WoT/WG/">Web of Things Working Group</a> has developed a first set of standardized building blocks.
           The core idea is based upon rich metadata that describes the data and possible interactions (i.e., affordances) exposed to applications,
           and the communications and security requirements for platforms to communicate effectively.
           The central documents are the <a href="https://www.w3.org/TR/wot-architecture/">WoT Architecture</a> and <a href="https://www.w3.org/TR/wot-thing-description/">WoT Thing Description</a> with its <i>Properties, Actions, Events</i> interaction model.


### PR DESCRIPTION
Resolves https://github.com/w3c/wot/issues/986

Well, mostly.  I could not see where the Marketing TF was mentioned in the charter,  and the broken link was on the web site, so I think this was an out-of-band comment we need to make on the strategy issue (and we need to fix the broken link in the web site).