### PR TITLE
Moving Planning.md items

### DIFF
--- a/planning/ThingDescription/td-next-work-items/binding-templates.md
+++ b/planning/ThingDescription/td-next-work-items/binding-templates.md
@@ -5,6 +5,12 @@
 We need to specify how a new binding should be submitted. E.g. Registry or a similar approach.
 Registry analysis is happening at a separate document. See [Registry Analysis](../../../registry-analysis/).
 
+Our approach should clarify the following points:
+
+- Rule-based validation process of the binding document submission (what checks should a submission pass)
+- Review process (do we organize special meetings, invite submitters to explain, how do we document it all etc.)
+- To be continued
+
 ## Binding Mechanism
 
 ### Binding Templates Integration

--- a/planning/ThingDescription/td-next-work-items/usability-and-design.md
+++ b/planning/ThingDescription/td-next-work-items/usability-and-design.md
@@ -101,10 +101,10 @@ Uniform pattern/state machines between Actions, Events, and Properties.
 
 ## Normative Parsing, Validation, Consumption
 
-Currently the TD specification defines an abstract information model and a default JSON serialization for TDs.
+Currently, the TD specification defines an abstract information model and a default JSON serialization for TDs.
 However, parsing, consuming and validating TDs are not normatively defined.
 A validation process is defined but is not normative, which leads to certain ambiguities for a Consumer parsing a TD.
-Additionally, no method is proposed for validation the extensions that are used via the prefixes and the @context.
+Additionally, no method is proposed for validation of the extensions that are used via the prefixes and the @context.
 The WG will specify normative algorithms for parsing, consuming and validating TDs to ensure interoperability of Consumers.
 
 ### TD Validation
@@ -113,6 +113,8 @@ What is a valid TD, are there any levels of validness?
 
 - A TD validator can do only JSON Schema validation but that is not enough to test everything.
 - A TD may be not completely valid but usable by a "degraded consumer" (see below) or a TD can be completely valid according to all the assertions and protocol bindings but not be usable by some consumers.
+
+Additionally, we need better validation of protocols and associated security in the TD.
 
 ### Consumption Rules
 


### PR DESCRIPTION
In the TD repo we have https://github.com/w3c/wot-thing-description/blob/main/PLANNING.md but it is outdated and should not be used. I am moving the information in there to here.