### PR TITLE
Policy Proposal Process

### DIFF
--- a/policies/README.md
+++ b/policies/README.md
@@ -1,0 +1,8 @@
+# Policies
+Active Web of Things WG policies adopted by group resolution.
+
+To propose a new policy, prepare a draft first in (wot/proposals/policies)[https://github.com/w3c/wot/main/proposals/policies] and then
+call for a group resolution to adopt it.  If the group resolution passes, it can be moved here and added to the index below.
+
+## Index
+Currently empty.

--- a/proposals/policies/README.md
+++ b/proposals/policies/README.md
@@ -1,6 +1,6 @@
 # Proposed Policies
 This directory will be the location where new policies should be proposed.
 Once adopted by a group resolution, they will be moved to 
-(wot/policies)[https://github.com/w3c/wot/main/policies).
+[wot/policies](https://github.com/w3c/wot/main/policies).
 
-A template for the format for proposed policies is in (template.md)[template.md].
+A template for the format for proposed policies is in [template.md](template.md).

--- a/proposals/policies/README.md
+++ b/proposals/policies/README.md
@@ -2,3 +2,5 @@
 This directory will be the location where new policies should be proposed.
 Once adopted by a group resolution, they will be moved to 
 (wot/policies)[https://github.com/w3c/wot/main/policies).
+
+A template for the format for proposed policies is in (template.md)[template.md].

--- a/proposals/policies/README.md
+++ b/proposals/policies/README.md
@@ -1,0 +1,4 @@
+# Proposed Policies
+This directory will be the location where new policies should be proposed.
+Once adopted by a group resolution, they will be moved to 
+(wot/policies)[https://github.com/w3c/wot/main/policies).

--- a/proposals/policies/chair-decision-process.md
+++ b/proposals/policies/chair-decision-process.md
@@ -5,5 +5,7 @@
 - Chairs' decisions will generally by consensus of all three chairs
 - Weekly meetings will be held just prior to main WoT working group call
 - If the chairs cannot meet consensus on a decision, and a decision needs to be made immediately, a majority vote (2/3) process will be used.
-- Consistent with the above, quorum is 2 out of 3 chairs.  If only one chair can make the chairs' meeting no decisions can be made, although some administrative work may take place (preparing agendas for the main call, etc).
-- A chair not attending a meeting will be considered to be abstaining from voting.  Consistent with the above, if only two chairs are present in a meeting and cannot agree on a decision, it will have to be deferred until the third chair can join.
+- Consistent with the above, quorum is 2 out of 3 chairs.  If only one chair can attend* the chairs' meeting no decisions can be made, although some administrative work may take place (preparing agendas for the main call, etc).
+- A chair not attending a meeting (who has not commented by email) will generally be considered to be abstaining from voting.  Consistent with the above, if only two chairs are present in a meeting and cannot agree on a decision, it will have to be deferred until the third chair can join.
+- If a chair cannot attend* a meeting but clearly states their decision on an issue via email prior to the meeting this input will be considered as being equivalent to in-person voting, but only for that specific topic, which needs to be clearly stated in an email to all chair and the team contact.
+- Regarding the meaning of "attend": It is acceptable for a chair to state their opinion on a topic via IRC only if they cannot log into the real-time video/audio conference for some reason.  Both forms of "live" communication are considered "attendance" at the meeting.

--- a/proposals/policies/chair-decision-process.md
+++ b/proposals/policies/chair-decision-process.md
@@ -1,0 +1,9 @@
+# Web of Things (WoT) Policy
+## Chairs' Decision Process and Quorum
+- The following relates only to decisions that the WG agrees can be delegated to chairs, which includes the following:
+    - TBD, ex. rejecting unsolicited IE applications
+- Chairs' decisions will generally by consensus of all three chairs
+- Weekly meetings will be held just prior to main WoT working group call
+- If the chairs cannot meet consensus on a decision, and a decision needs to be made immediately, a majority vote (2/3) process will be used.
+- Consistent with the above, quorum is 2 out of 3 chairs.  If only one chair can make the chairs' meeting no decisions can be made, although some administrative work may take place (preparing agendas for the main call, etc).
+- A chair not attending a meeting will be considered to be abstaining from voting.  Consistent with the above, if only two chairs are present in a meeting and cannot agree on a decision, it will have to be deferred until the third chair can join.

--- a/proposals/policies/chair-decision-process.md
+++ b/proposals/policies/chair-decision-process.md
@@ -1,4 +1,4 @@
-# Web of Things (WoT) Policy
+# Web of Things (WoT) Policy (Draft)
 ## Chairs' Decision Process and Quorum
 - The following relates only to decisions that the WG agrees can be delegated to chairs, which includes the following:
     - TBD, ex. rejecting unsolicited IE applications

--- a/proposals/policies/policy-adoption.md
+++ b/proposals/policies/policy-adoption.md
@@ -5,3 +5,8 @@
 - When the PR for the proposed policy is deemed ready to be discussed by the entire group, it can be merged and a call-for-resolution to adopt it should be sent by email to the entire group, with a link to the proposed policy.
 - At least two weeks should be given between the call for resolution and the actual resolution, which should be tabled in the WoT main call.
 - Once a resolution has passed for a proposed policy, it should be moved to [wot/policies](https://github.com/w3c/wot/main/policies) and will be considered immediately active.
+    - The "proposal" version MUST be deleted, i.e. it should be a "move" not a "copy" after a resolution for adoption to avoid duplicates.
+- It is possible that a call for resolution may result in requests for additional changes after discussion by the entire group in the WoT main call.
+    - In this case the draft proposal will stay in the proposals directory and a new PR will be made against it for the changes.
+    - The review period will be shortened to one week less a day after the PR with the change is created and an email is set to the membership linking to this PR and calling for a resolution.
+    - Ideally the PR is created the same day as the WoT main call in which case it is acceptable to have a resolution in the next WoT main call to adopt it.

--- a/proposals/policies/policy-adoption.md
+++ b/proposals/policies/policy-adoption.md
@@ -10,3 +10,6 @@
     - In this case the draft proposal will stay in the proposals directory and a new PR will be made against it for the changes.
     - The review period will be shortened to one week less a day after the PR with the change is created and an email is set to the membership linking to this PR and calling for a resolution.
     - Ideally the PR is created the same day as the WoT main call in which case it is acceptable to have a resolution in the next WoT main call to adopt it.
+    - This process may be repeated if necessary.
+- Rejected policies (for which no consensus can be reached in a group resolution or for which the group resolution is to reject the policy proposal) should be moved to a "rejected" subdirectory under the "proposals" directory.
+    - Again, the proposal version MUST be deleted; it should be a "move" not a "copy".

--- a/proposals/policies/policy-adoption.md
+++ b/proposals/policies/policy-adoption.md
@@ -1,7 +1,7 @@
 # Web of Things (WoT) Policy
 ## Policy Adoption
-- To propose a new policy, first create a PR against (wot/proposals/policies)[https://github.com/w3c/wot/main/proposals/policies].
+- To propose a new policy, first create a PR against [wot/proposals/policies](https://github.com/w3c/wot/main/proposals/policies).
     - Comments taken on the PR can be used for gathering feedback during "development"
 - When the PR for the proposed policy is deemed ready to be discussed by the entire group, it can be merged and a call-for-resolution to adopt it should be sent by email to the entire group, with a link to the proposed policy.
 - At least two weeks should be given between the call for resolution and the actual resolution, which should be tabled in the WoT main call.
-- Once a resolution has passed for a proposed policy, it should be moved to (wot/policies)[https://github.com/w3c/wot/main/policies] and will be considered immediately active.
+- Once a resolution has passed for a proposed policy, it should be moved to [wot/policies](https://github.com/w3c/wot/main/policies) and will be considered immediately active.

--- a/proposals/policies/policy-adoption.md
+++ b/proposals/policies/policy-adoption.md
@@ -1,0 +1,7 @@
+# Web of Things (WoT) Policy
+## Policy Adoption
+- To propose a new policy, first create a PR against (wot/proposals/policies)[https://github.com/w3c/wot/main/proposals/policies].
+    - Comments taken on the PR can be used for gathering feedback during "development"
+- When the PR for the proposed policy is deemed ready to be discussed by the entire group, it can be merged and a call-for-resolution to adopt it should be sent by email to the entire group, with a link to the proposed policy.
+- At least two weeks should be given between the call for resolution and the actual resolution, which should be tabled in the WoT main call.
+- Once a resolution has passed for a proposed policy, it should be moved to (wot/policies)[https://github.com/w3c/wot/main/policies] and will be considered immediately active.

--- a/proposals/policies/policy-adoption.md
+++ b/proposals/policies/policy-adoption.md
@@ -2,13 +2,16 @@
 ## Policy Adoption
 - To propose a new policy, first create a PR against [wot/proposals/policies](https://github.com/w3c/wot/main/proposals/policies).
     - Comments taken on the PR can be used for gathering feedback during "development"
-- When the PR for the proposed policy is deemed ready to be discussed by the entire group, it can be merged and a call-for-resolution to adopt it should be sent by email to the entire group, with a link to the proposed policy.
-- At least two weeks should be given between the call for resolution and the actual resolution, which should be tabled in the WoT main call.
+- When the PR for the proposed policy is deemed ready to be discussed by the entire group, it can be merged and a call-for-resolution to adopt it should be sent by email to the entire group, with a link to the proposed policy.  The call for resolution should also be announced in a WoT main call.
+- Consistent with the charter, 10 working days should be given between the call for resolution and the actual resolution, which should be tabled in the WoT main call.
+    - The charter allows between 5 to 10 working days at the discretion of the Chairs.
+    - "Working Days" will be defined as Monday through Friday, ignoring holidays (since these are not consistent between international locales).
+    - If a PR is created the same day as a WoT main call the entire day will be considered as being available for review, so it can be considered in a WoT main call two weeks later.
 - Once a resolution has passed for a proposed policy, it should be moved to [wot/policies](https://github.com/w3c/wot/main/policies) and will be considered immediately active.
     - The "proposal" version MUST be deleted, i.e. it should be a "move" not a "copy" after a resolution for adoption to avoid duplicates.
 - It is possible that a call for resolution may result in requests for additional changes after discussion by the entire group in the WoT main call.
     - In this case the draft proposal will stay in the proposals directory and a new PR will be made against it for the changes.
-    - The review period will be shortened to one week less a day after the PR with the change is created and an email is set to the membership linking to this PR and calling for a resolution.
+    - The review period will be shortened to 5 working days after the PR with the change is created and an email is set to the membership linking to this PR and calling for a resolution.
     - Ideally the PR is created the same day as the WoT main call in which case it is acceptable to have a resolution in the next WoT main call to adopt it.
     - This process may be repeated if necessary.
 - Rejected policies (for which no consensus can be reached in a group resolution or for which the group resolution is to reject the policy proposal) should be moved to a "rejected" subdirectory under the "proposals" directory.

--- a/proposals/policies/policy-adoption.md
+++ b/proposals/policies/policy-adoption.md
@@ -16,3 +16,4 @@
     - This process may be repeated if necessary.
 - Rejected policies (for which no consensus can be reached in a group resolution or for which the group resolution is to reject the policy proposal) should be moved to a "rejected" subdirectory under the "proposals" directory.
     - Again, the proposal version MUST be deleted; it should be a "move" not a "copy".
+    - For each rejected policy there should be a reason provided why it was rejected

--- a/proposals/policies/policy-adoption.md
+++ b/proposals/policies/policy-adoption.md
@@ -1,4 +1,4 @@
-# Web of Things (WoT) Policy
+# Web of Things (WoT) Policy (Draft)
 ## Policy Adoption
 - To propose a new policy, first create a PR against [wot/proposals/policies](https://github.com/w3c/wot/main/proposals/policies).
     - Comments taken on the PR can be used for gathering feedback during "development"

--- a/proposals/policies/template.md
+++ b/proposals/policies/template.md
@@ -1,0 +1,4 @@
+# Web of Things (WoT) Policy
+## Template
+- This is an example, not an actual proposed policy.
+- Keep things simple, not more than a quarter page of text, ideally in bullet-point form.


### PR DESCRIPTION
- Two directories supporting policy proposal process:
- To propose a policy, first create a draft in wot/proposals/policies
- Once a policy has been adopted by a group resolution, it can be moved to wot/policies
- As an example, I have proposed one example policy for how chair's decisions can be made with three co-chairs.
- Since the policy adoption process is itself a policy, also added that.
- Also added a template policy (simple format; bullet form is not essential, but keeping things simple yet unambiguous is)

Note: An alternative would be to have drafts kept as PRs directly against "wot/policies".   Not an unreasonable alternative, but a little harder to differentiate from other PRs, harder to see rendered versions (unless you navigate to the right branch), etc.   However a discussion on a PR can still be used during "development", then merging into the "proposals" directory is the signal that we are "calling the question" and there will be a call for resolution.

