### PR TITLE
Update wg-2021-extension-plan.md - Discovery

### DIFF
--- a/charters/wg-2021-extension-plan.md
+++ b/charters/wg-2021-extension-plan.md
@@ -34,10 +34,7 @@ We are developing a new draft charter proposed to begin in 1 June 2023.
 | Jan 19, 2023 | Discovery | CR transition |
 | Jan 19, 2023 | Arch1.1 | CR transition |
 | Jan 16-20, 2023 | Next | Next WG Charter Meeting |
-| Jan 25, 2023 | Discovery | CR2 draft |
-| Feb 8, 2023 | Discovery | CR2 transition request |
 | Feb 8, 2023 | Next | Next WG Charter - First Draft |
-| Feb 16, 2023 | Discovery | CR2 transition |
 | Feb 28, 2023 | Profile | CR draft |
 | Mar 1, 2023 | Next | Next WG Charter - Final Draft - Submit |
 | Mar 15, 2023 | Profile | CR transition request |
@@ -47,7 +44,7 @@ We are developing a new draft charter proposed to begin in 1 June 2023.
 | April 13, 2023 | Scripting API | Note published |
 | April 19, 2023 | TD1.1 | PR transition request (CR transition + 3mo) |
 | April 19, 2023 | Arch1.1 | PR transition request (CR transition + 3mo) |
-| May 19, 2023 | Discovery | PR transition request (CR2 transition + 3mo) |
+| April 19, 2023 | Discovery | PR transition request (CR transition + 3mo) |
 | May 31, 2023 | Profile | PR transition request (CR transition + 2mo) |
 | June 1, 2023 | Next | Next WG Charter Begins |
 | June 1, 2023 | Next | F2F - {Switzerland,Munich,Tokyo} - tentative |


### PR DESCRIPTION
Update Discovery deadlines - CR2 no longer needed, can move PR transition back to where it was