### PR TITLE
[Policy] Move decisions.md from "proposals" to "policies"

### DIFF
--- a/policies/decisions.md
+++ b/policies/decisions.md
@@ -1,0 +1,42 @@
+# Web of Things (WoT) Policy
+Note: The following is in the (draft) WoT charter, so this policy will be active when
+the charter is approved and can only be changed by modifying the charter.  It is included here 
+only for information and for clarification of certain points.
+
+## Group Decisions
+This group will seek to make decisions through consensus and due process, per the
+<a href="https://www.w3.org/Consortium/Process/#Consensus">W3C Process Document (section 5.2.1, Consensus)</a>.
+Typically, an editor or other participant makes an initial proposal, which is then refined in discussion with
+members of the group and other reviewers, and consensus emerges with little formal voting being required.
+
+However, if a decision is necessary for timely progress and consensus is not achieved after careful
+consideration of the range of views presented, the Chairs may call for a group vote and record a decision along
+with any objections.
+
+To afford asynchronous decisions and organizational deliberation, resolutions
+both proposed and taken in a face-to-face meeting or teleconference will be considered provisional.
+A call for consensus (CfC) will be issued for all such resolutions (via email)
+with a response period from 5 to 10 working days, depending on the Chairs' evaluation of the
+group consensus on the issue.
+If no objections are raised by the end of the response period, the resolution will be considered to have
+consensus as a resolution of the Working Group.
+
+In some cases, resolutions can be announced and proposed in advance, by circulating an email to the group
+with concrete proposed text for the resolution.  In these cases, the announcement can be considered the
+call for consensus (CfC) and when the resolution is made by the group, it can be considered final, at the
+discretion of the Chairs, if sufficient time (5 to 10 working days, at the discretion of the Chairs, as above)
+has been allowed for asynchronous input.
+This process will be followed especially for publication decisions which are then effective immediately.
+
+All decisions made by the group should be considered resolved unless and until new information becomes available
+or unless reopened at the discretion of the Chairs or the Director.
+
+### Clarifications
+However, the following interpretations are to be included in this policy as clarifications:
+- "Working Days" will be defined as Monday through Friday, ignoring holidays
+    - Holidays are not consistent between international locales, and taking the union of all holidays by all participants would create too much complication and delay, so we will adopt the simpler policy of ignoring them.
+    - In practice 5 working days is one week for review and 10 working days is two weeks.
+- For both "Advance" calls for resolutions announced, created and distributed the same day as a WoT main call, and resolutions "tentatively" agreed upon in a WoT main call, the entire day will be considered as being available for review.
+    - This allows for a resolution to take place in a WoT main call one to two weeks after an "advance" call for resolution made the same day as a WoT main call.
+    - For "tentative" resolutions proposed and made in a WoT main call, they can be closed (confirmed as full resolutions) one to two weeks later in the next WoT main call.  If there is no objection after the review period such resolutions will be considered confirmed at the close of the corresponding WoT main call.
+- If not otherwise stated by a Chair or by a policy, the default review period will be 5 working days.


### PR DESCRIPTION
* Move decisions.md from "proposals" to "policies", making it active
* Should only be merged after a WG resolution, currently planned for the main call on Sept 27
* Please use this PR in the meantime to comment on the policy or suggest concrete revisions