### PR TITLE
Fix 2023 charter links

### DIFF
--- a/charters/README.md
+++ b/charters/README.md
@@ -48,6 +48,6 @@ To do: following only points at draft, should be updated to point to published v
 
 #### 2023
 
-* [Working document](https://github.com/w3c/wot/blob/master/charters/wot-wg-2023-draft.html)
-  * [Rendered document](https://cdn.statically.io/gh/w3c/wot/main/charters/wot-wg-2023-draft.html?env=dev)
+* [Working document](https://github.com/w3c/wot-charter-drafts/blob/main/wot-wg-2023-draft.html)
+  * [Rendered document](https://w3c.github.io/wot-charter-drafts/wot-wg-2023-draft.html)
   


### PR DESCRIPTION
They were not pointing to the new repo