### PR TITLE
TD Planning: Linking Work Items from Sub Documents

### DIFF
--- a/planning/ThingDescription/td-next-work-items/binding-templates.md
+++ b/planning/ThingDescription/td-next-work-items/binding-templates.md
@@ -9,12 +9,7 @@ Registry analysis is happening at a separate document. See [Registry Analysis](.
 
 ### Binding Templates Integration
 
-It will be incorporated into the TD document.
-
-### Mapping TD elements to messages
-
-How can we represent all protocol messages sent and received?
-It should be using data schema to indicate application-specific parameters but we should be able to describe payload, header, uri variables, and other protocol parameters.
+Binding Templates core mechanism will be incorporated into the TD document.
 
 ### Payload Driven Protocols
 
@@ -31,11 +26,10 @@ The Binding Templates should be updated with concrete cases where this mechanism
 The Profiles can use this mechanism to reduce the size of TDs while making them easier to understand.
 The working group will also document in which cases this method does not work due to making the TDs too complicated to understand, thus requiring a binding document.
 
-### href and URI design
+Note: This is dependent on *Reusable TD Elements* of [Usability and Design](./usability-and-design.md) work item list.
 
 ### External Security Ontologies
 
 Currently security schemes are "baked into" the TD specification but it would be more manageable and consistent to break them out as separate ontologies so that all security schemes would be done via extensions. For protocol-specific security schemes in particular, these should be moved to the Protocol Bindings and ontologies supporting them. The TD 2.0 spec would be updated to only include general-purpose "structural" security schemes and "generic" schemes that apply to all protocols.
-
 
 See https://github.com/w3c/wot-charter-drafts/issues/57 , https://github.com/w3c/wot-thing-description/issues/1880

--- a/planning/ThingDescription/td-next-work-items/binding-templates.md
+++ b/planning/ThingDescription/td-next-work-items/binding-templates.md
@@ -1,10 +1,19 @@
 # TD.Next Binding Templates Work Items
 
-- Binding Submission Mechanism (e.g. Registry)
-- Binding Mechanism
-  - Integration of the Binding Templates into the TD document
-  - Mapping TD elements to messages
-  - Payload Driven Protocols (e.g. WS, SSE)
-  - `href` and URI design
-  - External Security Ontologies
-    - Also see https://github.com/w3c/wot-charter-drafts/issues/57 , https://github.com/w3c/wot-thing-description/issues/1880
+## Binding Submission Mechanism
+
+We need to specify how a new binding should be submitted. E.g. Registry or a similar approach
+
+## Binding Mechanism
+
+### Integration of the Binding Templates into the TD document
+
+### Mapping TD elements to messages
+
+### Payload Driven Protocols (e.g. WS, SSE)
+
+### `href` and URI design
+
+### External Security Ontologies
+
+See https://github.com/w3c/wot-charter-drafts/issues/57 , https://github.com/w3c/wot-thing-description/issues/1880

--- a/planning/ThingDescription/td-next-work-items/binding-templates.md
+++ b/planning/ThingDescription/td-next-work-items/binding-templates.md
@@ -2,18 +2,40 @@
 
 ## Binding Submission Mechanism
 
-We need to specify how a new binding should be submitted. E.g. Registry or a similar approach
+We need to specify how a new binding should be submitted. E.g. Registry or a similar approach.
+Registry analysis is happening at a separate document. See [Registry Analysis](../../../registry-analysis/).
 
 ## Binding Mechanism
 
-### Integration of the Binding Templates into the TD document
+### Binding Templates Integration
+
+It will be incorporated into the TD document.
 
 ### Mapping TD elements to messages
 
-### Payload Driven Protocols (e.g. WS, SSE)
+How can we represent all protocol messages sent and received?
+It should be using data schema to indicate application-specific parameters but we should be able to describe payload, header, uri variables, and other protocol parameters.
 
-### `href` and URI design
+### Payload Driven Protocols
+
+Some protocols are built on top of the application layer protocols. Some examples are:
+
+- RPC protocols on top of HTTP such as JSON-RPC.
+- Protocols using MQTT topics together with payloads to identify affordances.
+- Websocket sub-protocols.
+- SSE usage across implementations.
+- Webhook usage across implementations.
+
+The Thing Description should be updated with mechanisms that make it possible to describe such protocols while optimizing the TD instances to be human and machine readable. 
+The Binding Templates should be updated with concrete cases where this mechanism is already used.
+The Profiles can use this mechanism to reduce the size of TDs while making them easier to understand.
+The working group will also document in which cases this method does not work due to making the TDs too complicated to understand, thus requiring a binding document.
+
+### href and URI design
 
 ### External Security Ontologies
+
+Currently security schemes are "baked into" the TD specification but it would be more manageable and consistent to break them out as separate ontologies so that all security schemes would be done via extensions. For protocol-specific security schemes in particular, these should be moved to the Protocol Bindings and ontologies supporting them. The TD 2.0 spec would be updated to only include general-purpose "structural" security schemes and "generic" schemes that apply to all protocols.
+
 
 See https://github.com/w3c/wot-charter-drafts/issues/57 , https://github.com/w3c/wot-thing-description/issues/1880

--- a/planning/ThingDescription/td-next-work-items/new-features.md
+++ b/planning/ThingDescription/td-next-work-items/new-features.md
@@ -5,8 +5,13 @@ While the refactoring topics are being worked on, new features should not be inc
 Instead, the TF will analyze current solutions, gather existing use cases and discussions, and write the requirements to shape the feature.
 These are contained in this folder with the `analysis-` prefix.
 
-- Timeseries / Historical Data
-- Manageable Actions
-- Streaming
-- Signing and Canonicalization (there is discussion on where this should belong)
-  - TD Versioning
+## Timeseries / Historical Data
+
+## Manageable Actions
+
+## Streaming
+
+## Signing and Canonicalization (there is discussion on where this should belong)
+
+### TD Versioning
+

--- a/planning/ThingDescription/td-next-work-items/new-features.md
+++ b/planning/ThingDescription/td-next-work-items/new-features.md
@@ -1,11 +1,13 @@
-# Feature Aiming Work Items
+# TD.Next Feature Aiming Work Items
 
 For new features (keywords or behavior), a use case (or user story) should exist in the first place.
 While the refactoring topics are being worked on, new features should not be incorporated into the specification.
 Instead, the TF will analyze current solutions, gather existing use cases and discussions, and write the requirements to shape the feature.
 These are contained in this folder with the `analysis-` prefix.
 
-## Timeseries / Historical Data
+## Historical Data
+
+Also known as timeseries.
 
 Please refer to [Analysis Document](./../analysis-historical-data-work-item.md)
 
@@ -14,7 +16,7 @@ Please refer to [Analysis Document](./../analysis-historical-data-work-item.md)
 Note: This should be moved to an analysis document.
 
 Various use cases require the implementation of more complex actions that span multiple protocol transactions. Such actions are not simply invoked but need to managed over time by the Thing and the Consumer. 
-These are covered in the WoT Thing Description 1.1 via the initiation (invokeaction), monitoring (`queryaction`), and cancellation (`cancelaction`) of ongoing actions. 
+These are covered in the WoT Thing Description 1.1 via the initiation (invokeaction), monitoring (`queryaction`), and cancellation (`cancelaction`) of ongoing actions.
 However, the following points are not supported:
 
 - Sent and received payloads associated to the operations
@@ -40,7 +42,7 @@ Related Issues:
 Note: This should be moved to an analysis document.
 
 A streaming protocol establishes an ongoing connection supporting delivery of time-sensitive information such as audio or video. 
-Note that this connection in general may be over either reliable (TCP) or unreliable (UDP) transports, or over a combination, and may also support encryption or content management. 
+Note that this connection in general may be over either reliable (TCP) or unreliable (UDP) transports, or over a combination, and may also support encryption or content management.
 Streaming may also be used to support other kinds of ongoing time-sensitive data delivery.
 
 While related to event notification mechanisms, streaming in practice is supported by a specific set of protocols such as RTSP, HLS, DASH, MSE, WebRTC, etc.
@@ -54,14 +56,14 @@ Note: This should be moved to an analysis document.
 
 ### Signing
 
-Mechanisms for signing TDs documents were under discussion in the last charter but were not mature enough to include. 
+Mechanisms for signing TDs documents were under discussion in the last charter but were not mature enough to include.
 Adding support for TD canonicalization and signing would be helpful to ensure that TDs are not intercepted and modified by third parties.
 Verifying a signature requires identity management, i.e. the verifier needs to know or have trusted access to the public key of the signer.
 Directories need to be extended to verify signatures and generate new chained signatures as needed.
 
 ### Canonicalization
 
-Thing Descriptions can contain the same information but serialized differently even in the same serialization format, due to structures such as maps which do not impose an order. 
+Thing Descriptions can contain the same information but serialized differently even in the same serialization format, due to structures such as maps which do not impose an order.
 This is problematic for comparing TDs or more importantly, for signing them where every byte difference results in a different signature.
 Thus, the WG will develop a canonicalization algorithm based on JSON-LD.
 

--- a/planning/ThingDescription/td-next-work-items/new-features.md
+++ b/planning/ThingDescription/td-next-work-items/new-features.md
@@ -7,11 +7,78 @@ These are contained in this folder with the `analysis-` prefix.
 
 ## Timeseries / Historical Data
 
+Please refer to [Analysis Document](./../analysis-historical-data-work-item.md)
+
 ## Manageable Actions
+
+Note: This should be moved to an analysis document.
+
+Various use cases require the implementation of more complex actions that span multiple protocol transactions. Such actions are not simply invoked but need to managed over time by the Thing and the Consumer. 
+These are covered in the WoT Thing Description 1.1 via the initiation (invokeaction), monitoring (`queryaction`), and cancellation (`cancelaction`) of ongoing actions. 
+However, the following points are not supported:
+
+- Sent and received payloads associated to the operations
+- Management of dynamically generated identification
+- Describing queues of actions
+
+These limitations are also influencing the Profiles.
+
+Additionally, there have been proposals by the WG members that need to taken into account and evaluated:
+
+- <https://github.com/w3c/wot-thing-description/tree/main/proposals/hypermedia-control>
+- <https://github.com/w3c/wot-thing-description/tree/main/proposals/hypermedia-control-2>
+- <https://github.com/w3c/wot-thing-description/tree/main/proposals/hypermedia-control-3>
+
+Related Issues:
+
+- <https://github.com/w3c/wot-thing-description#1692>
+- <https://github.com/w3c/wot-thing-description#1644>
+- <https://github.com/w3c/wot-thing-description#1223>
 
 ## Streaming
 
-## Signing and Canonicalization (there is discussion on where this should belong)
+Note: This should be moved to an analysis document.
+
+A streaming protocol establishes an ongoing connection supporting delivery of time-sensitive information such as audio or video. 
+Note that this connection in general may be over either reliable (TCP) or unreliable (UDP) transports, or over a combination, and may also support encryption or content management. 
+Streaming may also be used to support other kinds of ongoing time-sensitive data delivery.
+
+While related to event notification mechanisms, streaming in practice is supported by a specific set of protocols such as RTSP, HLS, DASH, MSE, WebRTC, etc.
+This work item would add any infrastructure needed to TDs in order to support streaming protocol bindings generally, for example, by adding additional subprotocols supporting stream publication and subscription management (if needed).
+
+In order to clearly define what infrastructure is actually needed, if any, one or more concrete streaming protocol bindings should also be attempted, such as [RTSP](https://w3c.github.io/wot-charter-drafts/wot-wg-2023-details.html#rtsp-binding-workitem).
+
+## Signing and Canonicalization
+
+Note: This should be moved to an analysis document.
+
+### Signing
+
+Mechanisms for signing TDs documents were under discussion in the last charter but were not mature enough to include. 
+Adding support for TD canonicalization and signing would be helpful to ensure that TDs are not intercepted and modified by third parties.
+Verifying a signature requires identity management, i.e. the verifier needs to know or have trusted access to the public key of the signer.
+Directories need to be extended to verify signatures and generate new chained signatures as needed.
+
+### Canonicalization
+
+Thing Descriptions can contain the same information but serialized differently even in the same serialization format, due to structures such as maps which do not impose an order. 
+This is problematic for comparing TDs or more importantly, for signing them where every byte difference results in a different signature.
+Thus, the WG will develop a canonicalization algorithm based on JSON-LD.
+
+Related Issues:
+
+- <https://github.com/w3c/wot-thing-description/issues/1023>
+- <https://github.com/w3c/wot-thing-description/issues/940>
+
+Some work has been done in the previous charter but has been postponed due to lack of features in JSON-LD. Related PRs:
+
+- <https://github.com/w3c/wot-thing-description/pull/1304>
+- <https://github.com/w3c/wot-thing-description/pull/1151>
+- <https://github.com/w3c/wot-thing-description/pull/943>
+- <https://github.com/w3c/wot-thing-description/pull/1086>
 
 ### TD Versioning
 
+Note: This should be moved to an analysis document.
+
+Explain the semantics on how to version Thing Descriptions.

--- a/planning/ThingDescription/td-next-work-items/testing-and-tooling.md
+++ b/planning/ThingDescription/td-next-work-items/testing-and-tooling.md
@@ -1,6 +1,16 @@
 # Testing and Tooling
 
-- Linting
-- TD Testing for plugfest and testfests: Currently it is at Eclipse Thingweb Playground at <https://github.com/eclipse-thingweb/playground/tree/master/packages/assertions> but we should move it here.
-- Bugfixes (updates for the TD next. Actual bugs for 1.1 should be handled as errata)
-- Examples reorganization: It would be better to have complete TD examples that can be validated but at the same time we can show a part of it for specific features. Also, see <https://github.com/w3c/wot-thing-description/issues/1851>.
+## Linting
+
+## TD Testing for plugfest and testfests
+
+Currently it is at Eclipse Thingweb Playground at <https://github.com/eclipse-thingweb/playground/tree/master/packages/assertions> but we should move it here.
+
+## Bugfixes
+
+Small updates for the TD next. Actual bugs for 1.1 should be handled as errata
+
+## Examples reorganization
+
+It would be better to have complete TD examples that can be validated but at the same time we can show a part of it for specific features. 
+Also, see <https://github.com/w3c/wot-thing-description/issues/1851>.

--- a/planning/ThingDescription/td-next-work-items/testing-and-tooling.md
+++ b/planning/ThingDescription/td-next-work-items/testing-and-tooling.md
@@ -2,7 +2,18 @@
 
 ## Linting
 
-## TD Testing for plugfest and testfests
+Linting rules exist for programming languages or for API specifications in order to establish custom rules within projects. 
+How these rules can be defined for TDs is not specified in any way, making it difficult to constrain flexibility of TDs in a standardized manner. 
+The WG will define the mechanism for linting TDs together with optional rules that can be used by different projects.
+
+Related Issues:
+
+- <https://github.com/w3c/wot-thing-description/issues/1707>
+- <https://github.com/w3c/wot-thing-description/issues/1512>
+- <https://github.com/w3c/wot-thing-description/issues/1195>
+
+
+## Testing Procedure
 
 Currently it is at Eclipse Thingweb Playground at <https://github.com/eclipse-thingweb/playground/tree/master/packages/assertions> but we should move it here.
 
@@ -12,5 +23,5 @@ Small updates for the TD next. Actual bugs for 1.1 should be handled as errata
 
 ## Examples reorganization
 
-It would be better to have complete TD examples that can be validated but at the same time we can show a part of it for specific features. 
+It would be better to have complete TD examples that can be validated but at the same time we can show a part of it for specific features.
 Also, see <https://github.com/w3c/wot-thing-description/issues/1851>.

--- a/planning/ThingDescription/td-next-work-items/testing-and-tooling.md
+++ b/planning/ThingDescription/td-next-work-items/testing-and-tooling.md
@@ -1,4 +1,4 @@
-# Testing and Tooling
+# TD.Next Testing and Tooling Work Items
 
 ## Linting
 
@@ -12,7 +12,6 @@ Related Issues:
 - <https://github.com/w3c/wot-thing-description/issues/1512>
 - <https://github.com/w3c/wot-thing-description/issues/1195>
 
-
 ## Testing Procedure
 
 Currently it is at Eclipse Thingweb Playground at <https://github.com/eclipse-thingweb/playground/tree/master/packages/assertions> but we should move it here.
@@ -21,7 +20,14 @@ Currently it is at Eclipse Thingweb Playground at <https://github.com/eclipse-th
 
 Small updates for the TD next. Actual bugs for 1.1 should be handled as errata
 
-## Examples reorganization
+## Examples Reorganization
 
 It would be better to have complete TD examples that can be validated but at the same time we can show a part of it for specific features.
 Also, see <https://github.com/w3c/wot-thing-description/issues/1851>.
+
+## Spec Generation
+
+Single source of truth for specification generation.
+
+- Reducing the amount of documents that we need to maintain.
+- Make sure there are no gaps in the tooling and process for building index.html

--- a/planning/ThingDescription/td-next-work-items/usability-and-design.md
+++ b/planning/ThingDescription/td-next-work-items/usability-and-design.md
@@ -11,39 +11,84 @@ We should start a TD (re)design document that explains the idea behind the desig
 
 Changes that should be done while keeping the current content
 
-- Common definition section: Usability and readability improvements for not needing to "jump around" while reading
-- Grouping of normative requirements
-- Assertion id alignment: adding `td`, checking naming scheme
-- Better integration of Thing Model
+### Common definition section
+
+Usability and readability improvements for not needing to "jump around" while reading
+
+### Grouping of normative requirements
+
+### Assertion id alignment
+
+Adding `td`, checking naming scheme
+
+### Better integration of Thing Model
 
 ## Synchronization with other documents
 
-- Moving binding templates core document content to TD
-- Moving discovery-related text from TD to Discovery
+### Moving binding templates core document content to TD
+
+Please refer to the [binding templates planning document](binding-templates.md)
+
+### Moving discovery-related text from TD to Discovery
 
 ## Reusable TD Elements
 
-- Reusable connections, for example, an MQTT Broker connection that can be described at the top and used in the forms
-- Data Schema mapping information/metadata
-- Security schemes may need to be refactored and use the same pattern as other reusable elements
-- Inline Security
-- Scenarios, requirements, and use the same pattern for all reusable elements
-- Review the current state of the art in other standards
+### Reusable connections
+
+Currently, each form of an affordance has information on the endpoint, media type and other protocol related information. 
+It is possible to use the base term for simplifying the endpoint but it has limitations such as:
+
+- If the media type is also common across forms, it is repeated
+- Multiple bases are not possible
+- For protocols that are based on an initial connection and then subsequent messages, the semantics are not clear.
+
+Thus, a mechanism to describe connection and protocol information that can be used by other forms is needed. 
+In protocols with initial connection, this can be also used to indicate what needs to be done by the Consumer before executing any operation.
+
+Related Issues:
+
+- <https://github.com/w3c/wot-thing-description/issues/1664>
+- <https://github.com/w3c/wot-thing-description/issues/1248>
+- <https://github.com/w3c/wot-thing-description/issues/1242>
+- <https://github.com/w3c/wot-thing-description/issues/878>
+
+### Data Schema mapping information/metadata
+
+### Security Schemes Refactoring
+
+The need to be refactored and use the same pattern as other reusable elements
+
+### Inline Security
+
+### Scenarios, requirements, and use the same pattern for all reusable elements
+
+### Review the current state of the art in other standards
 
 ## Uniform pattern/state machines between Actions, Events, and Properties
 
-- Avoid doing the same thing in a different way, for example how to express observability and cancellation
-- Relationships across affordances, for example when an Action changes the state of a Property
-- Property vs. Action (also URI Variables redesign question)
+### Avoid doing the same thing in a different way, for example how to express observability and cancellation
+
+### Relationships across affordances, for example when an Action changes the state of a Property
+
+### Property vs. Action (also URI Variables redesign question)
 
 ## Normative Parsing, Validation, Consumption
 
-- What is a valid TD, are there any levels of validness?
-  - A TD validator can do only JSON Schema validation but that is not enough to test everything.
-  - A TD may be not completely valid but usable by a "degraded consumer" (see below) or a TD can be completely valid according to all the assertions and protocol bindings but not be usable by some consumers.
-- Do we want to prescribe how TDs are processed and consumed beyond the text level?
-- Degraded consumption rule for uniform degradation across consumers, e.g. TD too big, protocol or protocol options unknown, contentType unknown, etc.
+Currently the TD specification defines an abstract information model and a default JSON serialization for TDs.
+However, parsing, consuming and validating TDs are not normatively defined.
+A validation process is defined but is not normative, which leads to certain ambiguities for a Consumer parsing a TD.
+Additionally, no method is proposed for validation the extensions that are used via the prefixes and the @context.
+The WG will specify normative algorithms for parsing, consuming and validating TDs to ensure interoperability of Consumers.
+
+### What is a valid TD, are there any levels of validness?
+
+* A TD validator can do only JSON Schema validation but that is not enough to test everything.
+* A TD may be not completely valid but usable by a "degraded consumer" (see below) or a TD can be completely valid according to all the assertions and protocol bindings but not be usable by some consumers.
+
+### Do we want to prescribe how TDs are processed and consumed beyond the text level?
+
+### Degraded consumption rule for uniform degradation across consumers, e.g. TD too big, protocol or protocol options unknown, contentType unknown, etc.
 
 ## Single source of truth for build
 
-- Make sure there are no gaps in the tooling and process for building index.html
+* Make sure there are no gaps in the tooling and process for building index.html

--- a/planning/ThingDescription/td-next-work-items/usability-and-design.md
+++ b/planning/ThingDescription/td-next-work-items/usability-and-design.md
@@ -1,4 +1,4 @@
-# Usability and Design Work Items
+# TD.Next Usability and Design Work Items
 
 Changes that improve readability, the usability of the specification OR development, spec generation, bug fixes, and testing of the specification do not need use cases.
 These have more priority since they can impact how new features look like in a TD instance.
@@ -11,29 +11,36 @@ We should start a TD (re)design document that explains the idea behind the desig
 
 Changes that should be done while keeping the current content
 
-### Common definition section
+### Common Definition Section
 
 Usability and readability improvements for not needing to "jump around" while reading
 
 ### Grouping of normative requirements
 
+Making sure that important normative text is not scattered around too much.
+
 ### Assertion id alignment
 
 Adding `td`, checking naming scheme
 
-### Better integration of Thing Model
+### Better Integration of Thing Model
 
-## Synchronization with other documents
+There were questions about how much a TM is related to the TD.
+Some discussion might be needed.
 
-### Moving binding templates core document content to TD
+## Synchronization with Other Documents
 
-Please refer to the [binding templates planning document](binding-templates.md)
+### Discovery Sync
 
-### Moving discovery-related text from TD to Discovery
+Moving discovery-related text from TD to Discovery
+
+### Architecture Sync
+
+Checking overlaps with architecture.
 
 ## Reusable TD Elements
 
-### Reusable connections
+### Reusable Connections
 
 Currently, each form of an affordance has information on the endpoint, media type and other protocol related information. 
 It is possible to use the base term for simplifying the endpoint but it has limitations such as:
@@ -52,7 +59,16 @@ Related Issues:
 - <https://github.com/w3c/wot-thing-description/issues/1242>
 - <https://github.com/w3c/wot-thing-description/issues/878>
 
-### Data Schema mapping information/metadata
+### Data Schema Mapping
+
+Also known as: Mapping TD elements to messages
+
+How can we represent all protocol messages sent and received?
+It should be using data schema to indicate application-specific parameters but we should be able to describe payload, header, uri variables, and other protocol parameters.
+
+Related Issues:
+
+- BACnet URI Variables discussion
 
 ### Security Schemes Refactoring
 
@@ -60,17 +76,22 @@ The need to be refactored and use the same pattern as other reusable elements
 
 ### Inline Security
 
-### Scenarios, requirements, and use the same pattern for all reusable elements
+Simplifying the way to describe security when there is only one mechanism needed to be described (in contrast to needing two terms at the moment)
 
-### Review the current state of the art in other standards
+TODO: Find relevant discussions
 
-## Uniform pattern/state machines between Actions, Events, and Properties
+### Reusable Element Design
 
-### Avoid doing the same thing in a different way, for example how to express observability and cancellation
+Scenarios, requirements, and use the same pattern for all reusable elements.
+This will influence the items above.
 
-### Relationships across affordances, for example when an Action changes the state of a Property
+## Affordance Uniformity
 
-### Property vs. Action (also URI Variables redesign question)
+Uniform pattern/state machines between Actions, Events, and Properties.
+
+- Avoid doing the same thing in a different way, for example how to express observability and cancellation
+- Relationships across affordances, for example when an Action changes the state of a Property
+- Property vs. Action (also URI Variables redesign question)
 
 ## Normative Parsing, Validation, Consumption
 
@@ -80,15 +101,17 @@ A validation process is defined but is not normative, which leads to certain amb
 Additionally, no method is proposed for validation the extensions that are used via the prefixes and the @context.
 The WG will specify normative algorithms for parsing, consuming and validating TDs to ensure interoperability of Consumers.
 
-### What is a valid TD, are there any levels of validness?
+### TD Validation
 
-* A TD validator can do only JSON Schema validation but that is not enough to test everything.
-* A TD may be not completely valid but usable by a "degraded consumer" (see below) or a TD can be completely valid according to all the assertions and protocol bindings but not be usable by some consumers.
+What is a valid TD, are there any levels of validness?
 
-### Do we want to prescribe how TDs are processed and consumed beyond the text level?
+- A TD validator can do only JSON Schema validation but that is not enough to test everything.
+- A TD may be not completely valid but usable by a "degraded consumer" (see below) or a TD can be completely valid according to all the assertions and protocol bindings but not be usable by some consumers.
 
-### Degraded consumption rule for uniform degradation across consumers, e.g. TD too big, protocol or protocol options unknown, contentType unknown, etc.
+### Consumption Rules
 
-## Single source of truth for build
+Do we want to prescribe how TDs are processed and consumed beyond the text level?
 
-* Make sure there are no gaps in the tooling and process for building index.html
+### Degraded Consumption
+
+- Rule for uniform degradation across consumers, e.g. TD too big, protocol or protocol options unknown, contentType unknown, etc.

--- a/planning/ThingDescription/td-next-work-items/usability-and-design.md
+++ b/planning/ThingDescription/td-next-work-items/usability-and-design.md
@@ -15,11 +15,11 @@ Changes that should be done while keeping the current content
 
 Usability and readability improvements for not needing to "jump around" while reading
 
-### Grouping of normative requirements
+### Grouping of Normative Requirements
 
 Making sure that important normative text is not scattered around too much.
 
-### Assertion id alignment
+### Assertion id Alignment
 
 Adding `td`, checking naming scheme
 

--- a/planning/ThingDescription/work-items.md
+++ b/planning/ThingDescription/work-items.md
@@ -43,25 +43,27 @@ We should a roadmap for the TD specification that is aligned with the charter st
   - We can give something like "Story Points" to give a rough idea of the effort.
 - We should look at the schedule on a weekly basis, part of the meeting agenda.
 
-### Refactoring Roadmap
+### Specification Refactoring Roadmap
 
-In no particular order, we have the following:
+An example list of refactoring items with an order:
 
-- [Incorporating Binding Mechanism](./td-next-work-items/binding-templates.md#integration-of-the-binding-templates-into-the-td-document)
-- [Better integration of Thing Model](./td-next-work-items/usability-and-design.md#td-testing-for-plugfest-and-testfests)  
-- Specification Generation Tooling
-- Grouping of normative requirements (depends on specification generation tooling)
-- Common definitions section (usability improvements for not needing to "jump around" while reading) (depends on specification generation tooling)
-- Assertion id alignment: adding `td`, checking the naming scheme
-- Synchronization with other documents
-- Example reorganization
-- Testing Pipeline
+- [Incorporating Binding Mechanism](./td-next-work-items/binding-templates.md#binding-templates-integration)
+- [Specification Generation Tooling](./td-next-work-items/testing-and-tooling.md#spec-generation)
+- [Grouping of normative requirements](./td-next-work-items/usability-and-design.md#grouping-of-normative-requirements)
+- [Common definitions section](./td-next-work-items/usability-and-design.md#common-definition-section)
+- [Assertion id alignment](./td-next-work-items/usability-and-design.md#assertion-id-alignment)
+- [Synchronization with other documents](./td-next-work-items/usability-and-design.md#synchronization-with-other-documents)
+- [Example reorganization](./td-next-work-items/testing-and-tooling.md#examples-reorganization)
+- [Testing Pipeline](./td-next-work-items/testing-and-tooling.md#testing-procedure)
 
-### Redesign Roadmap
+### TD Instance Redesign Roadmap
+
+An example list of redesign items with an order:
 
 - Base connection design
 - Data mapping
-More to come here
+
+### New Features Roadmap
 
 ## Related Resources
 

--- a/planning/ThingDescription/work-items.md
+++ b/planning/ThingDescription/work-items.md
@@ -47,8 +47,8 @@ We should a roadmap for the TD specification that is aligned with the charter st
 
 In no particular order, we have the following:
 
-- Incorporating Binding Mechanism
-- Better integration of Thing Model
+- [Incorporating Binding Mechanism](./td-next-work-items/binding-templates.md#integration-of-the-binding-templates-into-the-td-document)
+- [Better integration of Thing Model](./td-next-work-items/usability-and-design.md#td-testing-for-plugfest-and-testfests)  
 - Specification Generation Tooling
 - Grouping of normative requirements (depends on specification generation tooling)
 - Common definitions section (usability improvements for not needing to "jump around" while reading) (depends on specification generation tooling)

--- a/planning/ThingDescription/work-items.md
+++ b/planning/ThingDescription/work-items.md
@@ -14,10 +14,7 @@ The work items are split into four categories.
 Such categories can be reflected with labels and different views in the GitHub project management panel.
 The task force will go through existing issues, pull requests, and discussions, and categorize them accordingly.
 
-- **Priorities:** The items below can be considered a flat list with no priorities set for now. Ideally, items that are dependencies to other items and those with concrete industry use cases will be prioritized.
-
-- **Organization:** In order to have a better overview, the list of work items should be kept low, and small work items should be grouped into bigger ones.
-This allows us to better label and manage the items.
+- **Priorities:** The items in each markdown under [td-next-work-items](./td-next-work-items) is a flat list with no priorities set for now. Ideally, items that are dependencies to other items and those with concrete industry use cases will be prioritized.
 
 - **Details:** The details of different work items can be found at <https://github.com/w3c/wot/blob/main/proposals/deliverable-proposals/thing-description.md>. We will consolidate such details and link them appropriately.
 
@@ -30,22 +27,23 @@ This allows us to better label and manage the items.
 
 ## Roadmap
 
-We have a roadmap for the TD specification that is aligned with the charter start and end dates.
+We should a roadmap for the TD specification that is aligned with the charter start and end dates.
+
+### WoT WG Charter Details
 
 - Charter End Date: 2 October 2025
 - CR Transition (feature freeze): July 10, 2025 (worst estimate)
 - Charter Start: October 2023
 
-Notes:
+#### Schedule for TD Deliverable
 
-- Stopping big features 6 months prior to CR Transition. That means January 10, 2025 -> End of 2024, we should be done with big features.
-  - The bigger the implementation impact, the more time to implement
-  - We can give something like "Story Points" to give a rough idea of the effort
-- We should look at the schedule on a weekly basis, part of the agenda
+- We will stop work big features 6 months prior to CR Transition. That means January 10, 2025. In other words, we should be done with big features by the end of 2024.
+- As a result, we should indicate whether a feature is considered a big feature. Some notes on this:
+  - The bigger the implementation impact, the more time to implement.
+  - We can give something like "Story Points" to give a rough idea of the effort.
+- We should look at the schedule on a weekly basis, part of the meeting agenda.
 
 ### Refactoring Roadmap
-
-Note: The items below will be turned to links.
 
 In no particular order, we have the following:
 


### PR DESCRIPTION
I simply link to the other md documents to avoid duplicate information.
