### PR TITLE
Reorganize work items

### DIFF
--- a/planning/ThingDescription/work-items.md
+++ b/planning/ThingDescription/work-items.md
@@ -31,38 +31,63 @@ This allows us to better label and manage the items.
     - Also see https://github.com/w3c/wot-charter-drafts/issues/57 , https://github.com/w3c/wot-thing-description/issues/1880
 
 ### Usability and Design Work Items
+
 Changes that improve readability, the usability of the specification OR development, spec generation, bug fix, and testing of the specification do not need use cases.
-- Reusable Elements and pointers (e.g. reusable payloads, initial connection)
-- Restructuring the TD Specification and Specification Generation
-  - This should be done while keeping the current content, e.g. grouping of normative requirements, common definitions section (usability improvements for not needing to "jump around" while reading)
-  - While doing the refactoring, we should have a document to discuss the design of TD
+
+#### Design Document
+
+We should start a TD (re)design document that explains the idea behind the design of different features. See [issue 1889](https://github.com/w3c/wot-thing-description/issues/1889).
+
+#### Document reorganization
+
+Changes that should be done while keeping the current content
+
+- Common definition section: Usability and readability improvements for not needing to "jump around" while reading
+- Grouping of normative requirements
+- Assertion id alignment: adding `td`, checking naming scheme
+
+#### Synchronization with other documents
+
+- Moving binding templates core document content to TD
+- Moving discovery-related text from TD to Discovery
+
+#### Reusable Elements
+
+- Reusable connections, for example, an MQTT Broker connection that can be described at the top and used in the forms
+- Data Schema mapping information/metadata
+- Security schemes may need to be refactored and use the same pattern as other reusable elements
+
+- Scenarios, requirements, and use the same pattern for all reusable elements
+- Review the current state of the art in other standards
+
+#### Uniform pattern/state machines between Actions, Events, and Properties
+
+- Avoid doing the same thing in a different way, for example how to express observability and cancellation
+- Relationships across affordances, for example when an Action changes the state of a Property
+- Property vs. Action (also URI Variables redesign question)
+
+#### Normative Parsing, Validation, Consumption
+
+- What is a valid TD, are there any levels of validness?
+  - A TD validator can do only JSON Schema validation but that is not enough to test everything. 
+  - A TD may be not completely valid but usable by a "degraded consumer" (see below) or a TD can be completely valid according to all the assertions and protocol bindings but not be usable by some consumers.
+- Do we want to prescribe how TDs are processed and consumed beyond the text level?
+- Degraded consumption rule for uniform degradation across consumers, e.g. TD too big, protocol or protocol options unknown, contentType unknown, etc.
+
+#### Single source of truth for build
+
+- Make sure there are no gaps in the tooling and process for building index.html
+
+#### Others
+
+Items that are not grouped in a topic above are listed here:
+
 - Inline Security
 - Better integration of Thing Model
 - TD Versioning: impacts signing and canonicalization (RDF canonicalization?)
-- Normative Parsing, Validation, Consumption
-#### Document reorganization
-- Common definition section
-- Grouping of normative requirements
-- Start a TD (re)design document
-#### Reusable Elements
-- Reusable connections, for example a MQTT Broker connection that can be described at the top and used in the forms
-- Data Schema mapping information/metadata
-- Security schemes may need to be refactored and use the same pattern as other reusable elements
-- Create a design document [issue](https://github.com/w3c/wot-thing-description/issues/1889)
-- scenarios, requirements, and use the same pattern for all reusable elements
-- Review current state of the art in other standards
-#### Uniform pattern/state machines between Actions, Events, and Properties
-- Avoid doing the same thing in a different way, for example how to express observability and cancellation
-- Relationships across affordances, for example when an Action changes the state of a Property
-- Design document, etc. 
-- Property vs. Action (also URI Variables redesign question)
-#### Normative Consumption
-- Do we want to proscribe how TDs are processed beyond text level?
-- Degraded consumption rule for uniform degradation across consumers, e.g. TD too big
-#### Single source of truth for build
-- Make sure there are no gaps in the tooling and process for building index.html
-### Feature Aiming Work Items
+- Creating the registry mechanism
 
+### Feature Aiming Work Items
 
 For new features (keywords or behavior), a use case (or user story) should exist in the first place.
 While the refactoring topics are being worked on, new features should not be incorporated into the specification.
@@ -76,8 +101,9 @@ Instead, the TF will analyze current solutions, gather existing use cases and di
 ### Supporting Work Items (to be renamed)
 
 - Linting
-- TD Testing for plugfest and testfests
+- TD Testing for plugfest and testfests: Currently it is at Eclipse Thingweb Playground at https://github.com/eclipse-thingweb/playground/tree/master/packages/assertions but we should move it here.
 - Bugfixes (updates for the TD next. Actual bugs for 1.1 should be handled as errata)
+- Examples reorganization: It would be better to have complete TD examples that can be validated but at the same time we can show a part of it for specific features. Also, see https://github.com/w3c/wot-thing-description/issues/1851.
 
 ## Notes
 
@@ -102,6 +128,10 @@ Notes:
 
 ### Refactoring Roadmap
 
+Notes:
+
+- We need to link back to the items above. A project management tool can help
+
 In no particular order, we have the following:
 
 - Incorporating Binding Mechanism
@@ -109,7 +139,7 @@ In no particular order, we have the following:
 - Specification Generation Tooling
 - Grouping of normative requirements (depends on specification generation tooling)
 - Common definitions section (usability improvements for not needing to "jump around" while reading) (depends on specification generation tooling)
-- Assertion id alignment: adding `td`, checking naming scheme
+- Assertion id alignment: adding `td`, checking the naming scheme
 - Synchronization with other documents
 - Example reorganization
 - Testing Pipeline


### PR DESCRIPTION
With @mjkoster we reorganized it so that no item is left out. The leftover problem is that we should put each item in an order (like the roadmap section) without duplicating them.