### PR TITLE
sort wg-2021-extension-plan.md

### DIFF
--- a/charters/wg-2021-extension-plan.md
+++ b/charters/wg-2021-extension-plan.md
@@ -14,11 +14,11 @@ During the second 6 months we can begin editor's draft documents for the planned
 | Feb 9, 2022 | TD1.1 | Normative feature freeze |
 | Mar 4, 2022 | Profiles | Clarify which normative sections should be included or should be improved |
 | mid-March, 2022 | - | Testfest/Plugfest 1 (focus on TD, Discovery) |
-| May 6, 2022 | TD1.1 | CR candidate |
 | Apr 11, 2022 | Discovery | Clarify which normative sections should be included or should be improved |
-| mid-May, 2022 | TD1.1 | CR transition |
 | Apr 25, 2022 | Discovery | Normative feature freeze |
+| May 6, 2022 | TD1.1 | CR candidate |
 | May 6, 2022 | Arch1.1 | Normative feature freeze |
+| mid-May, 2022 | TD1.1 | CR transition |
 | mid-May, 2022 | TD1.1 | PR transition |
 | June 3, 2022 | Arch1.1 | CR candidate |
 | mid-June, 2022 | Profiles | Normative feature freeze |


### PR DESCRIPTION
Sorted based on its due date.

I think it is a bug that the CR and PR transition of TD are on the same day (mid-May, 2022), but I left it as it is.