### PR TITLE
add scripting api as other deliverable to 2023 wg charter

### DIFF
--- a/charters/wot-wg-2023-draft.html
+++ b/charters/wot-wg-2023-draft.html
@@ -415,6 +415,10 @@
             <li>Use case and requirement documents;</li>
             <li>Test suite and implementation report for the specification;</li>
             <li>Primer or Best Practice documents to support web developers when designing applications.</li>
+			<li>WoT Scripting API (W3C Note): This document will present a design for a Scripting API that will support exposing and consuming Thing Descriptions while providing a high-level interface to interactions that is independent of protocol. The work will continuously align with the WoT TD specification. Besides these efforts, alignment with the WoT Discovery specification will be the main topic.<br>
+				<!-- Since we plan to publish an update soon the URL might need to change -->
+			    Draft state: <a href="https://www.w3.org/TR/2020/NOTE-wot-scripting-api-20201124/">Group Note</a>
+			</li>
           </ul>
         </section>
 


### PR DESCRIPTION
based on https://github.com/w3c/wot/pull/1043 and the *old* [charter](https://www.w3.org/2022/07/wot-wg-2022.html#other-deliverables)