### PR TITLE
Draft WG Charter - 2023

### DIFF
--- a/charters/README.md
+++ b/charters/README.md
@@ -1,5 +1,7 @@
 # W3C Web of Things Group Charters
 
+To do: should be updated to follow latest process documented here: https://www.w3.org/Guide/process/charter.html.
+
 As decided in the [WebConf on 27 Apr 2016](https://www.w3.org/2016/04/27-wot-minutes.html), we now use the following process for our charter work:
 
 ## Process
@@ -38,7 +40,13 @@ Check [How to Get Involved](https://github.com/w3c/wot#how-to-get-involved) if y
   * [Rendered document](http://w3c.github.io/wot/charters/wot-wg-2016.html)
 
 #### 2019
-Note: Submitted, not yet approved.
+
+To do: following only points at draft, should be updated to point to published version
 
 * [Working document](https://github.com/w3c/wot/blob/master/charters/wot-wg-charter-draft-2019.html)
   * [Rendered document](https://cdn.statically.io/gh/w3c/wot/master/charters/wot-wg-charter-draft-2019.html?env=dev)
+
+#### 2023
+
+* [Working document](https://github.com/w3c/wot/blob/master/charters/wot-wg-2023-draft.html)
+  * [Rendered document](https://cdn.statically.io/gh/w3c/wot/master/charters/wot-wg-2023-draft?env=dev)

--- a/charters/wot-wg-2023-draft.html
+++ b/charters/wot-wg-2023-draft.html
@@ -97,11 +97,10 @@
         <p class="join"><a href="https://www.w3.org/groups/wg/wot/join">Join the Web of Things Working Group.</a></p>
       </div>
 
-         <p style="padding: 0.5ex; border: 1px solid green"> This proposed charter is available
-      on <i class="todo"><a href="https://github.com/w3c/wot">GitHub</a>.
-
-    Feel free to raise <a href="https://github.com/w3c/@@/issues">issues</a></i>.
-          </p>
+      <p style="padding: 0.5ex; border: 1px solid green"> This proposed charter is available
+        on <a href="https://github.com/w3c/wot">GitHub</a>.
+        Feel free to raise <a href="https://github.com/w3c/wot/issues">issues</a>.
+      </p>
 
       <div id="details">
         <table class="summary-table">
@@ -110,7 +109,8 @@
               Charter Status
             </th>
             <td>
-              <i class="todo">See the <a href="https://www.w3.org/groups/wg/[shortname]/charters">group status page</a> and <a href="https://w3c.github.io/charter-drafts/charter-template.html#history">detailed change history</a>.</i>
+              See the <a href="https://www.w3.org/groups/wg/wot/charters">group status page</a> 
+	      and <a href="https://w3c.github.io/charter-drafts/charter-template.html#history">detailed change history</a>.
             </td>
           </tr>		
           <tr id="Duration">
@@ -118,7 +118,7 @@
               Start date
             </th>
             <td>
-              <i class="todo">[dd monthname yyyy] (date of the "Call for Participation", when the charter is approved)</i>
+              <i class="todo">1 June 2023 (ESTIMATED) (date of the "Call for Participation", when the charter is approved)</i>
             </td>
           </tr>
           <tr id="CharterEnd">
@@ -126,7 +126,7 @@
               End date
             </th>
             <td>
-              <i class="todo">[dd monthname yyyy]</i> (Start date + 2 years)
+              <i class="todo">1 June 2025 (ESTIMATED; Start date + 2 years)</i>
             </td>
           </tr>
           <tr>
@@ -142,7 +142,7 @@
               Team Contacts
             </th>
             <td>
-              <span class="todo"><a href="mailto:">[team contact name]</a></span> <i class="todo">(0.1 <abbr title="Full-Time Equivalent">FTE</abbr>)</i>
+	      <a href="mailto:ashimura@w3.org">Kazuyuki Ashimura</a> (0.2 <abbr title="Full-Time Equivalent">FTE</abbr>)
             </td>
           </tr>
           <tr>
@@ -150,9 +150,13 @@
               Meeting Schedule
             </th>
             <td>
-              <strong>Teleconferences:</strong> <i class="todo">topic-specific calls may be held</i> or <i class="todo">somthing else</i>
+	      <strong>Teleconferences:</strong>
+		    Weekly with additional topic specific calls as appropriate.<br/>
               <br>
-              <strong>Face-to-face:</strong> we will meet during the W3C's annual Technical Plenary week; additional face-to-face meetings may be scheduled by consent of the participants, usually no more than 3 per year.
+              <strong>Face-to-face:</strong>
+		    We will meet during the W3C's annual Technical Plenary week;
+		    additional face-to-face meetings may be scheduled by consent of the participants,
+		    with no more than four (4) face-to-face meetings in total per year.
             </td>
           </tr>
         </tbody></table>
@@ -161,20 +165,64 @@
       </div>
 
       <div id="background" class="background">
-        <p><i class="todo">Brief background of landscape, technology, and relationship to the Web, users, developers, implementers, and industry.</i></p>
+        <!-- Brief background of landscape, technology, and relationship to the Web, users, developers, implementers, and industry. -->
+	<p>This working group is tasked with the standardization
+           or extension of several technological building blocks
+           identified by the
+           <a href="https://www.w3.org/groups/ig/wot">Web of Things Interest Group</a> (IG)
+           as being important to advancing the Web of Things.
+           The WoT building blocks are intended to complement existing
+           and emerging IoT standards by focusing on enabling cross-platform and cross-domain interoperability.
+           The proposed work items are summarized in the <a href="#scope">Scope</a> section, and
+	   include <span class="todo">(REVISE) interoperability profiles for particular usage contexts;
+           vocabulary support for new protocols, security schemes, and links;
+           standardized discovery mechanisms;
+	   and improvements to Thing Description Templates.</span>
+           These work items will be prototyped and tested by multiple implementors in
+           WoT IG <a href="https://w3c.github.io/wot/current-practices/wot-practices.html#plugfests">PlugFests</a>
+           during development.
+           Open-source implementations will be prioritized.</p>
       </div>
 
       <section id="scope" class="scope">
         <h2>Scope</h2>
-        <p><i class="todo">What exactly is in scope, and out of scope.
-          For legal review. Be brief.</i></p>
+        <!-- What exactly is in scope, and out of scope.
+          For legal review. Be brief. -->
+        <p>The Working Group has the following work items in scope:</p>
+
+        <div class="summary">
+          <p style="text-align:left;font-style:italic">Scope Summary</p>
+          After each work item, in parenthesis, we identify the deliverables it may be included in.
+          <dl class="todo">
+	    <dt><a href="#scope-item-id"><strong>[scope-item-name]:</strong> ([deliverable])</a></dt>
+              <dd>[description]</dd>
+	  </dl>
+	</div>
+
+	<p>Details for each of these are given below.</p>
+
+	<div class="todo">
+	<h3 id="scope-item-id">[scope-item-name]</h3>
+        <p>
+	   [extended description]
+        </p>
+	</div>
 
         <section id="section-out-of-scope">
           <h3 id="out-of-scope">Out of Scope</h3>
-            <p>The following features are out of scope, and will not be addressed by this <i class="todo">(Working|Interest)</i> group.</p>
+            <p>The following features are out of scope, and will not be addressed by this Working group.</p>
 
-            <ul class="out-of-scope">
-            </ul>
+	    <dl class="out-of-scope">
+            <dt><strong>Application- and domain-specific metadata vocabularies:</strong></dt>
+            <dd>The Working Group is restricted to work on cross-domain vocabularies.</dd>
+            <dt><strong>APIs and security frameworks specific to particular platforms external to the W3C:</strong></dt>
+            <dd>The scope of the Working Group is restricted to APIs and security frameworks that are applicable across platforms.
+            We will not define new security mechanisms but will use existing mechanisms and best practices.</dd>
+            <dt><strong>Modification of protocols:</strong></dt>
+            <dd>If during work on protocol bindings, it becomes apparent that changes are needed to protocols,
+            the Web of Things Working Group will rely on the organization responsible for the protocol to make the changes.
+	    It is out of scope for the Working Group to standardize such changes itself.</dd>
+            </dl>
         </section>
 
       </section>

--- a/charters/wot-wg-2023-draft.html
+++ b/charters/wot-wg-2023-draft.html
@@ -3,7 +3,7 @@
 <html lang="en-US"><head><meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
     
 
-    <title>&lt;i class="todo"&gt;[name]&lt;/i&gt; (Working|Interest) Group Charter</title>
+    <title>[DRAFT] Web of Things Working Group Charter</title>
 
     <link rel="stylesheet" href="./wot-wg-2023-draft_files/w3cdoc.css" type="text/css" media="screen">
     <link rel="stylesheet" type="text/css" href="./wot-wg-2023-draft_files/pubrules-style.css">
@@ -74,18 +74,31 @@
 
 
     <main>
-      <h1 id="title"><i class="todo">PROPOSED [name]</i> (Working|Interest) Group Charter</h1>
+      <h1 id="title">PROPOSED Web of Things Working Group Charter</h1>
       <!-- delete PROPOSED after AC review completed -->
 
-      <p class="mission">The <strong>mission</strong> of the <a href="https://w3c.github.io/charter-drafts/charter-template.html"><i class="todo">[name]</i> (Working|Interest) Group</a> is to <i class="todo">[do something cool and specific on the Web]</i>.</p>
+      <p class="mission">
+	The <strong>mission</strong> of the
+        <a href="https://www.w3.org/groups/wg/wot">Web of Things Working Group</a>
+        is to counter the fragmentation of the IoT through
+        the specification of building blocks
+        that enable easy integration of IoT devices and services
+        across IoT platforms and application domains.
+        These building blocks should complement and enhance existing standards.
+        This
+        <a class="todo" href="">Working Group Charter</a>
+        covers those aspects that the
+        <a href="http://www.w3.org/groups/ig/wot">Web of Things Interest Group</a>
+        <a href="https://www.w3.org/2021/12/wot-ig-2021.html">(charter here)</a>
+        believes are mature enough to progress to W3C Recommendations.
       <!-- the link to the group is ALWAYS that available from https://www.w3.org/groups/wg or https://www.w3.org/groups/ig because each group page can then point to a different homepage, but not the other way around. -->
 
       <div class="noprint">
-        <p class="join"><a href="https://www.w3.org/groups/wg/[shortname]/join">Join the <i class="todo">[name]</i> (Working|Interest) Group.</a></p>
+        <p class="join"><a href="https://www.w3.org/groups/wg/wot/join">Join the Web of Things Working Group.</a></p>
       </div>
 
          <p style="padding: 0.5ex; border: 1px solid green"> This proposed charter is available
-      on <i class="todo"><a href="https://github.com/w3c/@@">GitHub</a>.
+      on <i class="todo"><a href="https://github.com/w3c/wot">GitHub</a>.
 
     Feel free to raise <a href="https://github.com/w3c/@@/issues">issues</a></i>.
           </p>

--- a/charters/wot-wg-2023-draft.html
+++ b/charters/wot-wg-2023-draft.html
@@ -1,0 +1,516 @@
+<!DOCTYPE html>
+<!-- saved from url=(0058)https://w3c.github.io/charter-drafts/charter-template.html -->
+<html lang="en-US"><head><meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+    
+
+    <title>&lt;i class="todo"&gt;[name]&lt;/i&gt; (Working|Interest) Group Charter</title>
+
+    <link rel="stylesheet" href="./wot-wg-2023-draft_files/w3cdoc.css" type="text/css" media="screen">
+    <link rel="stylesheet" type="text/css" href="./wot-wg-2023-draft_files/pubrules-style.css">
+    <link rel="stylesheet" type="text/css" href="./wot-wg-2023-draft_files/charter-style.css">
+    <style>
+      main {
+        max-width: 60em;
+        margin: 0 auto;
+      }
+
+      ul#navbar {
+        font-size: small;
+      }
+
+      dt.spec {
+        font-weight: bold;
+      }
+
+      dt.spec new {
+        background: yellow;
+      }
+
+      ul.out-of-scope > li {
+        font-weight: bold;
+      }
+
+      ul.out-of-scope > li > ul > li{
+        font-weight: normal;
+      }
+
+      .issue {
+        background: cornsilk;
+        font-style: italic;
+      }
+
+      .todo {
+        color: #900;
+      }
+
+      footer {
+        font-size: small;
+      }
+    </style>
+  </head>
+  <body>
+    <header id="header">
+      <aside>
+        <ul id="navbar">
+          <li><a href="https://w3c.github.io/charter-drafts/charter-template.html#background">Background</a></li>
+          <li><a href="https://w3c.github.io/charter-drafts/charter-template.html#scope">Scope</a></li>
+          <li><a href="https://w3c.github.io/charter-drafts/charter-template.html#deliverables">Deliverables</a></li>
+		  <li><a href="https://w3c.github.io/charter-drafts/charter-template.html#success-criteria">Success Criteria</a></li>
+          <li><a href="https://w3c.github.io/charter-drafts/charter-template.html#coordination">Coordination</a></li>
+          <li><a href="https://w3c.github.io/charter-drafts/charter-template.html#participation">Participation</a></li>
+          <li><a href="https://w3c.github.io/charter-drafts/charter-template.html#communication">Communication</a></li>
+          <li><a href="https://w3c.github.io/charter-drafts/charter-template.html#decisions">Decision Policy</a></li>
+          <i class="todo">[Keep 'Patent Policy' for a Working Group, 'Patent Disclosures' for an Interest Group]</i>
+          <li><a href="https://w3c.github.io/charter-drafts/charter-template.html#patentpolicy">Patent Policy</a></li>
+          <li><a href="https://w3c.github.io/charter-drafts/charter-template.html#patentpolicy">Patent Disclosures</a></li>
+          <li><a href="https://w3c.github.io/charter-drafts/charter-template.html#licensing">Licensing</a></li>
+          <li><a href="https://w3c.github.io/charter-drafts/charter-template.html#about">About this Charter</a></li>
+        </ul>
+      </aside>
+      <p>
+        <a href="https://www.w3.org/"><img alt="W3C" height="48" src="./wot-wg-2023-draft_files/w3c_home" width="72"></a>
+      </p>
+    </header>
+
+
+    <main>
+      <h1 id="title"><i class="todo">PROPOSED [name]</i> (Working|Interest) Group Charter</h1>
+      <!-- delete PROPOSED after AC review completed -->
+
+      <p class="mission">The <strong>mission</strong> of the <a href="https://w3c.github.io/charter-drafts/charter-template.html"><i class="todo">[name]</i> (Working|Interest) Group</a> is to <i class="todo">[do something cool and specific on the Web]</i>.</p>
+      <!-- the link to the group is ALWAYS that available from https://www.w3.org/groups/wg or https://www.w3.org/groups/ig because each group page can then point to a different homepage, but not the other way around. -->
+
+      <div class="noprint">
+        <p class="join"><a href="https://www.w3.org/groups/wg/[shortname]/join">Join the <i class="todo">[name]</i> (Working|Interest) Group.</a></p>
+      </div>
+
+         <p style="padding: 0.5ex; border: 1px solid green"> This proposed charter is available
+      on <i class="todo"><a href="https://github.com/w3c/@@">GitHub</a>.
+
+    Feel free to raise <a href="https://github.com/w3c/@@/issues">issues</a></i>.
+          </p>
+
+      <div id="details">
+        <table class="summary-table">
+          <tbody><tr id="Status">
+            <th>
+              Charter Status
+            </th>
+            <td>
+              <i class="todo">See the <a href="https://www.w3.org/groups/wg/[shortname]/charters">group status page</a> and <a href="https://w3c.github.io/charter-drafts/charter-template.html#history">detailed change history</a>.</i>
+            </td>
+          </tr>		
+          <tr id="Duration">
+            <th>
+              Start date
+            </th>
+            <td>
+              <i class="todo">[dd monthname yyyy] (date of the "Call for Participation", when the charter is approved)</i>
+            </td>
+          </tr>
+          <tr id="CharterEnd">
+            <th>
+              End date
+            </th>
+            <td>
+              <i class="todo">[dd monthname yyyy]</i> (Start date + 2 years)
+            </td>
+          </tr>
+          <tr>
+            <th>
+              Chairs
+            </th>
+            <td>
+              <i class="todo">[chair name] (affiliation)</i>
+            </td>
+          </tr>
+          <tr>
+            <th>
+              Team Contacts
+            </th>
+            <td>
+              <span class="todo"><a href="mailto:">[team contact name]</a></span> <i class="todo">(0.1 <abbr title="Full-Time Equivalent">FTE</abbr>)</i>
+            </td>
+          </tr>
+          <tr>
+            <th>
+              Meeting Schedule
+            </th>
+            <td>
+              <strong>Teleconferences:</strong> <i class="todo">topic-specific calls may be held</i> or <i class="todo">somthing else</i>
+              <br>
+              <strong>Face-to-face:</strong> we will meet during the W3C's annual Technical Plenary week; additional face-to-face meetings may be scheduled by consent of the participants, usually no more than 3 per year.
+            </td>
+          </tr>
+        </tbody></table>
+
+        <p class="issue"><b>Note:</b> The <a href="https://www.w3.org/Consortium/Process/#WGCharter">W3C Process Document</a> requires “The level of confidentiality of the group's proceedings and deliverables”; however, it does not mandate where this appears. Since all W3C Working Groups should be chartered as public, this notice has been moved from the essentials table to the <a href="https://w3c.github.io/charter-drafts/charter-template.html#public">communication section</a>.</p>
+      </div>
+
+      <div id="background" class="background">
+        <p><i class="todo">Brief background of landscape, technology, and relationship to the Web, users, developers, implementers, and industry.</i></p>
+      </div>
+
+      <section id="scope" class="scope">
+        <h2>Scope</h2>
+        <p><i class="todo">What exactly is in scope, and out of scope.
+          For legal review. Be brief.</i></p>
+
+        <section id="section-out-of-scope">
+          <h3 id="out-of-scope">Out of Scope</h3>
+            <p>The following features are out of scope, and will not be addressed by this <i class="todo">(Working|Interest)</i> group.</p>
+
+            <ul class="out-of-scope">
+            </ul>
+        </section>
+
+      </section>
+
+      <section id="deliverables">
+        <h2>
+          Deliverables
+        </h2>
+
+        <p><i class="todo">Updated document status is available on the <a href="https://www.w3.org/groups/wg/[shortname]/publications">group publication status page</a>. [or link to a page this group prefers to use]</i></p>
+
+        <p><i>Draft state</i> indicates the state of the deliverable at the time of the charter approval. <span class="todo">Choose one:</span> <i>Expected completion</i> indicates when the deliverable is projected to become a Recommendation, or otherwise reach a stable state
+          <span class="todo">The Working Group intends to publish the latest state of their work as Candidate Recommendation (with Snapshots) and does not intend to advance their documents to Recommendation</span>.</p>
+
+        <section id="normative">
+          <h3>
+            Normative Specifications
+          </h3>
+          <p>
+            The <i class="todo">(Working|Interest)</i> Group will deliver the following W3C normative specifications:
+          </p>
+          <dl>
+            <dt id="web-foo" class="spec"><a href="https://w3c.github.io/charter-drafts/charter-template.html#">Web <i class="todo">[spec name]</i></a></dt>
+            <dd>
+              <p>This specification defines <i class="todo">[concrete description]</i>.</p>
+
+              <p class="draft-status"><b>Draft state:</b> <i class="todo">[No draft | <a href="https://w3c.github.io/charter-drafts/charter-template.html#">Use Cases and Requirements</a> | <a href="https://w3c.github.io/charter-drafts/charter-template.html#">Editor's Draft</a> | <a href="https://w3c.github.io/charter-drafts/charter-template.html#">Member Submission</a> | <a href="https://w3c.github.io/charter-drafts/charter-template.html#">Adopted from WG/CG Foo</a> | <a href="https://w3c.github.io/charter-drafts/charter-template.html#">Working Draft</a>]</i></p>
+              <p class="milestone"><b>Expected completion:</b> <i class="todo">[Q1–4 yyyy]</i></p>
+              <p class="todo">Per <a href="https://www.w3.org/Consortium/Process/#WGCharter">5.2.6</a>, for every Recommendation Track deliverable that continues work on a Working Draft (WD) published under any other Charter (including a predecessor group of the same name), for which there is an existing <a href="https://www.w3.org/Consortium/Process/#exclusion-draft">Exclusion Draft</a>: </p>
+              <p><b>Adopted Draft:</b> The <span class="todo">title, stable URL, and publication date of the <a href="https://www.w3.org/Consortium/Process/#adopted-draft">Adopted Draft</a></span> which will serve as the basis for work on the deliverable.
+              </p><p><b>Exclusion Draft:</b> The <span class="todo">title, stable URL, and publication date of the most recent <a href="https://www.w3.org/Consortium/Process/#exclusion-draft">Exclusion Draft</a></span>.
+              <span class="todo">Exclusion period <b>began</b>; Exclusion period <b>ended</b>.</span> <span class="todo">(this <a href="https://www.w3.org/2004/01/pp-impl/charter-assistant?wgid=32061">charter assistant</a> helps in producing the list. use the proper <a href="https://www.w3.org/2004/01/pp-impl/">wgid</a>)</span>
+              </p><p><b>Exclusion Draft Charter:</b> The  <span class="todo">stable URL of the <a href="https://www.w3.org/Consortium/Process/#other-charter">Working Group charter</a></span> under which the most recent Exclusion Draft was published.
+            </p></dd>
+          </dl>
+
+
+        </section>
+
+        <section id="ig-other-deliverables">
+          <h3>
+            Other Deliverables
+          </h3>
+          <p>
+            Other non-normative documents may be created such as:
+          </p>
+          <ul>
+            <li>Use case and requirement documents;</li>
+            <li>Test suite and implementation report for the specification;</li>
+            <li>Primer or Best Practice documents to support web developers when designing applications.</li>
+          </ul>
+        </section>
+
+        <section id="timeline">
+          <h3>Timeline</h3>
+            <p class="todo">Put here a timeline view of all deliverables.</p>
+            <ul class="todo">
+              <li>Month YYYY: First teleconference</li>
+              <li>Month YYYY: First face-to-face meeting</li>
+              <li>Month YYYY: Requirements and Use Cases for FooML</li>
+              <li>Month YYYY: FPWD for FooML</li>
+              <li>Month YYYY: Requirements and Use Cases for BarML</li>
+              <li>Month YYYY: FPWD FooML Primer</li>
+            </ul>
+        </section>
+      </section>
+
+	<section id="success-criteria">
+	  <h2>Success Criteria</h2>
+
+    <!-- Testing and interop -->
+	  <p><span class="todo">Remove this clause if the Group does not intend to move to REC:</span> In order to advance to 
+		  <a href="https://www.w3.org/Consortium/Process/#RecsPR" title="Proposed Recommendation">Proposed Recommendation</a>, each normative specification is expected to have 
+		  <a href="https://www.w3.org/Consortium/Process/#implementation-experience">at least two independent interoperable
+			  implementations</a> of every feature defined in the specification, where
+interoperability can be verified by passing open test suites, and two or
+more implementations interoperating with each other. In order to advance to
+Proposed Recommendation, each normative specification must have an open
+test suite of every feature defined in the specification.</p>
+	  <p>There should be testing plans for each specification, starting from the earliest drafts.</p>
+    <p><span class="todo">Consider adopting a healthy testing policy, such as:</span> 
+      To promote interoperability, all changes made to specifications 
+      in Candidate Recommendation 
+      or to features that have deployed implementations
+      should have <a href="https://www.w3.org/2019/02/testing-policy.html">tests</a>.  
+      Testing efforts should be conducted via the <a href="https://github.com/web-platform-tests/wpt">Web Platform Tests</a> project.</p>
+
+    <!-- Horizontal review -->
+    <p>Each specification should contain sections detailing all known security and privacy implications for implementers, Web authors, and end users.</p>
+	  <p><i class="todo">For specifications of technologies that directly impact user experience, such as content technologies, as well as protocols and APIs which impact content: </i>
+		Each specification should contain a section on accessibility that describes the benefits and impacts, including ways specification features can be used to address them, and
+		recommendations for maximising accessibility in implementations.</p>
+	
+    <!-- Relevance and momentum -->
+	  <p><span class="todo">Consider adding this clause if the Group does not intend to move to REC:</span> All new features should be supported by at least two intents to implement before being incorporated in the specification.</p>
+	</section>
+
+      <section id="coordination">
+        <h2>Coordination</h2>
+        <p>For all specifications, this <i class="todo">(Working|Interest)</i> Group will seek <a href="https://www.w3.org/Guide/documentreview/#how_to_get_horizontal_review">horizontal review</a> for
+          accessibility, internationalization, privacy, and security with the relevant Working and
+          Interest Groups, and with the <a href="https://www.w3.org/2001/tag/" title="Technical Architecture Group">TAG</a>.
+          Invitation for review must be issued during each major standards-track document transition, including
+          <a href="https://www.w3.org/Consortium/Process/#RecsWD" title="First Public Working Draft">FPWD</a>.  The
+          <i class="todo">(Working|Interest)</i> Group is encouraged to engage collaboratively with the horizontal review groups throughout development of
+          each specification.  The <i class="todo">(Working|Interest)</i> Group is advised to seek a review at least 3 months before first entering
+          <a href="https://www.w3.org/Consortium/Process/#RecsCR" title="Candidate Recommendation">CR</a> and is encouraged
+          to proactively notify the horizontal review groups when major changes occur in a specification following a review.</p>
+
+        <p>Additional technical coordination with the following Groups will be made, per the <a href="https://www.w3.org/Consortium/Process/#WGCharter">W3C Process Document</a>:</p>
+
+      	<p class="todo">In addition to the above catch-all reference to horizontal review which includes accessibility review, please check with chairs and staff contacts of the <a href="https://www.w3.org/WAI/APA/">Accessible Platform Architectures Working Group</a> to determine if an additional liaison statement with more specific information about concrete review issues is needed in the list below.</p>
+
+        <section>
+          <h3 id="w3c-coordination">W3C Groups</h3>
+          <dl>
+            <dt><a href="https://w3c.github.io/charter-drafts/charter-template.html"><i class="todo">[other name]</i> Working Group</a></dt>
+            <dd><i class="todo">[specific nature of liaison]</i></dd>
+          </dl>
+
+          <p class="issue"><b>Note:</b> Do not list horizontal groups here, only specific WGs relevant to your work.</p>
+          <p class="issue"><b>Note:</b> Do not bury normative text inside the liaison section.
+            Instead, put it in the scope section.</p>
+        </section>
+
+        <section>
+          <h3 id="external-coordination">External Organizations</h3>
+          <dl>
+            <dt><a href="https://w3c.github.io/charter-drafts/charter-template.html"><i class="todo">[other name]</i> Working Group</a></dt>
+            <dd><i class="todo">[specific nature of liaison]</i></dd>
+          </dl>
+        </section>
+      </section>
+
+
+
+      <section class="participation">
+        <h2 id="participation">
+          Participation
+        </h2>
+        <p>
+          To be successful, this <i class="todo">(Working|Interest)</i> Group is expected to have 6 or more active participants for its duration, including representatives from the key implementors of this specification, and active Editors and Test Leads for each specification. The Chairs, specification Editors, and Test Leads are expected to contribute half of a working day per week towards the <i class="todo">(Working|Interest)</i> Group. There is no minimum requirement for other Participants.
+        </p>
+        <p>
+          The group encourages questions, comments and issues on its public mailing lists and document repositories, as described in <a href="https://w3c.github.io/charter-drafts/charter-template.html#communication">Communication</a>.
+        </p>
+        <p>
+          The group also welcomes non-Members to contribute technical submissions for consideration upon their agreement to the terms of the <a href="https://www.w3.org/Consortium/Patent-Policy/">W3C Patent Policy</a>.
+        </p>
+        <p>Participants in the group are required (by the <a href="https://www.w3.org/Consortium/Process/#ParticipationCriteria">W3C Process</a>) to follow the
+          W3C <a href="https://www.w3.org/Consortium/cepc/">Code of Ethics and Professional Conduct</a>.</p>
+      </section>
+
+
+
+      <section id="communication">
+        <h2>
+          Communication
+        </h2>
+        <p id="public">
+          Technical discussions for this <i class="todo">(Working|Interest)</i> Group are conducted in <a href="https://www.w3.org/Consortium/Process/#confidentiality-levels">public</a>: the meeting minutes from teleconference and face-to-face meetings will be archived for public review, and technical discussions and issue tracking will be conducted in a manner that can be both read and written to by the general public. Working Drafts and Editor's Drafts of specifications will be developed in public repositories and may permit direct public contribution requests.
+        The meetings themselves are not open to public participation, however.
+        </p>
+        <p>
+          Information about the group (including details about deliverables, issues, actions, status, participants, and meetings) will be available from the <a href="https://w3c.github.io/charter-drafts/charter-template.html"><i class="todo">[name]</i> (Working|Interest) Group home page.</a>
+        </p>
+        <p>
+          Most <i class="todo">[name]</i> (Working|Interest) Group teleconferences will focus on discussion of particular specifications, and will be conducted on an as-needed basis.
+        </p>
+        <p>
+          This group primarily conducts its technical work  <i class="todo">pick one, or both, as appropriate:</i> on the public mailing list <a class="todo" id="public-name" href="mailto:public-[email-list]@w3.org">public-<i class="todo">[email-list]</i>@w3.org</a> (<a class="todo" href="https://lists.w3.org/Archives/Public/public-[email-list]/">archive</a>)
+          <i class="todo">or</i> on <a class="todo" id="public-github" href="https://w3c.github.io/charter-drafts/[link%20to%20Github%20repo]">GitHub issues</a>.
+          The public is invited to review, discuss and contribute to this work.
+        </p>
+        <p>
+          The group may use a Member-confidential mailing list for administrative purposes and, at the discretion of the Chairs and members of the group, for member-only discussions in special cases when a participant requests such a discussion.
+        </p>
+      </section>
+
+
+
+      <section id="decisions">
+        <h2>
+          Decision Policy
+        </h2>
+        <p>
+          This group will seek to make decisions through consensus and due process, per the <a href="https://www.w3.org/Consortium/Process/#Consensus">W3C Process Document (section 5.2.1, Consensus)</a>. Typically, an editor or other participant makes an initial proposal, which is then refined in discussion with members of the group and other reviewers, and consensus emerges with little formal voting being required.</p>
+        <p>
+           However, if a decision is necessary for timely progress and consensus is not achieved after careful consideration of the range of views presented, the Chairs may call for a group vote and record a decision along with any objections.
+        </p>
+        <p>
+          To afford asynchronous decisions and organizational deliberation, any resolution (including publication decisions) taken in a face-to-face meeting or teleconference will be considered provisional.
+
+          A call for consensus (CfC) will be issued for all resolutions (for example, via email, GitHub issue or web-based survey), with a response period from <span id="cfc"><i class="todo">[pick a duration within:] one week to 10 working days</i></span>, depending on the chair's evaluation of the group consensus on the issue.
+
+          If no objections are raised by the end of the response period, the resolution will be considered to have consensus as a resolution of the <i class="todo">(Working|Interest)</i> Group.
+        </p>
+        <p>
+          All decisions made by the group should be considered resolved unless and until new information becomes available or unless reopened at the discretion of the Chairs or the Director.
+        </p>
+        <p>
+          This charter is written in accordance with the <a href="https://www.w3.org/Consortium/Process/#Votes">W3C Process Document (Section 5.2.3, Deciding by Vote)</a> and includes no voting procedures beyond what the Process Document requires.
+        </p>
+      </section>
+
+
+
+      <section id="patentpolicy">
+      <p><i class="todo">[Keep 'Patent Policy' for a Working Group, 'Patent Disclosures' for an Interest Group]</i></p>
+
+        <h2>
+          Patent Policy
+        </h2>
+        <p>
+          This Working Group operates under the <a href="https://www.w3.org/Consortium/Patent-Policy/">W3C Patent Policy</a> (Version of 15 September 2020). To promote the widest adoption of Web standards, W3C seeks to issue Web specifications that can be implemented, according to this policy, on a Royalty-Free basis.
+
+          For more information about disclosure obligations for this group, please see the <a href="https://www.w3.org/groups/wg/[shortname]/ipr">licensing information</a>.
+        </p>
+
+        <h2>Patent Disclosures </h2>
+        <p>The Interest Group provides an opportunity to
+          share perspectives on the topic addressed by this charter. W3C reminds
+          Interest Group participants of their obligation to comply with patent
+          disclosure obligations as set out in <a href="https://www.w3.org/Consortium/Patent-Policy/#sec-Disclosure">Section
+            6</a> of the W3C Patent Policy. While the Interest Group does not
+          produce Recommendation-track documents, when Interest Group
+          participants review Recommendation-track specifications from Working
+          Groups, the patent disclosure obligations do apply. For more information about disclosure obligations for this group,
+          please see the <a href="https://www.w3.org/groups/ig/[shortname]/ipr">licensing information</a>.</p>
+      </section>
+
+
+
+      <section id="licensing">
+        <h2>Licensing</h2>
+        <p>This <i class="todo">(Working|Interest)</i> Group will use the <i class="todo">[pick a license, one of:]</i>  <a href="https://www.w3.org/Consortium/Legal/copyright-documents">W3C Document license</a> | <a href="https://www.w3.org/Consortium/Legal/copyright-software">W3C Software and Document license</a> for all its deliverables.</p>
+      </section>
+
+
+
+      <section id="about">
+        <h2>
+          About this Charter
+        </h2>
+        <p>
+          This charter has been created according to <a href="https://www.w3.org/Consortium/Process/#GAGeneral">section 3.4</a> of the <a href="https://www.w3.org/Consortium/Process/">Process Document</a>. In the event of a conflict between this document or the provisions of any charter and the W3C Process, the W3C Process shall take precedence.
+        </p>
+
+        <section id="history">
+          <h3>
+            Charter History
+          </h3>
+          <p class="issue"><b>Note:</b>Display this table and update it when appropriate. Requirements for charter extension history are documented in the <a href="https://www.w3.org/Guide/process/charter.html#extension">Charter Guidebook (section 4)</a>.</p>
+
+          <p>The following table lists details of all changes from the initial charter, per the <a href="https://www.w3.org/Consortium/Process/#CharterReview">W3C Process Document (section 4.3, Advisory Committee Review of a Charter)</a>:</p>
+
+          <table class="history">
+            <tbody>
+              <tr>
+                <th>
+                  Charter Period
+                </th>
+                <th>
+                  Start Date
+                </th>
+                <th>
+                  End Date
+                </th>
+                <th>
+                  Changes
+                </th>
+              </tr>
+              <tr>
+                <th>
+                  <a class="todo" href="https://w3c.github.io/charter-drafts/charter-template.html">Initial Charter</a>
+                </th>
+                <td>
+                  <i class="todo">[dd monthname yyyy]</i>
+                </td>
+                <td>
+                  <i class="todo">[dd monthname yyyy]</i>
+                </td>
+                <td>
+                  <i class="todo">none</i>
+                </td>
+              </tr>
+              <tr>
+                <th>
+                  <a class="todo" href="https://w3c.github.io/charter-drafts/charter-template.html">Charter Extension</a>
+                </th>
+                <td>
+                  <i class="todo">[dd monthname yyyy]</i>
+                </td>
+                <td>
+                  <i class="todo">[dd monthname yyyy]</i>
+                </td>
+                <td>
+                  <i class="todo">none</i>
+                </td>
+              </tr>
+              <tr>
+                <th>
+                  <a class="todo" href="https://w3c.github.io/charter-drafts/charter-template.html">Rechartered</a>
+                </th>
+                <td>
+                  <i class="todo">[dd monthname yyyy]</i>
+                </td>
+                <td>
+                  <i class="todo">[dd monthname yyyy]</i>
+                </td>
+                <td>
+                  <p class="todo">[description of change to charter, with link to new deliverable item in charter] <b>Note:</b> use the class <code>new</code> for all new deliverables, for ease of recognition.</p>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </section>
+
+        <section id="changelog">
+          <h3>Change log</h3>
+
+          <!-- Use this section for changes _after_ the charter was approved by the Director. -->
+          <p>Changes to this document are documented in this section.</p>
+          <!--
+          <dl id='changes'>
+            <dt>YYYY-MM-DD</dt>
+            <dd>[changes]]</dd>
+          </dl>
+          -->
+        </section>
+      </section>
+    </main>
+
+    <hr>
+
+    <footer>
+      <address>
+        <i class="todo"><a href="mailto:">[team contact name]</a></i>
+      </address>
+
+<p class="copyright">Copyright © <i class="todo">[yyyy]</i> <a href="https://www.w3.org/">World Wide Web Consortium</a>.<br>
+  <abbr title="World Wide Web Consortium">W3C</abbr><sup>®</sup>
+  <a href="https://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer">liability</a>,
+  <a href="https://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks">trademark</a> and
+      <a rel="license" href="https://www.w3.org/Consortium/Legal/2015/copyright-software-and-document" title="W3C Software and Document Notice and License">permissive document license</a> rules apply.</p>
+      <hr>
+      <p><span class="todo"><a href="https://github.com/w3c/charter-drafts">Yes, it's on GitHub!</a>.</span></p>
+    </footer>
+
+  
+
+</body></html>


### PR DESCRIPTION
- Template copied from https://w3c.github.io/charter-drafts/charter-template.html
- Official process: https://www.w3.org/Guide/process/charter.html
- Update README to point at above process document, link to draft charter
- [Rendered document](https://cdn.statically.io/gh/w3c/wot/wot-wg-2023-charter-draft/charters/wot-wg-2023-draft.html?env=dev)