### PR TITLE
Update wg-2021-extension-plan.md

### DIFF
--- a/charters/wg-2021-extension-plan.md
+++ b/charters/wg-2021-extension-plan.md
@@ -29,18 +29,18 @@ We are developing a new draft charter proposed to begin in 1 June 2023.
 | Dec 8, 2022 | Profiles | WD candidate - for testing  |
 | Dec 12-16, 2022 | Profiles | Plugfest+Testfest for TD, Profile, Discovery (Munich?) |
 | Dec 20 (ish), 2022 | Next | Next WG Charter Discussion |
-| Jan 18, 2023 | Profiles | WD2 publication |
-| Jan 18, 2023 | TD1.1 | CR transition |
-| Jan 18, 2023 | Discovery | CR transition |
-| Jan 18, 2023 | Arch1.1 | CR transition |
+| Jan 19, 2023 | Profiles | WD2 publication |
+| Jan 19, 2023 | TD1.1 | CR transition |
+| Jan 19, 2023 | Discovery | CR transition |
+| Jan 19, 2023 | Arch1.1 | CR transition |
 | Jan 16-20, 2023 | Next | Next WG Charter Draft |
 | Feb 16, 2023 | Discovery | CR2 transition |
 | Feb 28, 2023 | Profile | CR draft |
 | Mar 15, 2023 | Profile | CR transition request |
 | Mar 30, 2023 | Profile | CR transition |
 | Mar 22, 2023 | Next | Next WG Charter AC Review Complete |
-| April 14, 2023 | TD1.1 | PR transition request (CR transition + 3mo) |
-| April 14, 2023 | Arch1.1 | PR transition request (CR transition + 3mo) |
+| April 19, 2023 | TD1.1 | PR transition request (CR transition + 3mo) |
+| April 19, 2023 | Arch1.1 | PR transition request (CR transition + 3mo) |
 | May 19, 2023 | Discovery | PR transition request (CR2 transition + 3mo) |
 | May 31, 2023 | Profile | PR transition request (CR transition + 2mo) |
 | June 1, 2023 | Next | Next WG Charter Begins |

--- a/charters/wg-2021-extension-plan.md
+++ b/charters/wg-2021-extension-plan.md
@@ -36,11 +36,13 @@ We are developing a new draft charter proposed to begin in 1 June 2023.
 | Jan 16-20, 2023 | Next | Next WG Charter Meeting |
 | Jan 25, 2023 | Discovery | CR2 draft |
 | Feb 8, 2023 | Discovery | CR2 transition request |
+| Feb 8, 2023 | Next | Next WG Charter - First Draft |
 | Feb 16, 2023 | Discovery | CR2 transition |
+| Feb 22, 2023 | Next | Next WG Charter - Final Draft - Submit |
 | Feb 28, 2023 | Profile | CR draft |
 | Mar 15, 2023 | Profile | CR transition request |
 | Mar 30, 2023 | Profile | CR transition |
-| Mar 22, 2023 | Next | Next WG Charter AC Review Complete |
+| Mar 22, 2023 | Next | Next WG Charter AC Review Complete (submission + 1mo) |
 | April 19, 2023 | TD1.1 | PR transition request (CR transition + 3mo) |
 | April 19, 2023 | Arch1.1 | PR transition request (CR transition + 3mo) |
 | May 19, 2023 | Discovery | PR transition request (CR2 transition + 3mo) |

--- a/charters/wg-2021-extension-plan.md
+++ b/charters/wg-2021-extension-plan.md
@@ -29,10 +29,10 @@ We are developing a new draft charter proposed to begin in 1 June 2023.
 | Dec 8, 2022 | Profiles | WD candidate - for testing  |
 | Dec 12-16, 2022 | Profiles | Plugfest+Testfest for TD, Profile, Discovery (Munich?) |
 | Dec 20 (ish), 2022 | Next | Next WG Charter Discussion |
-| Jan 13, 2023 | Profiles | New WD publication |
-| Jan 13, 2023 | TD1.1 | CR transition |
-| Jan 13, 2023 | Discovery | CR transition |
-| Jan 13, 2023 | Arch1.1 | CR transition |
+| Jan 18, 2023 | Profiles | WD2 publication |
+| Jan 18, 2023 | TD1.1 | CR transition |
+| Jan 18, 2023 | Discovery | CR transition |
+| Jan 18, 2023 | Arch1.1 | CR transition |
 | Jan 16-20, 2023 | Next | Next WG Charter Draft |
 | Feb 16, 2023 | Discovery | CR2 transition |
 | Feb 28, 2023 | Profile | CR draft |

--- a/charters/wg-2021-extension-plan.md
+++ b/charters/wg-2021-extension-plan.md
@@ -1,8 +1,6 @@
-# WG 2021 Extension Plan
-We will request a 12mo extension to the WG charter, based on the following plan.
-Note however that the spec generation schedule is based on a 6 month extension plan.
-The additional 6 months will be used as a buffer for wide review and testing.
-During the second 6 months we can begin editor's draft documents for the planned WG rechartering for 2023.
+# WG Extension Plan
+We will request an extension to the current (2019) WG charter, based on the following plan.
+We are developing a new draft charter proposed to begin in 1 June 2023.
 
 | Due date | Spec. | Description |
 | --- | --- | --- |
@@ -35,13 +33,19 @@ During the second 6 months we can begin editor's draft documents for the planned
 | Jan 13, 2023 | TD1.1 | CR transition |
 | Jan 13, 2023 | Discovery | CR transition |
 | Jan 13, 2023 | Arch1.1 | CR transition |
-| Jan 16-20, 2023 | Next | Next WG Charter Finalization |
-| Feb 28, 2023 | Profile CR draft |
+| Jan 16-20, 2023 | Next | Next WG Charter Draft |
+| Feb 16, 2023 | Discovery | CR2 transition |
+| Feb 28, 2023 | Profile | CR draft |
+| Mar 15, 2023 | Profile | CR transition request |
+| Mar 30, 2023 | Profile | CR transition |
 | Mar 22, 2023 | Next | Next WG Charter AC Review Complete |
 | April 14, 2023 | TD1.1 | PR transition request (CR transition + 3mo) |
-| April 14, 2023 | Discovery | PR transition request (CR transition + 3mo) |
 | April 14, 2023 | Arch1.1 | PR transition request (CR transition + 3mo) |
+| May 19, 2023 | Discovery | PR transition request (CR2 transition + 3mo) |
+| May 31, 2023 | Profile | PR transition request (CR transition + 2mo) |
 | June 1, 2023 | Next | Next WG Charter Begins |
 | June 1, 2023 | Next | F2F - {Switzerland,Munich,Tokyo} - tentative |
-| June 29, 2023 | All | REC transition (PR transition request + 1wk + 2mo) |
+| June 29, 2023 | TD 1.1 | REC transition (PR transition request + 1wk + 2mo) |
+| June 29, 2023 | Arch 1.1 | REC transition (PR transition request + 1wk + 2mo) |
+| Aug 3, 2023 | Discovery | REC transition (PR transition request + 1wk + 2mo) |
 | Oct-Nov, 2023 | Next | TPAC - Europe - tentative |

--- a/charters/wg-2021-extension-plan.md
+++ b/charters/wg-2021-extension-plan.md
@@ -48,4 +48,4 @@ We are developing a new draft charter proposed to begin in 1 June 2023.
 | June 29, 2023 | TD 1.1 | REC transition (PR transition request + 1wk + 2mo) |
 | June 29, 2023 | Arch 1.1 | REC transition (PR transition request + 1wk + 2mo) |
 | Aug 3, 2023 | Discovery | REC transition (PR transition request + 1wk + 2mo) |
-| Oct-Nov, 2023 | Next | TPAC - Europe - tentative |
+| Sept 11-15, 2023 | Next | TPAC 2023 - Seville, Spain |

--- a/charters/wg-2021-extension-plan.md
+++ b/charters/wg-2021-extension-plan.md
@@ -33,7 +33,9 @@ We are developing a new draft charter proposed to begin in 1 June 2023.
 | Jan 19, 2023 | TD1.1 | CR transition |
 | Jan 19, 2023 | Discovery | CR transition |
 | Jan 19, 2023 | Arch1.1 | CR transition |
-| Jan 16-20, 2023 | Next | Next WG Charter Draft |
+| Jan 16-20, 2023 | Next | Next WG Charter Meeting |
+| Jan 25, 2023 | Discovery | CR2 draft |
+| Feb 8, 2023 | Discovery | CR2 transition request |
 | Feb 16, 2023 | Discovery | CR2 transition |
 | Feb 28, 2023 | Profile | CR draft |
 | Mar 15, 2023 | Profile | CR transition request |

--- a/charters/wg-2021-extension-plan.md
+++ b/charters/wg-2021-extension-plan.md
@@ -29,7 +29,7 @@ We are developing a new draft charter proposed to begin in 1 June 2023.
 | Dec 8, 2022 | Profiles | WD candidate - for testing  |
 | Dec 12-16, 2022 | Profiles | Plugfest+Testfest for TD, Profile, Discovery (Munich?) |
 | Dec 20 (ish), 2022 | Next | Next WG Charter Discussion |
-| Jan 19, 2023 | Profiles | WD2 publication |
+| Jan 18, 2023 | Profiles | WD2 publication |
 | Jan 19, 2023 | TD1.1 | CR transition |
 | Jan 19, 2023 | Discovery | CR transition |
 | Jan 19, 2023 | Arch1.1 | CR transition |


### PR DESCRIPTION
Update schedule assuming 4mo extension.  Add in deadlines for Profile.  We *might* be able to squeeze in a PR transition for Profile, but just barely.

Add in additional CR2 deadlines for Discovery, which we need to fix the DID problem.

Note this schedule has us going to PR prior to the end of the charter, but REC afterwards.