### PR TITLE
Create Security Deliverable Proposal

### DIFF
--- a/proposals/deliverable-proposals/README.md
+++ b/proposals/deliverable-proposals/README.md
@@ -8,6 +8,7 @@ so use HTML if possible for the actual content.
 Just put a blank line before and after and avoid blank lines in the middle of
 any HTML content.
 
-* [Onboarding](onboarding.md)
+* <strike>[Onboarding](onboarding.md)</strike>
+* [Security](security.md)
 * [Discovery](discovery.md)
 * [Profiles](profiles.md)

--- a/proposals/deliverable-proposals/README.md
+++ b/proposals/deliverable-proposals/README.md
@@ -8,7 +8,7 @@ so use HTML if possible for the actual content.
 Just put a blank line before and after and avoid blank lines in the middle of
 any HTML content.
 
-* <strike>[Onboarding](onboarding.md)</strike>
+* <strike>[Onboarding](onboarding.md)</strike> (DEPRECATED - merged with Security proposal)
 * [Security](security.md)
 * [Discovery](discovery.md)
 * [Profiles](profiles.md)

--- a/proposals/deliverable-proposals/onboarding.md
+++ b/proposals/deliverable-proposals/onboarding.md
@@ -1,4 +1,5 @@
 # Onboarding
+DEPRECATED - To be incorporated into a consolidated Security proposal.
 
 ## Motivation
 In order to establish secure communications in some contexts, for example on a LAN,

--- a/proposals/deliverable-proposals/security.md
+++ b/proposals/deliverable-proposals/security.md
@@ -59,4 +59,4 @@ Currently security schemes are "baked into" the TD specification but it would
 be more manageable and consistent to break them out as separate ontologies so that all
 security schemes would be done via extensions.  Then the TD 2.0 spec would only
 have to include general-purpose "structural" security schemes like `nosec` and `combo`.
-
+The security ontologies and URLs for them would be published in a new [Registry Track Note](https://www.w3.org/2021/Process-20211102/#registries).

--- a/proposals/deliverable-proposals/security.md
+++ b/proposals/deliverable-proposals/security.md
@@ -1,0 +1,56 @@
+# Security and Privacy
+
+## Motivation
+Security and Privacy considerations and assertions related to them are currently
+scattered across many deliverables.  In addition, we have an informative guideline
+document that does not have any assertions. 
+
+Consolidating this material into a single document would make it easier to review
+(and this is important, since security reviewers are hard to get and yet such
+review is critical) and would also create a location for new security features to
+be placed, such as onboarding.
+
+## Description
+The WoT Security and Privacy deliverable would describe integrated security and privacy 
+considerations and features for all WoT systems and deliverables.  In addition to consolidating existing informative
+and normative security and privacy content from existing document, this
+deliverable would provide a location for new normative security and privacy features to
+be located.
+
+### Consolidation
+The following existing content would be consolidated:
+- Secure transport assertions (e.g. TLS version).
+- How to handle key management LANs where CA is not available.
+- PII handling assertions.
+- Security bootstrapping (e.g. first contact with an unknown Thing).
+- Informative content from the existing WoT Security and Privacy Guidelines document,
+  including definitions, threat models, risks, actors, and testing recommendations.
+  
+## New
+The following new features would be defined normatively.
+
+### Onboarding.
+In order to establish secure communications in some contexts, for example on a LAN,
+some form of onboarding process to establish mutual trust between Things and
+Consumers is needed.  Having a prescriptive (but optional) process for this
+would be useful.
+
+Note that this may be part of a larger "lifecycle" which would be described in the 
+Architecture document.
+
+<p>
+In this work item we will define mechanisms to perform minimum-effort
+onboarding of
+Things in a secure way that conforms to the security and privacy requirements
+of specific deployment scenarios and use cases.
+</p>
+<p>
+This work item complements the work that is done for device discovery,
+however is also applicable for other use cases.
+</p>
+
+### Signing
+In order to ensure integrity of TDs, they may have to be signed in a way
+consistent with emerging RDF/JSON-LD in this space.  Signatures also
+need to be validated and this requires a key (or identity) management system.
+

--- a/proposals/deliverable-proposals/security.md
+++ b/proposals/deliverable-proposals/security.md
@@ -25,6 +25,7 @@ The following existing content would be consolidated:
 - Security bootstrapping (e.g. first contact with an unknown Thing), currently in Discovery.
 - Informative content from the existing WoT Security and Privacy Guidelines document,
   including definitions, threat models, risks, actors, and testing recommendations.
+  - Best practices, i.e. which security schemes are recommended for new development and which are provided only for compatibility with brownfield devices.
   
 ## New
 The following new features would be defined normatively.

--- a/proposals/deliverable-proposals/security.md
+++ b/proposals/deliverable-proposals/security.md
@@ -10,6 +10,8 @@ Consolidating this material into a single normative document would make it easie
 review is critical) and would also create a location for new security features to
 be placed, such as onboarding.
 
+To reflect the new document's status, it would need a new name, such as "WoT Security and Privacy Recommendations" or "WoT Security and Privacy Recommended Practices".
+
 ## Description
 The WoT Security and Privacy deliverable would describe integrated security and privacy 
 considerations and features for all WoT systems and deliverables.  In addition to consolidating existing informative

--- a/proposals/deliverable-proposals/security.md
+++ b/proposals/deliverable-proposals/security.md
@@ -5,7 +5,7 @@ Security and Privacy considerations and assertions related to them are currently
 scattered across many deliverables.  In addition, we have an informative guideline
 document that does not have any assertions. 
 
-Consolidating this material into a single document would make it easier to review
+Consolidating this material into a single normative document would make it easier to review
 (and this is important, since security reviewers are hard to get and yet such
 review is critical) and would also create a location for new security features to
 be placed, such as onboarding.

--- a/proposals/deliverable-proposals/security.md
+++ b/proposals/deliverable-proposals/security.md
@@ -19,17 +19,17 @@ be located.
 
 ### Consolidation
 The following existing content would be consolidated:
-- Secure transport assertions (e.g. TLS version).
-- How to handle key management LANs where CA is not available.
-- PII handling assertions.
-- Security bootstrapping (e.g. first contact with an unknown Thing).
+- Secure transport assertions (e.g. TLS version), currently in Arch.
+- Deployment on LANs where CA is not available, currently in Arch and TD.
+- PII handling assertions, currently scattered.
+- Security bootstrapping (e.g. first contact with an unknown Thing), currently in Discovery.
 - Informative content from the existing WoT Security and Privacy Guidelines document,
   including definitions, threat models, risks, actors, and testing recommendations.
   
 ## New
 The following new features would be defined normatively.
 
-### Onboarding.
+### Onboarding
 In order to establish secure communications in some contexts, for example on a LAN,
 some form of onboarding process to establish mutual trust between Things and
 Consumers is needed.  Having a prescriptive (but optional) process for this
@@ -53,4 +53,10 @@ however is also applicable for other use cases.
 In order to ensure integrity of TDs, they may have to be signed in a way
 consistent with emerging RDF/JSON-LD in this space.  Signatures also
 need to be validated and this requires a key (or identity) management system.
+
+### Security Scheme Ontology
+Currently security schemes are "baked into" the TD specification but it would
+be more manageable and consistent to break them out as separate ontologies so that all
+security schemes would be done via extensions.  Then the TD 2.0 spec would only
+have to include general-purpose "structural" security schemes like `nosec` and `combo`.
 


### PR DESCRIPTION
Initial security deliverable proposal
- General consolidation of existing but scattered security content
- New security content, including onboarding, signatures, and security schemes
- old onboarding proposal deprecated - content absorbed into this one