### PR TITLE
Minutes Policy Proposal

### DIFF
--- a/policies/minutes.md
+++ b/policies/minutes.md
@@ -1,0 +1,12 @@
+# Web of Things (WoT) Policy
+## Minutes
+- During each WoT main call or WoT TF call,
+  there will be an opportunity for corrections to be made to the draft minutes of previous calls.
+- Draft minutes will be made available at a URL of the form <code>https://www.w3.org/yyyy/mm/dd-wot-minutes.html</code>
+  not less than 48 hours before each call (for the main call) and similar forms for TF calls.
+- We will generally NOT review minutes in calls unless a group member mentions a need for a correction.
+- It is the responsibility of group members to review minutes prior to each call.
+    - The chairs in particular must review the minutes of the main call, and task force leads are responsible for reviewing the minutes of task forces.
+- For exceptional (non-repeating) meetings, such as testfests, plugfests, and planning meetings, minutes will be confirmed in the main call.
+    - Generally, unless a need for correction is raised, time will not be spend in the main call reviewing such minutes.
+    - In these cases an email should be sent out prior to the main call with links to the minutes at least 48 hours in advance.


### PR DESCRIPTION
- Define a policy for reviewing main call and task force minutes
- Avoid having to spend time on this in calls
- Two responsibilities defined: - Minutes need to be made available in advance.  48 hours is given, which means if main call minutes are out by Monday morning we can confirm them in a main call on Wednesday. - Chairs and task force leads MUST review minutes prior to the corresponding calls.