### PR TITLE
Reorganization of TD Work Items as Separate Documents

### DIFF
--- a/planning/ThingDescription/td-next-work-items/README.md
+++ b/planning/ThingDescription/td-next-work-items/README.md
@@ -1,0 +1,4 @@
+# Categorized Work Items
+
+The documents here detail the work items per category.
+The filename is the category name.

--- a/planning/ThingDescription/td-next-work-items/binding-templates.md
+++ b/planning/ThingDescription/td-next-work-items/binding-templates.md
@@ -1,0 +1,10 @@
+# TD.Next Binding Templates Work Items
+
+- Binding Submission Mechanism (e.g. Registry)
+- Binding Mechanism
+  - Integration of the Binding Templates into the TD document
+  - Mapping TD elements to messages
+  - Payload Driven Protocols (e.g. WS, SSE)
+  - `href` and URI design
+  - External Security Ontologies
+    - Also see https://github.com/w3c/wot-charter-drafts/issues/57 , https://github.com/w3c/wot-thing-description/issues/1880

--- a/planning/ThingDescription/td-next-work-items/new-features.md
+++ b/planning/ThingDescription/td-next-work-items/new-features.md
@@ -1,0 +1,12 @@
+# Feature Aiming Work Items
+
+For new features (keywords or behavior), a use case (or user story) should exist in the first place.
+While the refactoring topics are being worked on, new features should not be incorporated into the specification.
+Instead, the TF will analyze current solutions, gather existing use cases and discussions, and write the requirements to shape the feature.
+These are contained in this folder with the `analysis-` prefix.
+
+- Timeseries / Historical Data
+- Manageable Actions
+- Streaming
+- Signing and Canonicalization (there is discussion on where this should belong)
+  - TD Versioning

--- a/planning/ThingDescription/td-next-work-items/testing-and-tooling.md
+++ b/planning/ThingDescription/td-next-work-items/testing-and-tooling.md
@@ -1,0 +1,6 @@
+# Testing and Tooling
+
+- Linting
+- TD Testing for plugfest and testfests: Currently it is at Eclipse Thingweb Playground at <https://github.com/eclipse-thingweb/playground/tree/master/packages/assertions> but we should move it here.
+- Bugfixes (updates for the TD next. Actual bugs for 1.1 should be handled as errata)
+- Examples reorganization: It would be better to have complete TD examples that can be validated but at the same time we can show a part of it for specific features. Also, see <https://github.com/w3c/wot-thing-description/issues/1851>.

--- a/planning/ThingDescription/td-next-work-items/usability-and-design.md
+++ b/planning/ThingDescription/td-next-work-items/usability-and-design.md
@@ -1,0 +1,49 @@
+# Usability and Design Work Items
+
+Changes that improve readability, the usability of the specification OR development, spec generation, bug fixes, and testing of the specification do not need use cases.
+These have more priority since they can impact how new features look like in a TD instance.
+
+## Design Document
+
+We should start a TD (re)design document that explains the idea behind the design of different features. See [issue 1889](https://github.com/w3c/wot-thing-description/issues/1889).
+
+## Document reorganization
+
+Changes that should be done while keeping the current content
+
+- Common definition section: Usability and readability improvements for not needing to "jump around" while reading
+- Grouping of normative requirements
+- Assertion id alignment: adding `td`, checking naming scheme
+- Better integration of Thing Model
+
+## Synchronization with other documents
+
+- Moving binding templates core document content to TD
+- Moving discovery-related text from TD to Discovery
+
+## Reusable TD Elements
+
+- Reusable connections, for example, an MQTT Broker connection that can be described at the top and used in the forms
+- Data Schema mapping information/metadata
+- Security schemes may need to be refactored and use the same pattern as other reusable elements
+- Inline Security
+- Scenarios, requirements, and use the same pattern for all reusable elements
+- Review the current state of the art in other standards
+
+## Uniform pattern/state machines between Actions, Events, and Properties
+
+- Avoid doing the same thing in a different way, for example how to express observability and cancellation
+- Relationships across affordances, for example when an Action changes the state of a Property
+- Property vs. Action (also URI Variables redesign question)
+
+## Normative Parsing, Validation, Consumption
+
+- What is a valid TD, are there any levels of validness?
+  - A TD validator can do only JSON Schema validation but that is not enough to test everything.
+  - A TD may be not completely valid but usable by a "degraded consumer" (see below) or a TD can be completely valid according to all the assertions and protocol bindings but not be usable by some consumers.
+- Do we want to prescribe how TDs are processed and consumed beyond the text level?
+- Degraded consumption rule for uniform degradation across consumers, e.g. TD too big, protocol or protocol options unknown, contentType unknown, etc.
+
+## Single source of truth for build
+
+- Make sure there are no gaps in the tooling and process for building index.html

--- a/planning/ThingDescription/work-items.md
+++ b/planning/ThingDescription/work-items.md
@@ -6,10 +6,10 @@ This is copied from <https://www.w3.org/WoT/IG/wiki/WG_WoT_Thing_Description_Web
 
 The work items are split into four categories.
 
-1. The first category is Binding Templates, which involves specifying the mechanism but also the submission mechanism.
-2. The second category focuses on work items that are more about restructuring, redesigning, and improving the usability of the specification. These could pave the way for new features.
-3. The third category is about work items that are directly linked to new features.
-4. The fourth category is currently called supporting work items (can be renamed) and they improve various mechanisms but are not necessarily new keywords for TD instances.
+1. [Binding Templates](./td-next-work-items/binding-templates.md): The first category is Binding Templates, which involves specifying the mechanism but also the submission mechanism.
+2. [Usability and Design](./td-next-work-items/usability-and-design.md): The second category focuses on work items that are more about restructuring, redesigning, and improving the usability of the specification. These could pave the way for new features.
+3. [New Features](./td-next-work-items/new-features.md): The third category is about work items that are directly linked to new features.
+4. [Testing and Tooling](./td-next-work-items/testing-and-tooling.md): The fourth category is comprised of items that help the specification management and maintain a consistency.
 
 Such categories can be reflected with labels and different views in the GitHub project management panel.
 The task force will go through existing issues, pull requests, and discussions, and categorize them accordingly.
@@ -20,87 +20,6 @@ The task force will go through existing issues, pull requests, and discussions, 
 This allows us to better label and manage the items.
 
 - **Details:** The details of different work items can be found at <https://github.com/w3c/wot/blob/main/proposals/deliverable-proposals/thing-description.md>. We will consolidate such details and link them appropriately.
-
-### Binding Templates
-
-- Binding Submission Mechanism (e.g. Registry)
-- Binding Mechanism
-  - Integration of the Binding Templates into the TD document
-  - Mapping TD elements to messages
-  - Payload Driven Protocols (e.g. WS, SSE)
-  - `href` and URI design
-  - External Security Ontologies
-    - Also see https://github.com/w3c/wot-charter-drafts/issues/57 , https://github.com/w3c/wot-thing-description/issues/1880
-
-### Usability and Design Work Items
-
-Changes that improve readability, the usability of the specification OR development, spec generation, bug fixes, and testing of the specification do not need use cases.
-These have more priority since they can impact how new features look like in a TD instance.
-
-#### Design Document
-
-We should start a TD (re)design document that explains the idea behind the design of different features. See [issue 1889](https://github.com/w3c/wot-thing-description/issues/1889).
-
-#### Document reorganization
-
-Changes that should be done while keeping the current content
-
-- Common definition section: Usability and readability improvements for not needing to "jump around" while reading
-- Grouping of normative requirements
-- Assertion id alignment: adding `td`, checking naming scheme
-- Better integration of Thing Model
-
-#### Synchronization with other documents
-
-- Moving binding templates core document content to TD
-- Moving discovery-related text from TD to Discovery
-
-#### Reusable TD Elements
-
-- Reusable connections, for example, an MQTT Broker connection that can be described at the top and used in the forms
-- Data Schema mapping information/metadata
-- Security schemes may need to be refactored and use the same pattern as other reusable elements
-- Inline Security
-- Scenarios, requirements, and use the same pattern for all reusable elements
-- Review the current state of the art in other standards
-
-#### Uniform pattern/state machines between Actions, Events, and Properties
-
-- Avoid doing the same thing in a different way, for example how to express observability and cancellation
-- Relationships across affordances, for example when an Action changes the state of a Property
-- Property vs. Action (also URI Variables redesign question)
-
-#### Normative Parsing, Validation, Consumption
-
-- What is a valid TD, are there any levels of validness?
-  - A TD validator can do only JSON Schema validation but that is not enough to test everything.
-  - A TD may be not completely valid but usable by a "degraded consumer" (see below) or a TD can be completely valid according to all the assertions and protocol bindings but not be usable by some consumers.
-- Do we want to prescribe how TDs are processed and consumed beyond the text level?
-- Degraded consumption rule for uniform degradation across consumers, e.g. TD too big, protocol or protocol options unknown, contentType unknown, etc.
-
-#### Single source of truth for build
-
-- Make sure there are no gaps in the tooling and process for building index.html
-
-### Feature Aiming Work Items
-
-For new features (keywords or behavior), a use case (or user story) should exist in the first place.
-While the refactoring topics are being worked on, new features should not be incorporated into the specification.
-Instead, the TF will analyze current solutions, gather existing use cases and discussions, and write the requirements to shape the feature.
-These are contained in this folder with the `analysis-` prefix.
-
-- Timeseries / Historical Data
-- Manageable Actions
-- Streaming
-- Signing and Canonicalization (there is discussion on where this should belong)
-  - TD Versioning
-
-### Supporting Work Items (to be renamed)
-
-- Linting
-- TD Testing for plugfest and testfests: Currently it is at Eclipse Thingweb Playground at <https://github.com/eclipse-thingweb/playground/tree/master/packages/assertions> but we should move it here.
-- Bugfixes (updates for the TD next. Actual bugs for 1.1 should be handled as errata)
-- Examples reorganization: It would be better to have complete TD examples that can be validated but at the same time we can show a part of it for specific features. Also, see <https://github.com/w3c/wot-thing-description/issues/1851>.
 
 ## Notes
 
@@ -126,9 +45,7 @@ Notes:
 
 ### Refactoring Roadmap
 
-Notes:
-
-- We need to link back to the items above. A project management tool can help
+Note: The items below will be turned to links.
 
 In no particular order, we have the following:
 

--- a/planning/ThingDescription/work-items.md
+++ b/planning/ThingDescription/work-items.md
@@ -1,10 +1,10 @@
 # [DRAFT] Web of Things TD Work Items 
 
-This is copied from https://www.w3.org/WoT/IG/wiki/WG_WoT_Thing_Description_WebConf and is further restructured here.
+This is copied from <https://www.w3.org/WoT/IG/wiki/WG_WoT_Thing_Description_WebConf> and is further restructured here.
 
 ## Categories
 
-The work items are split into four categories. 
+The work items are split into four categories.
 
 1. The first category is Binding Templates, which involves specifying the mechanism but also the submission mechanism.
 2. The second category focuses on work items that are more about restructuring, redesigning, and improving the usability of the specification. These could pave the way for new features.
@@ -16,7 +16,7 @@ The task force will go through existing issues, pull requests, and discussions, 
 
 - **Priorities:** The items below can be considered a flat list with no priorities set for now. Ideally, items that are dependencies to other items and those with concrete industry use cases will be prioritized.
 
-- **Organization:** In order to have a better overview, the list of work items should be kept low, and small work items should be grouped into bigger ones. 
+- **Organization:** In order to have a better overview, the list of work items should be kept low, and small work items should be grouped into bigger ones.
 This allows us to better label and manage the items.
 
 - **Details:** The details of different work items can be found at <https://github.com/w3c/wot/blob/main/proposals/deliverable-proposals/thing-description.md>. We will consolidate such details and link them appropriately.
@@ -73,7 +73,7 @@ Changes that should be done while keeping the current content
 #### Normative Parsing, Validation, Consumption
 
 - What is a valid TD, are there any levels of validness?
-  - A TD validator can do only JSON Schema validation but that is not enough to test everything. 
+  - A TD validator can do only JSON Schema validation but that is not enough to test everything.
   - A TD may be not completely valid but usable by a "degraded consumer" (see below) or a TD can be completely valid according to all the assertions and protocol bindings but not be usable by some consumers.
 - Do we want to prescribe how TDs are processed and consumed beyond the text level?
 - Degraded consumption rule for uniform degradation across consumers, e.g. TD too big, protocol or protocol options unknown, contentType unknown, etc.
@@ -98,9 +98,9 @@ These are contained in this folder with the `analysis-` prefix.
 ### Supporting Work Items (to be renamed)
 
 - Linting
-- TD Testing for plugfest and testfests: Currently it is at Eclipse Thingweb Playground at https://github.com/eclipse-thingweb/playground/tree/master/packages/assertions but we should move it here.
+- TD Testing for plugfest and testfests: Currently it is at Eclipse Thingweb Playground at <https://github.com/eclipse-thingweb/playground/tree/master/packages/assertions> but we should move it here.
 - Bugfixes (updates for the TD next. Actual bugs for 1.1 should be handled as errata)
-- Examples reorganization: It would be better to have complete TD examples that can be validated but at the same time we can show a part of it for specific features. Also, see https://github.com/w3c/wot-thing-description/issues/1851.
+- Examples reorganization: It would be better to have complete TD examples that can be validated but at the same time we can show a part of it for specific features. Also, see <https://github.com/w3c/wot-thing-description/issues/1851>.
 
 ## Notes
 
@@ -118,6 +118,7 @@ We have a roadmap for the TD specification that is aligned with the charter star
 - Charter Start: October 2023
 
 Notes:
+
 - Stopping big features 6 months prior to CR Transition. That means January 10, 2025 -> End of 2024, we should be done with big features.
   - The bigger the implementation impact, the more time to implement
   - We can give something like "Story Points" to give a rough idea of the effort
@@ -151,7 +152,7 @@ More to come here
 
 In addition to GitHub issues and Use Cases, there are various documents that should be read before starting the work
 
-- Long Running Actions Proposals: https://github.com/w3c/wot-thing-description/tree/main/proposals
-- Registry Analysis: https://github.com/w3c/wot/tree/main/registry-analysis
-- Historical Data Landscape: https://github.com/w3c/wot/pull/1112
-- Charter Details: https://w3c.github.io/wot-charter-drafts/wot-wg-2023-details.html
+- Long Running Actions Proposals: <https://github.com/w3c/wot-thing-description/tree/main/proposals>
+- Registry Analysis: <https://github.com/w3c/wot/tree/main/registry-analysis>
+- Historical Data Landscape: <https://github.com/w3c/wot/pull/1112>
+- Charter Details: <https://w3c.github.io/wot-charter-drafts/wot-wg-2023-details.html>


### PR DESCRIPTION
Since the list of work items is getting large, with @mjkoster we have decided to split them into multiple documents (one per category). The content has not changed. 

As a next step, we will turn each item into a header so that we can link to them from the main work items document.