### PR TITLE
Update Plan due to delay in Discovery, TD 1.1, CR/PR typo

### DIFF
--- a/charters/wg-2021-extension-plan.md
+++ b/charters/wg-2021-extension-plan.md
@@ -11,7 +11,7 @@ During the second 6 months we can begin editor's draft documents for the planned
 5. Clarify which normative sections should be included or should be improved in Architecture 1.1 by Feb 4
 6. Clarify which normative sections should be included or should be improved in Discovery by Feb 14
 7. Normative feature freeze for Architecture spec by Feb 4, 2022
-8. Normative feature freeze for TD 1.1 spec by Feb 4, 2022
+8. Normative feature freeze for TD 1.1 spec by Feb 9, 2022
 9. Normative feature freeze for Discovery spec by Feb 28, 2022
 10. Clarify which normative sections should be included or should be improved in Profile by Mar 4
 11. Testfest/Plugfest 1 in mid-March (focus on TD, Discovery)
@@ -27,6 +27,6 @@ During the second 6 months we can begin editor's draft documents for the planned
 21. CR candidate for Profiles by July 30, 2022
 22. CR Transition for Discovery by Aug 31, 2022
 23. CR Transition for Profiles by Aug 31, 2022
-24. CR Transition for Discovery by Nov 1, 2022
-25. CR Transition for Profiles by Nov 1, 2022
+24. PR Transition for Discovery by Nov 1, 2022
+25. PR Transition for Profiles by Nov 1, 2022
 26. REC transition before end of extended charter on Feb 1, 2023

--- a/charters/wg-2021-extension-plan.md
+++ b/charters/wg-2021-extension-plan.md
@@ -9,10 +9,10 @@ During the second 6 months we can begin editor's draft documents for the planned
 3. Document consistency check complete by Feb 4
 4. Clarify which normative sections should be included or should be improved in TD 1.1 by Feb 4
 5. Clarify which normative sections should be included or should be improved in Architecture 1.1 by Feb 4
-6. Clarify which normative sections should be included or should be improved in Discovery by Feb 4
+6. Clarify which normative sections should be included or should be improved in Discovery by Feb 14
 7. Normative feature freeze for Architecture spec by Feb 4, 2022
 8. Normative feature freeze for TD 1.1 spec by Feb 4, 2022
-9. Normative feature freeze for Discovery spec by Feb 4, 2022
+9. Normative feature freeze for Discovery spec by Feb 28, 2022
 10. Clarify which normative sections should be included or should be improved in Profile by Mar 4
 11. Testfest/Plugfest 1 in mid-March (focus on TD, Discovery)
 12. CR candidate for Architecture by March 30, 2022

--- a/charters/wg-2021-extension-plan.md
+++ b/charters/wg-2021-extension-plan.md
@@ -27,6 +27,7 @@ During the second 6 months we can begin editor's draft documents for the planned
 21. CR candidate for Profiles by July 30, 2022
 22. CR Transition for Discovery by Aug 31, 2022
 23. CR Transition for Profiles by Aug 31, 2022
-24. PR Transition for Discovery by Nov 1, 2022
-25. PR Transition for Profiles by Nov 1, 2022
-26. REC transition before end of extended charter on Feb 1, 2023
+24. TPAC 2022 (possibly hybrid) Sept 12-16, 2022 (tentative)
+25. PR Transition for Discovery by Nov 1, 2022
+26. PR Transition for Profiles by Nov 1, 2022
+27. REC transition before end of extended charter on Feb 1, 2023


### PR DESCRIPTION
- Still outstanding issues with Discovery, need new normative content, delaying freeze to Feb 28.
- Moving TD 1.1 normative feature freeze to Feb 9 (tentative)
- Fixing typo: Nov 1 is PR transition for Profiles and Discovery, not CR transition