### PR TITLE
TD/Binding Planning: Badges for work items to match GitHub labels

### DIFF
--- a/planning/ThingDescription/td-next-work-items/binding-templates.md
+++ b/planning/ThingDescription/td-next-work-items/binding-templates.md
@@ -1,4 +1,5 @@
 # TD.Next Binding Templates Work Items
+![GitHub labels](https://img.shields.io/github/labels/w3c/wot-thing-description/Binding)
 
 ## Binding Submission Mechanism
 
@@ -12,12 +13,15 @@ Our approach should clarify the following points:
 - To be continued
 
 ## Binding Mechanism
+![GitHub labels](https://img.shields.io/github/labels/w3c/wot-thing-description/Binding)
 
 ### Binding Templates Integration
+![GitHub labels](https://img.shields.io/github/labels/w3c/wot-thing-description/Binding) ![GitHub labels](https://img.shields.io/github/labels/w3c/wot-thing-description/document%20reorganization)
 
 Binding Templates core mechanism will be incorporated into the TD document.
 
 ### Payload Driven Protocols
+![GitHub labels](https://img.shields.io/github/labels/w3c/wot-thing-description/data%20mapping)
 
 Some protocols are built on top of the application layer protocols. Some examples are:
 
@@ -35,6 +39,7 @@ The working group will also document in which cases this method does not work du
 Note: This is dependent on *Reusable TD Elements* of [Usability and Design](./usability-and-design.md) work item list.
 
 ### External Security Ontologies
+![GitHub labels](https://img.shields.io/github/labels/w3c/wot-thing-description/Binding) ![GitHub labels](https://img.shields.io/github/labels/w3c/wot-thing-description/Security)
 
 Currently security schemes are "baked into" the TD specification but it would be more manageable and consistent to break them out as separate ontologies so that all security schemes would be done via extensions. For protocol-specific security schemes in particular, these should be moved to the Protocol Bindings and ontologies supporting them. The TD 2.0 spec would be updated to only include general-purpose "structural" security schemes and "generic" schemes that apply to all protocols.
 

--- a/planning/ThingDescription/td-next-work-items/new-features.md
+++ b/planning/ThingDescription/td-next-work-items/new-features.md
@@ -66,7 +66,7 @@ Verifying a signature requires identity management, i.e. the verifier needs to k
 Directories need to be extended to verify signatures and generate new chained signatures as needed.
 
 ### Canonicalization
-![GitHub labels](https://img.shields.io/github/labels/w3c/wot-thing-description/canonicalization)
+![GitHub labels](https://img.shields.io/github/labels/w3c/wot-thing-description/canonicaliziation)
 
 Thing Descriptions can contain the same information but serialized differently even in the same serialization format, due to structures such as maps which do not impose an order.
 This is problematic for comparing TDs or more importantly, for signing them where every byte difference results in a different signature.

--- a/planning/ThingDescription/td-next-work-items/new-features.md
+++ b/planning/ThingDescription/td-next-work-items/new-features.md
@@ -6,12 +6,14 @@ Instead, the TF will analyze current solutions, gather existing use cases and di
 These are contained in this folder with the `analysis-` prefix.
 
 ## Historical Data
+![GitHub labels](https://img.shields.io/github/labels/w3c/wot-thing-description/historical%20data)
 
-Also known as timeseries.
+Also known as time series.
 
 Please refer to [Analysis Document](./../analysis-historical-data-work-item.md)
 
-## Manageable Actions
+## Manageable Affordances
+![GitHub labels](https://img.shields.io/github/labels/w3c/wot-thing-description/manageable%20affordances)
 
 Note: This should be moved to an analysis document.
 
@@ -38,6 +40,7 @@ Related Issues:
 - <https://github.com/w3c/wot-thing-description#1223>
 
 ## Streaming
+![GitHub labels](https://img.shields.io/github/labels/w3c/wot-thing-description/streaming)
 
 Note: This should be moved to an analysis document.
 
@@ -55,6 +58,7 @@ In order to clearly define what infrastructure is actually needed, if any, one o
 Note: This should be moved to an analysis document.
 
 ### Signing
+![GitHub labels](https://img.shields.io/github/labels/w3c/wot-thing-description/signing)
 
 Mechanisms for signing TDs documents were under discussion in the last charter but were not mature enough to include.
 Adding support for TD canonicalization and signing would be helpful to ensure that TDs are not intercepted and modified by third parties.
@@ -62,6 +66,7 @@ Verifying a signature requires identity management, i.e. the verifier needs to k
 Directories need to be extended to verify signatures and generate new chained signatures as needed.
 
 ### Canonicalization
+![GitHub labels](https://img.shields.io/github/labels/w3c/wot-thing-description/canonicalization)
 
 Thing Descriptions can contain the same information but serialized differently even in the same serialization format, due to structures such as maps which do not impose an order.
 This is problematic for comparing TDs or more importantly, for signing them where every byte difference results in a different signature.
@@ -80,6 +85,7 @@ Some work has been done in the previous charter but has been postponed due to la
 - <https://github.com/w3c/wot-thing-description/pull/1086>
 
 ### TD Versioning
+![GitHub labels](https://img.shields.io/github/labels/w3c/wot-thing-description/versioning)
 
 Note: This should be moved to an analysis document.
 

--- a/planning/ThingDescription/td-next-work-items/testing-and-tooling.md
+++ b/planning/ThingDescription/td-next-work-items/testing-and-tooling.md
@@ -1,6 +1,7 @@
 # TD.Next Testing and Tooling Work Items
 
 ## Linting
+![GitHub labels](https://img.shields.io/github/labels/w3c/wot-thing-description/linting)
 
 Linting rules exist for programming languages or for API specifications in order to establish custom rules within projects. 
 How these rules can be defined for TDs is not specified in any way, making it difficult to constrain flexibility of TDs in a standardized manner. 
@@ -13,10 +14,12 @@ Related Issues:
 - <https://github.com/w3c/wot-thing-description/issues/1195>
 
 ## Testing Procedure
+![GitHub labels](https://img.shields.io/github/labels/w3c/wot-thing-description/Testing)
 
 Currently it is at Eclipse Thingweb Playground at <https://github.com/eclipse-thingweb/playground/tree/master/packages/assertions> but we should move it here.
 
 ## Bugfixes
+![GitHub labels](https://img.shields.io/github/labels/w3c/wot-thing-description/bug)
 
 Small updates for the TD next. Actual bugs for 1.1 should be handled as errata
 
@@ -26,6 +29,7 @@ It would be better to have complete TD examples that can be validated but at the
 Also, see <https://github.com/w3c/wot-thing-description/issues/1851>.
 
 ## Spec Generation
+![GitHub labels](https://img.shields.io/github/labels/w3c/wot-thing-description/Tooling)
 
 Single source of truth for specification generation.
 

--- a/planning/ThingDescription/td-next-work-items/usability-and-design.md
+++ b/planning/ThingDescription/td-next-work-items/usability-and-design.md
@@ -60,6 +60,7 @@ Related Issues:
 - <https://github.com/w3c/wot-thing-description/issues/878>
 
 ### Data Schema Mapping
+![GitHub labels](https://img.shields.io/github/labels/w3c/wot-thing-description/data%20mapping)
 
 Also known as: Mapping TD elements to messages
 

--- a/planning/ThingDescription/td-next-work-items/usability-and-design.md
+++ b/planning/ThingDescription/td-next-work-items/usability-and-design.md
@@ -8,6 +8,7 @@ These have more priority since they can impact how new features look like in a T
 We should start a TD (re)design document that explains the idea behind the design of different features. See [issue 1889](https://github.com/w3c/wot-thing-description/issues/1889).
 
 ## Document reorganization
+![GitHub labels](https://img.shields.io/github/labels/w3c/wot-thing-description/document%20reorganization)
 
 Changes that should be done while keeping the current content
 
@@ -29,6 +30,7 @@ There were questions about how much a TM is related to the TD.
 Some discussion might be needed.
 
 ## Synchronization with Other Documents
+![GitHub labels](https://img.shields.io/github/labels/w3c/wot-thing-description/document%20synchronisation)
 
 ### Discovery Sync
 
@@ -39,8 +41,11 @@ Moving discovery-related text from TD to Discovery
 Checking overlaps with architecture.
 
 ## Reusable TD Elements
+![GitHub labels](https://img.shields.io/github/labels/w3c/wot-thing-description/Security)
 
 ### Reusable Connections
+![GitHub labels](https://img.shields.io/github/labels/w3c/wot-thing-description/reusable%20connections)
+
 
 Currently, each form of an affordance has information on the endpoint, media type and other protocol related information. 
 It is possible to use the base term for simplifying the endpoint but it has limitations such as:
@@ -86,10 +91,13 @@ Also known as: Mapping TD elements to messages
 - [HTTP Headers in directory exploration (Problem 2)](https://github.com/eclipse-thingweb/node-wot/issues/1221)
 
 ### Security Schemes Refactoring
+![GitHub labels](https://img.shields.io/github/labels/w3c/wot-thing-description/Security) ![GitHub labels](https://img.shields.io/github/labels/w3c/wot-thing-description/Binding)
+
 
 The need to be refactored and use the same pattern as other reusable elements
 
 ### Inline Security
+![GitHub labels](https://img.shields.io/github/labels/w3c/wot-thing-description/Security) ![GitHub labels](https://img.shields.io/github/labels/w3c/wot-thing-description/reusable%20elements)
 
 Simplifying the way to describe security when there is only one mechanism needed to be described (in contrast to needing two terms at the moment)
 
@@ -98,6 +106,7 @@ Relevant discussions:
 - https://github.com/w3c/wot-thing-description/pull/945
 
 ### Reusable Element Design
+![GitHub labels](https://img.shields.io/github/labels/w3c/wot-thing-description/Security)
 
 Scenarios, requirements, and use the same pattern for all reusable elements.
 This will influence the items above.
@@ -107,6 +116,7 @@ Related discussions:
 - https://github.com/w3c/wot-thing-description/pull/1341 (but many are linked here as well)
 
 ## Affordance Uniformity
+![GitHub labels](https://img.shields.io/github/labels/w3c/wot-thing-description/affordance%20uniformity)
 
 Uniform pattern/state machines between Actions, Events, and Properties.
 
@@ -115,6 +125,7 @@ Uniform pattern/state machines between Actions, Events, and Properties.
 - Property vs. Action (also URI Variables redesign question)
 
 ## Normative Parsing, Validation, Consumption
+![GitHub labels](https://img.shields.io/github/labels/w3c/wot-thing-description/Validation)
 
 Currently, the TD specification defines an abstract information model and a default JSON serialization for TDs.
 However, parsing, consuming and validating TDs are not normatively defined.


### PR DESCRIPTION
Using https://shields.io/badges/git-hub-labels, I am adding small badges next to work items. That way, they can be visually linked to issue labels. Also, this gives an overview of labels to use when filtering issues (cc @lu-zero )