### PR TITLE
Update wg-2021-extension-plan.md

### DIFF
--- a/charters/wg-2021-extension-plan.md
+++ b/charters/wg-2021-extension-plan.md
@@ -30,9 +30,15 @@ During the second 6 months we can begin editor's draft documents for the planned
 | Nov 2, 2022 | Arch1.1 | CR transition request |
 | Dec 8, 2022 | Profiles | WD candidate - for testing  |
 | Dec 12-16, 2022 | Profiles | Plugfest+Testfest for TD, Profile, Discovery (Munich?) |
+| Dec 14, 2022 | TD1.1 | CR transition (estimated) |
+| Dec 14, 2022 | Discovery | CR transition (estimated) |
+| Dec 14, 2022 | Arch1.1 | CR transition (estimated) |
 | Dec 20 (ish), 2022 | Next | Next WG Charter Discussion |
 | Dec 21, 2022 | Profiles | New WD |
-| Jan 11, 2023 | TD1.1 | PR transition request |
-| Jan 11, 2023 | Discovery | PR transition request |
-| Jan 24, 2023 | Arch1.1 | PR transition request |
-| March 7, 2023 | All | REC transition |
+| Jan 16-20, 2023 | Next | Next WG Charter Finalization |
+| <strike>Jan 11, 2023</strike> Mar 16, 2023 | TD1.1 | PR transition request (CR transition + 3mo) |
+| <strike>Jan 11, 2023</strike> Mar 16, 2023 | Discovery | PR transition request (CR transition + 3mo) |
+| <strike>Jan 24, 2023</strike> Mar 16, 2023 | Arch1.1 | PR transition request (CR transition + 3mo) |
+| Mar 22, 2023 | Next | Next WG Charter AC Review Complete |
+| May 25, 2023 | All | REC transition (PR transition request + 1wk + 2mo) |
+| May 1, 2023 | Next | Next WG Charter Begins |


### PR DESCRIPTION
Add 
- Revised CR transition schedule expectations
- Next WG charter development timeline

Note: these changes go past the end of our current WG charter and are based on the expectation of a 3mo extension.  Note that the next WG charter would start May 1, 2023 (proposed).