### PR TITLE
Split schedule.md into WG and IG schedules

### DIFF
--- a/planning/ig-schedule.md
+++ b/planning/ig-schedule.md
@@ -13,10 +13,9 @@ Archives of older schedules (which combine IG and WG schedules):
 | March, 2025 | UCR | Use Case and Requirements - new use cases accepted |
 
 ## Current
-Note: some of these dates are now past and need to be rescheduled.
 | Due date | Spec. | Description |
 | --- | --- | --- |
-| mid-April, 2025 | All | Use Case and Requirements Note Publication - restructured |
-| June, 2025 | | Testing (IG event, results contributed to WG) |
-| September, 2025 | UCR | Use Case and Requirements Note Publication - update |
-| May 19, 2026 |   | End of WG Charter |
+| mid-August, 2025 | All | Use Case and Requirements Note Publication - restructured |
+| November, 2025 | | Testing (Plugfest, TPAC2025, IG event, results contributed to WG) |
+| June, 2026 | UCR | Use Case and Requirements Note Publication - update |
+| May 19, 2026 |   | End of IG Charter |

--- a/planning/ig-schedule.md
+++ b/planning/ig-schedule.md
@@ -1,5 +1,6 @@
 # IG Schedule
 This schedule spans the [current IG charter](https://www.w3.org/2024/04/wot-ig-2024.html) which started on May 20, 2024 and ends on May 19, 2026.
+The [WG Schedule](wg-schedule.md) is managed separately.
 
 Archives of older schedules (which combine IG and WG schedules):
 * [2021-2023](schedule_2023.md)

--- a/planning/ig-schedule.md
+++ b/planning/ig-schedule.md
@@ -1,5 +1,6 @@
 # IG Schedule
 This schedule spans the [current IG charter](https://www.w3.org/2024/04/wot-ig-2024.html) which started on May 20, 2024 and ends on May 19, 2026.
+
 The [WG Schedule](wg-schedule.md) is managed separately.
 
 Archives of older schedules (which combine IG and WG schedules):

--- a/planning/ig-schedule.md
+++ b/planning/ig-schedule.md
@@ -1,0 +1,20 @@
+# IG Schedule
+This schedule spans the [current IG charter](https://www.w3.org/2024/04/wot-ig-2024.html) which started on May 20, 2024 and ends on May 19, 2026.
+
+Archives of older schedules (which combine IG and WG schedules):
+* [2021-2023](schedule_2023.md)
+
+## Past
+| Due date | Spec. | Description |
+| --- | --- | --- |
+| December 11, 2024 | | Use Cases and Requirements process defined |
+| March, 2025 | UCR | Use Case and Requirements - new use cases accepted |
+
+## Current
+Note: some of these dates are now past and need to be rescheduled.
+| Due date | Spec. | Description |
+| --- | --- | --- |
+| mid-April, 2025 | All | Use Case and Requirements Note Publication - restructured |
+| June, 2025 | | Testing (IG event, results contributed to WG) |
+| September, 2025 | UCR | Use Case and Requirements Note Publication - update |
+| May 19, 2026 |   | End of WG Charter |

--- a/planning/schedule.md
+++ b/planning/schedule.md
@@ -1,0 +1,4 @@
+# Schedule
+
+* [IG Schedule](ig-schedule.md)
+* [WG Schedule](wg-schedule.md)

--- a/planning/schedule.md
+++ b/planning/schedule.md
@@ -1,7 +1,7 @@
-# Schedule
+# WG Schedule
 This schedule spans the [current WG charter](https://www.w3.org/2023/10/wot-wg-2023.html) which started in October 3, 2023 and ends in October 2, 2025.
 
-Archives of older schedules:
+Archives of older schedules (which combine IG and WG schedules):
 * [2021-2023](schedule_2023.md)
 
 ## Past

--- a/planning/wg-schedule.md
+++ b/planning/wg-schedule.md
@@ -1,5 +1,6 @@
 # WG Schedule
 This schedule spans the [current WG charter](https://www.w3.org/2023/10/wot-wg-2023.html) which started on October 3, 2023 and ends on October 2, 2025.
+The [IG Schedule](ig-schedule.md) is managed separately.
 
 Archives of older schedules (which combine IG and WG schedules):
 * [2021-2023](schedule_2023.md)

--- a/planning/wg-schedule.md
+++ b/planning/wg-schedule.md
@@ -1,5 +1,5 @@
 # WG Schedule
-This schedule spans the [current WG charter](https://www.w3.org/2023/10/wot-wg-2023.html) which started in October 3, 2023 and ends in October 2, 2025.
+This schedule spans the [current WG charter](https://www.w3.org/2023/10/wot-wg-2023.html) which started on October 3, 2023 and ends on October 2, 2025.
 
 Archives of older schedules (which combine IG and WG schedules):
 * [2021-2023](schedule_2023.md)

--- a/planning/wg-schedule.md
+++ b/planning/wg-schedule.md
@@ -1,5 +1,6 @@
 # WG Schedule
 This schedule spans the [current WG charter](https://www.w3.org/2023/10/wot-wg-2023.html) which started on October 3, 2023 and ends on October 2, 2025.
+
 The [IG Schedule](ig-schedule.md) is managed separately.
 
 Archives of older schedules (which combine IG and WG schedules):

--- a/planning/wg-schedule.md
+++ b/planning/wg-schedule.md
@@ -18,18 +18,12 @@ Archives of older schedules (which combine IG and WG schedules):
 | June 2024 | Interim updates, e.g. refactoring |
 | September 23-27, 2024 | All | [TPAC 2024](https://www.w3.org/2024/09/TPAC/); [WoT meetings Sept 26-27](https://www.w3.org/WoT/IG/wiki/Wiki_for_F2F_2024_planning) |
 | November 25-29, 2024 | All | [WoT Week 2024](https://www.w3.org/WoT/IG/wiki/Wiki_for_WoT_Week_2024_planning); WoT@Industry Open Day Nov 27 |
-| December 11, 2024 | | Use Cases and Requirements process defined |
 | mid-December, 2024 | TD | TD FPWD Publication Request - target - Freezing Addition of Big Features|
 | mid-December, 2024 | Discovery | Discovery FPWD Publication Request - target |
 | March 13, 2025 | All | FPWD Publication Requests - latest |
-| March, 2025 | All | Use Case and Requirements - new use cases accepted |
-| mid-April, 2025 | All | Use Case and Requirements Note Publication - restructured |
-| June, 2025 | | Testing (results contributed to WG) |
 | July 3, 2025 | All | CR Transition Requests - latest |
 | August 19, 2025 | All | PR Transition Requests - latest |
-| September, 2025 | All | Use Case and Requirements Note Publication - update |
 | September, 2025 | | Security and Privacy Guidelines Note Publication - update |
-| September, 2025 | All | Use Case and Requirements Note Publication - update |
 | September 24, 2025 | All | REC Transition Requests - latest |
 | October 2, 2025 |   | End of WG Charter |
 


### PR DESCRIPTION
As discussed in the main call on 4 June, this PR splits the schedule into WG and IG schedules.  To keep PRs separate for future updates I split them into two files.  I however created an "index" schedule.md to point to both of them to avoid broken links, and cross-linked the two files.

It seems the UC&R document is the only IG document we have published, let me know if I am wrong.  The Security and Privacy document is a WG publication, BTW.  Testing is technically an IG activity (or IG/CG joint effort...) and so things like it and the Plugfest should go on the IG schedule also.

Some of the dates in the IG schedule are in the past now and need to be either confirmed as being accomplished (and moved to the past) or deferred.  We will discuss the UC&R deadlines in the next UC&R call.