### PR TITLE
WG Charter - Binding Templates 

### DIFF
--- a/charters/wot-wg-2023-draft.html
+++ b/charters/wot-wg-2023-draft.html
@@ -242,6 +242,42 @@
               <a href="#security-deliverable">Security</a>,
               <a href="#profiles-deliverable">Profiles</a>):</dt>
             <dd>Add normative binding mechanism</dd>
+          <dt><a href="#http-binding-workitem"><strong>HTTP Protocol Binding</strong></a> 
+            (<a href="#binding:-deliverable">Binding Templates</a>)
+            <dd>Add normative HTTP binding</dd>
+          <dt><a href="#coap-binding-workitem"><strong>CoAP Protocol Binding</strong></a> 
+              (<a href="#binding:-deliverable">Binding Templates</a>)
+              <dd>Add normative CoAP binding</dd>
+          <dt><a href="#mqtt-binding-workitem"><strong>MQTT Protocol Binding</strong></a> 
+            (<a href="#binding:-deliverable">Binding Templates</a>)
+            <dd>Add normative MQTT binding</dd>
+          <dt><a href="#modbus-binding-workitem"><strong>Modbus Protocol Binding</strong></a> 
+            (<a href="#binding:-deliverable">Binding Templates</a>)
+            <dd>Add normative Modbus binding</dd>
+          <dt><a href="#bacnet-binding-workitem"><strong>BACnet Protocol Binding</strong></a> 
+            (<a href="#binding:-deliverable">Binding Templates</a>)
+            <dd>Add normative BACnet binding</dd>
+          <dt><a href="#opcua-binding-workitem"><strong>OPC UA Protocol Binding</strong></a> 
+            (<a href="#binding:-deliverable">Binding Templates</a>)
+            <dd>Add normative OPC UA binding</dd>
+          <dt><a href="#grpc-binding-workitem"><strong>gRPC Protocol Binding</strong></a> 
+            (<a href="#binding:-deliverable">Binding Templates</a>)
+            <dd>Add normative gRPC binding</dd>
+          <dt><a href="#json-binding-workitem"><strong>JSON Payload Binding</strong></a> 
+            (<a href="#binding:-deliverable">Binding Templates</a>)
+            <dd>Add normative JSON binding</dd>
+          <dt><a href="#cbor-binding-workitem"><strong>CBOR Payload Binding</strong></a> 
+            (<a href="#binding:-deliverable">Binding Templates</a>)
+            <dd>Add normative CBOR binding</dd>
+          <dt><a href="#xml-binding-workitem"><strong>XML Payload Binding</strong></a> 
+            (<a href="#binding:-deliverable">Binding Templates</a>)
+            <dd>Add normative XML binding</dd>
+          <dt><a href="#cloudevents-binding-workitem"><strong>CloudEvents Payload Binding</strong></a> 
+            (<a href="#binding:-deliverable">Binding Templates</a>)
+            <dd>Add normative CloudEvents binding</dd>
+          <dt><a href="#echonet-binding-workitem"><strong>ECHONET Lite Web API Combination Binding</strong></a> 
+            (<a href="#binding:-deliverable">Binding Templates</a>)
+            <dd>Add normative ECHONET Lite Web API binding</dd>
 	        </dl>
 	      </div>
 
@@ -360,64 +396,64 @@
       The current mechanism for how a protocol or payload binding should happen is largely informative with some normative text in different deliverables.
       The WG will consolidate the explanation of the mechanism and explain it in further detail.
     </p>
-  <h3 id="http-binding-workitem">HTTP Binding</h3>
+  <h3 id="http-binding-workitem">HTTP Protocol Binding</h3>
     <p>
-      The WG will work on the current HTTP Binding that is split also into the TD specification in order to publish it as a standalone normative document.
+      The WG will work on the current HTTP Protocol Binding that is split also into the TD specification in order to publish it as a standalone normative document.
       This will reference the HTTP in RDF ontology, introduce default values and describe the terms associated with the behavior of Things regarding the usage of the HTTP.
     </p>
-  <h3 id="coap-binding-workitem">CoAP Binding</h3>
+  <h3 id="coap-binding-workitem">CoAP Protocol Binding</h3>
     <p>
-      The WG will work on the current Modbus Binding in order to publish it as a standalone normative document.
+      The WG will work on the current Modbus Protocol Binding in order to publish it as a standalone normative document.
       This will include a CoAP ontology, introduce default values and describe the terms associated with the behavior of Things regarding the usage of the CoAP.
     </p>
-  <h3 id="mqtt-binding-workitem">MQTT Binding</h3>
+  <h3 id="mqtt-binding-workitem">MQTT Protocol Binding</h3>
     <p>
-      The WG will work on the current MQTT Binding in order to publish it as a standalone normative document.
+      The WG will work on the current MQTT Protocol Binding in order to publish it as a standalone normative document.
       This will include a MQTT ontology, introduce default values and describe the terms associated with the behavior of Things and Brokers regarding the usage of the MQTT.
     </p>
-  <h3 id="modbus-binding-workitem">Modbus Binding</h3>
+  <h3 id="modbus-binding-workitem">Modbus Protocol Binding</h3>
     <p>
-      The WG will work on the current Modbus Binding in order to publish it as a standalone normative document.
+      The WG will work on the current Modbus Protocol Binding in order to publish it as a standalone normative document.
       This will include a Modbus ontology, introduce default values and describe the terms associated with the behavior of Things regarding the usage of the Modbus.
     </p>
-  <h3 id="bacnet-binding-workitem" class="todo">BACnet Binding</h3>
+  <h3 id="bacnet-binding-workitem" class="todo">BACnet Protocol Binding</h3>
     <p>
-      The WG will work on specifying a BACnet Binding for the Web of Things in order to publish it as a standalone normative document.
+      The WG will work on specifying a BACnet Protocol Binding for the Web of Things in order to publish it as a standalone normative document.
       This will include a BACnet ontology, introduce default values and describe the terms associated with the behavior of Things regarding the usage of the BACnet.
       Note: How should we mention ASHRAE here?
     </p>
-  <h3 id="opcua-binding-workitem" class="todo">OPC UA Binding</h3>
+  <h3 id="opcua-binding-workitem" class="todo">OPC UA Protocol Binding</h3>
     <p>
-      The WG will work on specifying an OPC UA Binding for the Web of Things in order to publish it as a standalone normative document.
+      The WG will work on specifying an OPC UA Protocol Binding for the Web of Things in order to publish it as a standalone normative document.
       This will include a OPC UA ontology, introduce default values and describe the terms associated with the behavior of Things regarding the usage of the OPC UA.
       Note: How should we mention OPC Foundation here?
     </p>
-  <h3 id="gRPC-binding-workitem">gRPC Binding</h3>
+  <h3 id="grpc-binding-workitem">gRPC Protocol Binding</h3>
     <p>
-      The WG will work on specifying a gRPC Binding for the Web of Things in order to publish it as a standalone normative document.
+      The WG will work on specifying a gRPC Protocol Binding for the Web of Things in order to publish it as a standalone normative document.
       This will include a gRPC ontology, introduce default values and describe the terms associated with the behavior of Things regarding the usage of the gRPC.
     </p>
-  <h3 id="json-binding-workitem">JSON Binding</h3>
+  <h3 id="json-binding-workitem">JSON Payload Binding</h3>
     <p>
       The WG will work on specifying a JSON Payload Binding for the Web of Things in order to publish it as a standalone normative document.
       This will include specification on the usage of Data Schema terms as well as <code>contentType</code> term usage within forms.
     </p>
-  <h3 id="cbor-binding-workitem">CBOR Binding</h3>
+  <h3 id="cbor-binding-workitem">CBOR Payload Binding</h3>
     <p>
       The WG will work on specifying a CBOR Payload Binding for the Web of Things in order to publish it as a standalone normative document.
       This will include specification on the usage of Data Schema terms as well as <code>contentType</code> term usage within forms.
     </p>
-  <h3 id="xml-binding-workitem">XML Binding</h3>
+  <h3 id="xml-binding-workitem">XML Payload Binding</h3>
     <p>
       The WG will work on specifying an XML Payload Binding for the Web of Things in order to publish it as a standalone normative document.
       This will include specification on the usage of Data Schema terms as well as <code>contentType</code> term usage within forms.
     </p>
-  <h3 id="cloudevents-binding-workitem">CloudEvents Binding</h3>
+  <h3 id="cloudevents-binding-workitem">CloudEvents Payload Binding</h3>
     <p>
       The WG will work on specifying an CloudEvents Payload Binding for the Web of Things in order to publish it as a standalone normative document.
       This will include specification on the usage of Data Schema terms as well as <code>contentType</code> term usage within forms.
     </p>
-  <h3 id="echonet-binding-workitem" class="todo">ECHONET Lite Web API Binding</h3>
+  <h3 id="echonet-binding-workitem" class="todo">ECHONET Lite Web API Combination Binding</h3>
     <p>
       The WG will work on specifying an ECHONET Lite Web API Combination Binding for the Web of Things in order to publish it as a standalone normative document.
       This will include specification on the usage of Data Schema terms, together with how form elements should be structured with possible other assertions on the TD instances.

--- a/charters/wot-wg-2023-draft.html
+++ b/charters/wot-wg-2023-draft.html
@@ -236,6 +236,12 @@
             <a href="#security-deliverable">Security</a>):</dt>
            <dd>Add support for TD signing and support signed TDs in the discovery process.
             Requires definition of TD canonicalization.</dd>
+          <dt><a href="#binding-mechanism-workitem"><strong>Binding Mechanism</strong></a> 
+            (<a href="#binding:-deliverable">Binding Templates</a>,
+              <a href="#thing-description-deliverable">Thing Description</a>,
+              <a href="#security-deliverable">Security</a>,
+              <a href="#profiles-deliverable">Profiles</a>):</dt>
+            <dd>Add normative binding mechanism</dd>
 	        </dl>
 	      </div>
 
@@ -349,7 +355,74 @@
         Directories should be extended to verify signatures and generate new chained signatures
         as needed.
         </p>
-
+  <h3 id="binding-mechanism-workitem">Binding Mechanism</h3>
+    <p>
+      The current mechanism for how a protocol or payload binding should happen is largely informative with some normative text in different deliverables.
+      The WG will consolidate the explanation of the mechanism and explain it in further detail.
+    </p>
+  <h3 id="http-binding-workitem">HTTP Binding</h3>
+    <p>
+      The WG will work on the current HTTP Binding that is split also into the TD specification in order to publish it as a standalone normative document.
+      This will reference the HTTP in RDF ontology, introduce default values and describe the terms associated with the behavior of Things regarding the usage of the HTTP.
+    </p>
+  <h3 id="coap-binding-workitem">CoAP Binding</h3>
+    <p>
+      The WG will work on the current Modbus Binding in order to publish it as a standalone normative document.
+      This will include a CoAP ontology, introduce default values and describe the terms associated with the behavior of Things regarding the usage of the CoAP.
+    </p>
+  <h3 id="mqtt-binding-workitem">MQTT Binding</h3>
+    <p>
+      The WG will work on the current MQTT Binding in order to publish it as a standalone normative document.
+      This will include a MQTT ontology, introduce default values and describe the terms associated with the behavior of Things and Brokers regarding the usage of the MQTT.
+    </p>
+  <h3 id="modbus-binding-workitem">Modbus Binding</h3>
+    <p>
+      The WG will work on the current Modbus Binding in order to publish it as a standalone normative document.
+      This will include a Modbus ontology, introduce default values and describe the terms associated with the behavior of Things regarding the usage of the Modbus.
+    </p>
+  <h3 id="bacnet-binding-workitem" class="todo">BACnet Binding</h3>
+    <p>
+      The WG will work on specifying a BACnet Binding for the Web of Things in order to publish it as a standalone normative document.
+      This will include a BACnet ontology, introduce default values and describe the terms associated with the behavior of Things regarding the usage of the BACnet.
+      Note: How should we mention ASHRAE here?
+    </p>
+  <h3 id="opcua-binding-workitem" class="todo">OPC UA Binding</h3>
+    <p>
+      The WG will work on specifying an OPC UA Binding for the Web of Things in order to publish it as a standalone normative document.
+      This will include a OPC UA ontology, introduce default values and describe the terms associated with the behavior of Things regarding the usage of the OPC UA.
+      Note: How should we mention OPC Foundation here?
+    </p>
+  <h3 id="gRPC-binding-workitem">gRPC Binding</h3>
+    <p>
+      The WG will work on specifying a gRPC Binding for the Web of Things in order to publish it as a standalone normative document.
+      This will include a gRPC ontology, introduce default values and describe the terms associated with the behavior of Things regarding the usage of the gRPC.
+    </p>
+  <h3 id="json-binding-workitem">JSON Binding</h3>
+    <p>
+      The WG will work on specifying a JSON Payload Binding for the Web of Things in order to publish it as a standalone normative document.
+      This will include specification on the usage of Data Schema terms as well as <code>contentType</code> term usage within forms.
+    </p>
+  <h3 id="cbor-binding-workitem">CBOR Binding</h3>
+    <p>
+      The WG will work on specifying a CBOR Payload Binding for the Web of Things in order to publish it as a standalone normative document.
+      This will include specification on the usage of Data Schema terms as well as <code>contentType</code> term usage within forms.
+    </p>
+  <h3 id="xml-binding-workitem">XML Binding</h3>
+    <p>
+      The WG will work on specifying an XML Payload Binding for the Web of Things in order to publish it as a standalone normative document.
+      This will include specification on the usage of Data Schema terms as well as <code>contentType</code> term usage within forms.
+    </p>
+  <h3 id="cloudevents-binding-workitem">CloudEvents Binding</h3>
+    <p>
+      The WG will work on specifying an CloudEvents Payload Binding for the Web of Things in order to publish it as a standalone normative document.
+      This will include specification on the usage of Data Schema terms as well as <code>contentType</code> term usage within forms.
+    </p>
+  <h3 id="echonet-binding-workitem" class="todo">ECHONET Lite Web API Binding</h3>
+    <p>
+      The WG will work on specifying an ECHONET Lite Web API Combination Binding for the Web of Things in order to publish it as a standalone normative document.
+      This will include specification on the usage of Data Schema terms, together with how form elements should be structured with possible other assertions on the TD instances.
+      Note: How should we mention ECHONET Consortium here?
+    </p>
         <section id="section-out-of-scope">
           <h3 id="out-of-scope">Out of Scope</h3>
             <p>The following features are out of scope, and will not be addressed by this Working group.</p>

--- a/charters/wot-wg-2023-draft.html
+++ b/charters/wot-wg-2023-draft.html
@@ -400,6 +400,23 @@
               as a Candidate Recommendation on 19 January 2023.</p>
               </p>
             </p></dd>
+            <dt id="binding-deliverable" class="spec">Web of Things (WoT) Binding Templates</dt>
+            <dd>
+              <p>
+                This specification defines the mechanism to bind protocols, payload and media formats, or combination of the two to the Web of Things.
+                The binding mechanism will be a normative document with the following set of registry sections:
+                <ul>
+                  <li>3 registry sections dedicated to stable bindings that reach at least a working draft status</li>
+                  <li>3 registry sections dedicated to experimental bindings that are at least publicly available</li>
+                </ul>
+              </p>
+            
+              <p class="draft-status"><b>Draft state:</b>No draft</p>
+              <p class="milestone todo"><b>Expected completion:</b> TBD</p>
+              <p class="todo"><b>Adopted Draft:</b>TBD</p>
+              </p>
+              </p>
+            </dd>
           </dl>
 
         </section>


### PR DESCRIPTION
Note: Still a draft until the work items are defined.

Also see https://github.com/w3c/wot/blob/main/proposals/deliverable-proposals/binding-templates.md

I am proposing to have a normative binding templates deliverable that has registry sections. In order to promote the visibility of even experimental bindings, I am proposing to create two set of registry sections that each have 3 registries, one for stable and one for experimental. I have put an initial description of what "experimental" and "stable" means but I think it needs work or discussion.