### PR TITLE
WG 2023 Charter - Decision Policy

### DIFF
--- a/charters/wot-wg-2023-draft.html
+++ b/charters/wot-wg-2023-draft.html
@@ -416,9 +416,9 @@ test suite of every feature defined in the specification.</p>
         <p>
           To afford asynchronous decisions and organizational deliberation, any resolution (including publication decisions) taken in a face-to-face meeting or teleconference will be considered provisional.
 
-          A call for consensus (CfC) will be issued for all resolutions (for example, via email, GitHub issue or web-based survey), with a response period from <span id="cfc"><i class="todo">[pick a duration within:] one week to 10 working days</i></span>, depending on the chair's evaluation of the group consensus on the issue.
+          A call for consensus (CfC) will be issued for all resolutions (for example, via email, GitHub issue or web-based survey), with a response period from one week to 10 working days, depending on the chair's evaluation of the group consensus on the issue.
 
-          If no objections are raised by the end of the response period, the resolution will be considered to have consensus as a resolution of the <i class="todo">(Working|Interest)</i> Group.
+          If no objections are raised by the end of the response period, the resolution will be considered to have consensus as a resolution of the Working Group.
         </p>
         <p>
           All decisions made by the group should be considered resolved unless and until new information becomes available or unless reopened at the discretion of the Chairs or the Director.


### PR DESCRIPTION
- Define decision policy
- Initial version: just revise the template to apply to a Working Group.  
- Expect further input and modifications before we merge, for example to specify CfC policy (is draft minutes enough?) and async decision policy on PRs, so expect further changes on this section; this PR is just a starting point.