### PR TITLE
Article Selection Policy

### DIFF
--- a/proposals/policies/article-selection.md
+++ b/proposals/policies/article-selection.md
@@ -2,7 +2,7 @@
 
 ## WoT Articles Selection
 
-The Web of Things Interest Group Marketing Task Force collects articles about the Web of Things on the official web page of the W3C Web of Things at [the official webpage](https://www.w3.org/WoT/about/articles/).
+The Web of Things Interest Group Marketing Task Force collects links to articles about the Web of Things on the official web page of the W3C Web of Things at [the official webpage](https://www.w3.org/WoT/about/articles/).
 
 The allowed articles must be from one of the following categories:
 

--- a/proposals/policies/article-selection.md
+++ b/proposals/policies/article-selection.md
@@ -8,6 +8,6 @@ The allowed articles must be from one of the following categories:
 
 - It is written by the W3C WoT WG/IG as a whole or W3C Team. Examples are press releases
 - It is written in collaboration with the WoT IG/WG where the marketing TF is the point of contact. Interest Group has reviewed it before it is published. Examples are collaborations such as the one with the JSON Schema (see [here](https://json-schema.org/blog/posts/w3c-wot-case-study)).
-- It is written by one of the member organizations or someone affiliated by one of the member organizations.
+- It is written by one of the IG or WG member organizations or someone affiliated by one of the member organizations or Invited Experts of the WoT IG or WoT WG.
 
 Thus, third-party articles are not allowed until further changes to this policy.

--- a/proposals/policies/article-selection.md
+++ b/proposals/policies/article-selection.md
@@ -7,7 +7,7 @@ The Web of Things Interest Group Marketing Task Force collects links to articles
 The allowed articles must be from one of the following categories:
 
 - It is written by the W3C WoT WG/IG as a whole or W3C Team. Examples are press releases
-- It is written in collaboration with the WoT IG/WG where the marketing TF is the point of contact. Interest Group has reviewed it before it is published. Examples are collaborations.
+- It is written in collaboration with the WoT IG/WG where the marketing TF is the point of contact. Interest Group has reviewed it before it is published. Examples are collaborations such as the one with the JSON Schema (see [here](https://json-schema.org/blog/posts/w3c-wot-case-study)).
 - It is written by one of the member organizations or someone affiliated by one of the member organizations.
 
 Thus, third-party articles are not allowed until further changes to this policy.

--- a/proposals/policies/article-selection.md
+++ b/proposals/policies/article-selection.md
@@ -10,4 +10,4 @@ As a default, articles should be from one of the following categories:
 - It is written in collaboration with the WoT IG/WG where the marketing TF is the point of contact. Interest Group has reviewed it before it is published. Examples are collaborations such as the one with the JSON Schema (see [here](https://json-schema.org/blog/posts/w3c-wot-case-study)).
 - It is written by one of the IG or WG member organizations or someone affiliated by one of the member organizations or Invited Experts of the WoT IG or WoT WG.
 
-Thus, third-party articles are not allowed until further changes to this policy.
+Thus, third-party articles are only allowed as exceptions to the default policy and require consensus of the WoT Interest Group.

--- a/proposals/policies/article-selection.md
+++ b/proposals/policies/article-selection.md
@@ -4,7 +4,7 @@
 
 The Web of Things Interest Group Marketing Task Force collects links to articles about the Web of Things on the official web page of the W3C Web of Things at [the official webpage](https://www.w3.org/WoT/about/articles/).
 
-The allowed articles must be from one of the following categories:
+As a default, articles should be from one of the following categories:
 
 - It is written by the W3C WoT WG/IG as a whole or W3C Team. Examples are press releases
 - It is written in collaboration with the WoT IG/WG where the marketing TF is the point of contact. Interest Group has reviewed it before it is published. Examples are collaborations such as the one with the JSON Schema (see [here](https://json-schema.org/blog/posts/w3c-wot-case-study)).

--- a/proposals/policies/article-selection.md
+++ b/proposals/policies/article-selection.md
@@ -8,6 +8,6 @@ As a default, articles should be from one of the following categories:
 
 - It is written by the W3C WoT WG/IG as a whole or W3C Team. Examples are press releases
 - It is written in collaboration with the WoT IG/WG where the marketing TF is the point of contact. Interest Group has reviewed it before it is published. Examples are collaborations such as the one with the JSON Schema (see [here](https://json-schema.org/blog/posts/w3c-wot-case-study)).
-- It is written by one of the IG or WG member organizations or someone affiliated by one of the member organizations or Invited Experts of the WoT IG or WoT WG.
+- It is written by an official participant in the IG or WG.
 
 Thus, third-party articles are only allowed as exceptions to the default policy and require consensus of the WoT Interest Group.

--- a/proposals/policies/article-selection.md
+++ b/proposals/policies/article-selection.md
@@ -1,0 +1,13 @@
+# Web of Things (WoT) Policy (Draft)
+
+## WoT Articles Selection
+
+The Web of Things Interest Group Marketing Task Force collects articles about the Web of Things on the official web page of the W3C Web of Things at [the official webpage](https://www.w3.org/WoT/about/articles/).
+
+The allowed articles must be from one of the following categories:
+
+- It is written by the W3C WoT WG/IG as a whole or W3C Team. Examples are press releases
+- It is written in collaboration with the WoT IG/WG where the marketing TF is the point of contact. Interest Group has reviewed it before it is published. Examples are collaborations.
+- It is written by one of the member organizations or someone affiliated by one of the member organizations.
+
+Thus, third-party articles are not allowed until further changes to this policy.


### PR DESCRIPTION
This policy has been already agreed upon in https://www.w3.org/2023/04/12-wot-minutes.html#r01 and documented at https://github.com/w3c/wot-marketing/blob/main/Article_Policy.md . Since we have the policies here, it makes sense to move it here.