### PR TITLE
Pres for WoT demo - retail/home

### DIFF
--- a/PRESENTATIONS/2022-09-hybrid-f2f/README.md
+++ b/PRESENTATIONS/2022-09-hybrid-f2f/README.md
@@ -43,14 +43,16 @@ Eastern time, and there is a 3h difference between these.
    - [PDF](2022-09-12-WoT-F2F-Opening-McCool.pdf)
    - [PPTX](2022-09-12-WoT-F2F-Opening-McCool.pptx)
 * Liaison:
-   - [PDF](2022-09-12-WoT-F2F-ECHONET-Liaison.pdf)
+   - ECHONET - [PDF](2022-09-12-WoT-F2F-ECHONET-Liaison.pdf)
 
 ### Wednesday 14 September 2022 - 2h - 8:00am-10:00am Pacific
 * [Agenda](https://www.w3.org/WoT/IG/wiki/F2F_meeting,_September_2022#Wednesday.2C_September_14)
 
 ### DEMO BREAKOUT: Wednesday 14 September 2022 - 1h - 3pm Pacific (tentative)
 * [Agenda](https://www.w3.org/WoT/IG/wiki/F2F_meeting,_September_2022#WoT_Status_Update_and_Demos)
-
+* Demos:
+   - Retail - [PDF](2022-05-WoT-Connexxus-McCool.pdf)
+   
 ## Post-TPAC
 ### Tuesday 20 September 2022 - 2h - 8:00am-10:00am Eastern
 * [Agenda](https://www.w3.org/WoT/IG/wiki/F2F_meeting,_September_2022#Tuesday.2C_September_20)


### PR DESCRIPTION
A copy of what I prepared for Conexxus' strategy conference in May 2022.  I didn't have time to do significant updates and upon review felt that it had held up pretty well, so will just use the slides as is.  Also my demo is not running anymore (I since moved the devices around) and at any rate it is quite fussy to do live (webcams don't pick up colors very well, etc). so I will just play the video.  There are too many slides for the demo timeslot though so I will select a subset.