### PR TITLE
Planning Document: Initial Connection Topic's Basic Issue Analysis

### DIFF
--- a/planning/ThingDescription/td-next-work-items/usability-and-design.md
+++ b/planning/ThingDescription/td-next-work-items/usability-and-design.md
@@ -58,14 +58,14 @@ It is possible to use the base term for simplifying the endpoint but it has limi
 Related Issues:
 
 - Umbrella Issue: <https://github.com/w3c/wot-thing-description/issues/1248>
-- Media Type Override: <https://github.com/w3c/wot-thing-description/issues/204>
-- Single base <https://github.com/w3c/wot-thing-description/issues/803>
-- <https://github.com/w3c/wot-thing-description/issues/878> 35 comments
-- <https://github.com/w3c/wot-thing-description/issues/977>
-- <https://github.com/w3c/wot-thing-description/issues/1070>
-- <https://github.com/w3c/wot-thing-description/issues/1242>
-- <https://github.com/w3c/wot-thing-description/issues/1664>
-- <https://github.com/w3c/wot-thing-description/issues/1834>
+- Media Type and Security Override: <https://github.com/w3c/wot-thing-description/issues/204>: Sharing a media type and security (already possible) among forms
+- Single base with multiple protocols: <https://github.com/w3c/wot-thing-description/issues/803>: Having the same feature as the `security` term in form protocols
+- Reused Connection: <https://github.com/w3c/wot-thing-description/issues/878>: Implying a first connection that is not dropped but actually reused later
+- Out-of-band IP address: <https://github.com/w3c/wot-thing-description/issues/977>: Sort of related. Deducing the IP address from an out-of-band way
+- Reused Connection in WS: <https://github.com/w3c/wot-thing-description/issues/1070>: Similar issue to 878 but giving more details on WebSocket
+- Linking to Initial Connection: <https://github.com/w3c/wot-thing-description/issues/1242>: Similar issue to 803.
+- Reused Connection in WS 2: <https://github.com/w3c/wot-thing-description/issues/1664>: Similar issue to 878 abd 1070
+- Linking to Initial Connection 2: <https://github.com/w3c/wot-thing-description/issues/1834>: Similar issue to 803 and 1242
 
 **Requirements**
 

--- a/planning/ThingDescription/td-next-work-items/usability-and-design.md
+++ b/planning/ThingDescription/td-next-work-items/usability-and-design.md
@@ -47,28 +47,31 @@ Checking overlaps with architecture.
 ![GitHub labels](https://img.shields.io/github/labels/w3c/wot-thing-description/reusable%20connections)
 
 **Problem:**
-Currently, each form of an affordance has information on the endpoint, media type and other protocol related information. 
+Currently, each form of an affordance has information on the endpoint, media type, and other protocol-related information. 
 It is possible to use the base term for simplifying the endpoint but it has limitations such as:
 
 - If the media type is common across forms but is not `application/json`, it is repeated in each form.
-- If there are common protocol stack configurations such as different default verb, baud rate, endianness, they are repeated in each form
-- Multiple bases are not possible, thus each form repeats multiple bases. This is relevant when a TD has local and public IP addresses
-- For protocols that are based on an initial connection and then subsequent messages, the semantics are not clear. Thus, a Consumer can establish multiple connections instead of reusing the initial connection. See Example of Message Flow section below
+- If there are common protocol stack configurations such as different default verbs, baud rates, and endianness, they are repeated in each form
+- Multiple bases are not possible. Thus, each form repeats multiple bases. This is relevant when a TD has local and public IP addresses
+- For protocols that are based on an initial connection and then subsequent messages, the semantics are not clear. Thus, a Consumer can establish multiple connections instead of reusing the initial connection. See the Example of the Message Flow section below
 
 Related Issues:
 
-- <https://github.com/w3c/wot-thing-description/issues/1664>
-- <https://github.com/w3c/wot-thing-description/issues/1248>
-- <https://github.com/w3c/wot-thing-description/issues/1242>
+- Umbrella Issue: <https://github.com/w3c/wot-thing-description/issues/1248>
+- Media Type Override: <https://github.com/w3c/wot-thing-description/issues/204>
+- Single base <https://github.com/w3c/wot-thing-description/issues/803>
 - <https://github.com/w3c/wot-thing-description/issues/878> 35 comments
-- <https://github.com/w3c/wot-thing-description/issues/803>
+- <https://github.com/w3c/wot-thing-description/issues/977>
+- <https://github.com/w3c/wot-thing-description/issues/1070>
+- <https://github.com/w3c/wot-thing-description/issues/1242>
+- <https://github.com/w3c/wot-thing-description/issues/1664>
 - <https://github.com/w3c/wot-thing-description/issues/1834>
 
 **Requirements**
 
-- Basic Requirement: A mechanism to describe connection and protocol information that can be used by other forms is needed. In protocols with initial connection, this can be also used to indicate what needs to be done by the Consumer before executing any operation.
+- Basic Requirement: A mechanism to describe connection and protocol information that other forms can use is needed. In protocols with initial connection, this can also be used to indicate what needs to be done by the Consumer before executing any operation.
 - Detailed Requirements:
-  - Each connection needs to be identifiable but we need to make sure to not include privacy or security risks
+  - Each connection needs to be identifiable, but we need to make sure not to include privacy or security risks
   - The initial connection must not be mandatory to establish upon TD consumption and should left to the implementation when to establish and close it.
 
 **Notes:**


### PR DESCRIPTION
A small PR just to organize the issue list. I have merged the list here with what is in https://github.com/w3c/wot-thing-description/issues/1248

Some important observations:

- There are a lot of overlaps between the issues as highlighted in the PR
- There are 3 main discussions: 
  1. Having a place to put common connection information
  2. Linking to a common connection information.
  3. Signaling that a form in an affordance can reuse the connection established before so that the Consumer does not open a new connection per operation execution

Subpoint 2 is about a keyword (more or less), whereas subpoint 3 is more about the underlying mechanism. Probably subpoint 3 will be the major point of discussion since it includes lifecycle aspects.