### PR TITLE
Add 2 weeks review period for binding templates

### DIFF
--- a/charters/wg-2021-extension-plan.md
+++ b/charters/wg-2021-extension-plan.md
@@ -41,10 +41,10 @@ We are developing a new draft charter proposed to begin in 1 June 2023.
 | Feb 28, 2023 | Profile | CR draft |
 | Mar 1, 2023 | Next | Next WG Charter - Final Draft - Submit |
 | Mar 15, 2023 | Profile | CR transition request |
-| Mar 30, 2023 | Profile | CR transition |
-| Mar 30, 2023 | Binding Templates | Starting WG Review |
 | Mar 22, 2023 | Next | Next WG Charter AC Review Complete (submission + 1mo) |
 | Mar 27, 2023 | Scripting API | Note draft ready for group review |
+| Mar 30, 2023 | Profile | CR transition |
+| Mar 30, 2023 | Binding Templates | Starting WG Review |
 | April 13, 2023 | Scripting API | Note published |
 | April 13, 2023 | Binding Templates | Note published |
 | April 19, 2023 | TD1.1 | PR transition request (CR transition + 3mo) |

--- a/charters/wg-2021-extension-plan.md
+++ b/charters/wg-2021-extension-plan.md
@@ -42,10 +42,11 @@ We are developing a new draft charter proposed to begin in 1 June 2023.
 | Mar 1, 2023 | Next | Next WG Charter - Final Draft - Submit |
 | Mar 15, 2023 | Profile | CR transition request |
 | Mar 30, 2023 | Profile | CR transition |
-| Mar 30, 2023 | Binding Templates | WG Note Publication |
+| Mar 30, 2023 | Binding Templates | Starting WG Review |
 | Mar 22, 2023 | Next | Next WG Charter AC Review Complete (submission + 1mo) |
 | Mar 27, 2023 | Scripting API | Note draft ready for group review |
 | April 13, 2023 | Scripting API | Note published |
+| April 13, 2023 | Binding Templates | Note published |
 | April 19, 2023 | TD1.1 | PR transition request (CR transition + 3mo) |
 | April 19, 2023 | Arch1.1 | PR transition request (CR transition + 3mo) |
 | May 19, 2023 | Discovery | PR transition request (CR2 transition + 3mo) |


### PR DESCRIPTION
TD Call of 22.02:
- We should have the 2 week review before the publication, thus adding it separately to the plan