### PR TITLE
Update 2023 Press Release draft to include Notes

### DIFF
--- a/MARKETING/PressReleaseDrafts/2023/draft.md
+++ b/MARKETING/PressReleaseDrafts/2023/draft.md
@@ -10,6 +10,10 @@ are now official W3C Recommendations.
 Without breaking compatibility with the [first release in 2020](https://www.w3.org/press-releases/2020/wot-rec/),
 these new W3C Recommendations improve and expand the scope of the Web of Things,
 and add significant new functionality.
+In addition, two supporting W3C Notes have been updated, the
+[Web of Things (WoT) Binding Templates](https://www.w3.org/TR/wot-binding-templates/) 
+and the
+[Web of Things (WoT) Scripting API](https://www.w3.org/TR/wot-scripting-api/).
 
 <!-- Why is it important? -->
 ## WoT addresses the IoT fragmentation problem


### PR DESCRIPTION
- Mention and link to two updated Notes (for Binding Templates and Scripting API) at end of opening paragraph in draft 2023 press release
- Should only be merged if (a) WG agrees (b) Notes actually published (c) Marcomm agrees