### PR TITLE
Update wot-wg-2022-draft.html with the "groups" URL

### DIFF
--- a/charters/wot-wg-2022-draft.html
+++ b/charters/wot-wg-2022-draft.html
@@ -76,7 +76,7 @@
 
       <p class="mission">
         The <strong>mission</strong> of the 
-        <a href="https://www.w3.org/WoT/WG/">Web of Things Working Group</a> 
+        <a href="https://www.w3.org/groups/wg/wot">Web of Things Working Group</a> 
         is to counter the fragmentation of the IoT through 
         the specification of building blocks 
         that enable easy integration of IoT devices and services
@@ -85,7 +85,7 @@
         This 
         <a href="">Working Group Charter</a> 
         covers those aspects that the 
-        <a href="http://www.w3.org/WoT/IG/">Web of Things Interest Group</a> 
+        <a href="http://www.w3.org/groups/ig/wot">Web of Things Interest Group</a> 
         <a href="http://w3c.github.io/wot/charters/wot-ig-2019.html">(2019 charter here)</a> 
         believes are mature enough to progress to W3C Recommendations. 
       <!--
@@ -162,7 +162,7 @@
         <p>This working group is tasked with the standardization 
            or extension of several technological building blocks 
            identified by the 
-           <a href="https://www.w3.org/WoT/IG/">Web of Things Interest Group</a> (IG) 
+           <a href="https://www.w3.org/groups/ig/wot">Web of Things Interest Group</a> (IG) 
            as being important to advancing the Web of Things. 
            The WoT building blocks are intended to complement existing 
            and emerging IoT standards by focusing on enabling cross-platform and cross-domain interoperability. 
@@ -865,7 +865,7 @@ associated Call for Exclusion on 6 November 2019 ending on 5 January 2020.<br/>
         <section>
           <h3 id="w3c-coordination">W3C Groups</h3>
           <dl>
-            <dt><a href="https://www.w3.org/WoT/IG/">Web of Things Interest Group</a></dt>
+            <dt><a href="https://www.w3.org/groups/ig/wot">Web of Things Interest Group</a></dt>
             <dd>For collaboration as outlined in <a href="#scope">Scope</a>.</dd>
             <dt><a href="https://www.w3.org/2018/json-ld-wg/">JSON-LD Working Group</a></dt>
             <dd>For collaboration on JSON-LD features and WoT use cases.</dd>


### PR DESCRIPTION
As you know, the W3C groups information is managed automatically based on the W3C DB and the GitHub repositories, e.g., [the WG page](https://www.w3.org/groups/wg/). So we're encouraged to use the https://www.w3.org/groups/wg/wot URL instead of our familiar https://www.w3.org/WoT/wg URL, and [the latest Charter template](https://w3c.github.io/charter-drafts/charter-template.html) also use it.

So I'd suggest we also use the groups URL instead of using our group page URL directly.

Please note that the auto-generated [standard WG page for WoT] (https://www.w3.org/groups/wg/wot) has a link saying “Homepage” to get [our own home page](https://www.w3.org/WoT/wg/) under “General Information”.