### PR TITLE
Decision Policy - from draft Charter

### DIFF
--- a/proposals/policies/decisions.md
+++ b/proposals/policies/decisions.md
@@ -1,0 +1,39 @@
+# Web of Things (WoT) Policy
+Note: The following is in the (draft) WoT charter, so this policy will be active when
+the charter is approved and can only be changed by modifying the charter.  It is included here 
+only for information.
+
+## Group Decisions
+      <p>
+        This group will seek to make decisions through consensus and due process, per the <a
+          href="https://www.w3.org/Consortium/Process/#Consensus">W3C Process Document (section 5.2.1, Consensus)</a>.
+        Typically, an editor or other participant makes an initial proposal, which is then refined in discussion with
+        members of the group and other reviewers, and consensus emerges with little formal voting being required.</p>
+      <p>
+        However, if a decision is necessary for timely progress and consensus is not achieved after careful
+        consideration of the range of views presented, the Chairs may call for a group vote and record a decision along
+        with any objections.
+      </p>
+      <p>
+        To afford asynchronous decisions and organizational deliberation, resolutions 
+        both proposed and taken in a face-to-face meeting or teleconference will be considered provisional.
+
+        A call for consensus (CfC) will be issued for all such resolutions (via email)
+        with a response period from 5 to 10 working days, depending on the Chairs' evaluation of the
+        group consensus on the issue.
+
+        If no objections are raised by the end of the response period, the resolution will be considered to have
+        consensus as a resolution of the Working Group.
+      </p>
+      <p>
+        In some cases, resolutions can be announced and proposed in advance, by circulating an email to the group
+        with concrete proposed text for the resolution.  In these cases, the announcement can be considered the 
+        call for consensus (CfC) and when the resolution is made by the group, it can be considered final, at the 
+        discretion of the Chairs, if sufficient time (5 to 10 working days, at the discretion of the Chairs, as above)
+        has been allowed for asynchronous input.  
+        This process will be followed especially for publication decisions which are then effective immediately.
+      </p>
+      <p>
+        All decisions made by the group should be considered resolved unless and until new information becomes available
+        or unless reopened at the discretion of the Chairs or the Director.
+      </p>

--- a/proposals/policies/decisions.md
+++ b/proposals/policies/decisions.md
@@ -3,6 +3,13 @@ Note: The following is in the (draft) WoT charter, so this policy will be active
 the charter is approved and can only be changed by modifying the charter.  It is included here 
 only for information.
 
+However, the following interpretations are to be included in this policy as clarifications:
+- "Working Days" will be defined as Monday through Friday, ignoring holidays
+    - Holidays are not consistent between international locales, and taking the union of all holidays by all participants would create too much complication and delay, so we will adopt the simpler policy of ignoring them.
+    - In practice 5 working days is one week for review and 10 working days is two weeks.
+- If a call for resolution is created and distributed the same day as a WoT main call the entire day will be considered as being available for review.
+    - In particular, in practice this allows for a resolution to take place in a WoT main call two weeks after a call for resolution made the same day as a WoT main call.
+
 ## Group Decisions
       <p>
         This group will seek to make decisions through consensus and due process, per the <a

--- a/proposals/policies/decisions.md
+++ b/proposals/policies/decisions.md
@@ -7,40 +7,36 @@ However, the following interpretations are to be included in this policy as clar
 - "Working Days" will be defined as Monday through Friday, ignoring holidays
     - Holidays are not consistent between international locales, and taking the union of all holidays by all participants would create too much complication and delay, so we will adopt the simpler policy of ignoring them.
     - In practice 5 working days is one week for review and 10 working days is two weeks.
-- If a call for resolution is created and distributed the same day as a WoT main call the entire day will be considered as being available for review.
-    - In particular, in practice this allows for a resolution to take place in a WoT main call two weeks after a call for resolution made the same day as a WoT main call.
+- For both "Advance" calls for resolutions announced, created and distributed the same day as a WoT main call, and resolutions "tentatively" agreed upon in a WoT main call, the entire day will be considered as being available for review.
+    - This allows for a resolution to take place in a WoT main call one to two weeks after an "advance" call for resolution made the same day as a WoT main call.
+    - For "tentative" resolutions proposed and made in a WoT main call, they can be closed (confirmed as full resolutions) one to two weeks later in the next WoT main call.  If there is no objection after the review period such resolutions will be considered confirmed at the close of the corresponding WoT main call.
+- If not otherwise stated by a Chair or by a policy, the default review period will be 5 working days.
 
 ## Group Decisions
-      <p>
-        This group will seek to make decisions through consensus and due process, per the <a
-          href="https://www.w3.org/Consortium/Process/#Consensus">W3C Process Document (section 5.2.1, Consensus)</a>.
-        Typically, an editor or other participant makes an initial proposal, which is then refined in discussion with
-        members of the group and other reviewers, and consensus emerges with little formal voting being required.</p>
-      <p>
-        However, if a decision is necessary for timely progress and consensus is not achieved after careful
-        consideration of the range of views presented, the Chairs may call for a group vote and record a decision along
-        with any objections.
-      </p>
-      <p>
-        To afford asynchronous decisions and organizational deliberation, resolutions 
-        both proposed and taken in a face-to-face meeting or teleconference will be considered provisional.
+This group will seek to make decisions through consensus and due process, per the
+<a href="https://www.w3.org/Consortium/Process/#Consensus">W3C Process Document (section 5.2.1, Consensus)</a>.
+Typically, an editor or other participant makes an initial proposal, which is then refined in discussion with
+members of the group and other reviewers, and consensus emerges with little formal voting being required.
 
-        A call for consensus (CfC) will be issued for all such resolutions (via email)
-        with a response period from 5 to 10 working days, depending on the Chairs' evaluation of the
-        group consensus on the issue.
+However, if a decision is necessary for timely progress and consensus is not achieved after careful
+consideration of the range of views presented, the Chairs may call for a group vote and record a decision along
+with any objections.
 
-        If no objections are raised by the end of the response period, the resolution will be considered to have
-        consensus as a resolution of the Working Group.
-      </p>
-      <p>
-        In some cases, resolutions can be announced and proposed in advance, by circulating an email to the group
-        with concrete proposed text for the resolution.  In these cases, the announcement can be considered the 
-        call for consensus (CfC) and when the resolution is made by the group, it can be considered final, at the 
-        discretion of the Chairs, if sufficient time (5 to 10 working days, at the discretion of the Chairs, as above)
-        has been allowed for asynchronous input.  
-        This process will be followed especially for publication decisions which are then effective immediately.
-      </p>
-      <p>
-        All decisions made by the group should be considered resolved unless and until new information becomes available
-        or unless reopened at the discretion of the Chairs or the Director.
-      </p>
+To afford asynchronous decisions and organizational deliberation, resolutions
+both proposed and taken in a face-to-face meeting or teleconference will be considered provisional.
+A call for consensus (CfC) will be issued for all such resolutions (via email)
+with a response period from 5 to 10 working days, depending on the Chairs' evaluation of the
+group consensus on the issue.
+If no objections are raised by the end of the response period, the resolution will be considered to have
+consensus as a resolution of the Working Group.
+
+In some cases, resolutions can be announced and proposed in advance, by circulating an email to the group
+with concrete proposed text for the resolution.  In these cases, the announcement can be considered the
+call for consensus (CfC) and when the resolution is made by the group, it can be considered final, at the
+discretion of the Chairs, if sufficient time (5 to 10 working days, at the discretion of the Chairs, as above)
+has been allowed for asynchronous input.
+This process will be followed especially for publication decisions which are then effective immediately.
+
+All decisions made by the group should be considered resolved unless and until new information becomes available
+or unless reopened at the discretion of the Chairs or the Director.
+


### PR DESCRIPTION
- copy of decision policy from charter (with note saying it's a copy and we can't modify it)
- Note the "5 to 10 working days" - will update the "policy process proposal" to be consistent.
- There are a couple of ambiguities around the definition of "working day" (e.g. what about holidays?) and whether the day the CfR is announced (or the tentative resolution is adopted) is included in the review period (which impacts how days are converted to weeks), so this policy includes those two points as clarifications.
- Also added a "default review period" of 5 days (unless overridden by a chair or by policy).  This is to avoid ambiguity in case we forget.

A bit complicated since we can have both "tentative" resolutions (with review happening after the fact) or "advance" resolutions (with review before).