### PR TITLE
add wot-wg-2025-draft.html

### DIFF
--- a/charters/wot-wg-2025-draft.html
+++ b/charters/wot-wg-2025-draft.html
@@ -1,0 +1,1103 @@
+<!DOCTYPE html>
+<html lang="en-US">
+  <head>
+    <meta charset="utf-8">
+
+    <title><i class="todo">[name]</i> <i class="todo">(Working|Interest)</i> Group Charter</title>
+
+    <link rel="stylesheet" href="https://www.w3.org/2005/10/w3cdoc.css" type="text/css" media="screen">
+    <link rel="stylesheet" type="text/css" href="https://www.w3.org/OldGuide/pubrules-style.css">
+    <link rel="stylesheet" type="text/css" href="https://www.w3.org/2006/02/charter-style.css">
+    <style>
+      main {
+        max-width: 60em;
+        margin: 0 auto;
+      }
+
+      ul#navbar {
+        font-size: small;
+      }
+
+      dt.spec {
+        font-weight: bold;
+      }
+
+      dt.spec new {
+        background: yellow;
+      }
+
+      ul.out-of-scope > li {
+        font-weight: bold;
+      }
+
+      ul.out-of-scope > li > ul > li{
+        font-weight: normal;
+      }
+
+      .issue {
+        background: cornsilk;
+        font-style: italic;
+      }
+
+      .todo {
+        color: #900;
+      }
+
+      footer {
+        font-size: small;
+      }
+    </style>
+  </head>
+  <body>
+    <header id="header">
+      <aside>
+        <ul id="navbar">
+          <li><a href="#background">Background</a></li>
+          <li><a href="#scope">Scope</a></li>
+          <li><a href="#deliverables">Deliverables</a></li>
+		  <li><a href="#success-criteria">Success Criteria</a></li>
+          <li><a href="#coordination">Coordination</a></li>
+          <li><a href="#participation">Participation</a></li>
+          <li><a href="#communication">Communication</a></li>
+          <li><a href="#decisions">Decision Policy</a></li>
+          <li><a href="#patentpolicy">Patent Policy</a></li>
+          <li><a href="#licensing">Licensing</a></li>
+          <li><a href="#about">About this Charter</a></li>
+        </ul>
+      </aside>
+      <p>
+        <a href="https://www.w3.org/"><img alt="W3C" height="48" src="https://www.w3.org/Icons/w3c_home" width="72"></a>
+      </p>
+    </header>
+
+
+    <main>
+      <h1 id="title"><i class="todo">DRAFT</i> Web of Things Working Group Charter</h1>
+      <!-- replace DRAFT with PROPOSED when the AC review starts -->
+      <!-- delete PROPOSED after AC review completed -->
+
+      <p class="mission">The <strong>mission</strong> of the <a href="https://www.w3.org/groups/wg/wot">Web of Things Working
+          Group</a> is to counter the fragmentation of the Internet of
+          Things (IoT) through the specification of building blocks that
+          enable easy integration of IoT devices and services across IoT
+          platforms and application domains. 
+          <!-- the link to the group is ALWAYS that available from https://www.w3.org/groups/wg or https://www.w3.org/groups/ig because each group page can then point to a different homepage, but not the other way around. -->
+          These building blocks complement and enhance the use of
+          existing standards; provide a common description across
+          different ecosystems, standards, and communities; and provide
+          prescriptive definitions where appropriate. 
+
+      <!-- the link to the group is ALWAYS that available from https://www.w3.org/groups/wg or https://www.w3.org/groups/ig because each group page can then point to a different homepage, but not the other way around. -->
+
+      <div class="noprint">
+        <p class="join"><a href="https://www.w3.org/groups/wg/wot/join/">Join the Web of Things Working Group.</a></p>
+      </div>
+
+      <!-- replace "draft charter" with "proposed charter" when the AC review starts -->
+      <!-- replace GitHub link and issues link to the specific charter in GH and its issues repo -->
+      <!-- delete the GH link after AC review completed -->
+      <p style="padding: 0.5ex; border: 1px solid green"> This proposed charter is available
+      on <i class="todo"><a href="https://github.com/w3c/wot/blob/gh-pages/wot-wg-2025-draft.html">GitHub</a>.
+
+    Feel free to raise <a href="https://github.com/w3c/wot/issues?q=is%3Aissue%20state%3Aopen">issues</a></i>.
+          </p>
+
+      <div id="details">
+        <table class="summary-table">
+          <tr id="Status">
+            <th>
+              Charter Status
+            </th>
+            <td>
+              <i class="todo">See the <a href="https://www.w3.org/groups/wg/wot/charters/">group status page</A> and <a href="#history">detailed change history</a>.</i>
+            </td>
+          </tr>
+          <tr id="Duration">
+            <th>
+              Start date
+            </th>
+            <td>
+              <i class="todo">[dd monthname yyyy] (date of the "Call for Participation", when the charter is approved)</i>
+            </td>
+          </tr>
+          <tr id="CharterEnd">
+            <th>
+              End date
+            </th>
+            <td>
+              <i class="todo">[dd monthname yyyy]</i> (Start date + 2 years)
+            </td>
+          </tr>
+          <tr>
+            <th>
+              Chairs
+            </th>
+            <td>
+              <i class="todo">[chair name] (affiliation)</i>
+            </td>
+          </tr>
+          <tr>
+            <th>
+              Team Contacts
+            </th>
+            <td>
+              <span class="todo"><a href="mailto:">[team contact name]</a></span> <i class="todo">(0.2 <abbr title="Full-Time Equivalent">FTE</abbr>)</i>
+            </td>
+          </tr>
+          <tr>
+            <th>
+              Meeting Schedule
+            </th>
+            <td>
+                  <strong>Teleconferences:</strong> Weekly with additional topic specific calls as appropriate.<br>
+                  <strong>Face-to-face:</strong> we will meet during the W3C's annual Technical Plenary week; additional face-to-face meetings may be scheduled by consent of the participants, usually no more than 3 per year.
+              </td>
+          </tr>
+        </table>
+
+      </div>
+
+      <div id="background" class="background">
+        <h2>Motivation and Background</h2>
+      <p>Currently the IoT is highly fragmented with a multitude of
+      different standards and ecosystems which often do not easily
+      interoperate. This is a concern as much of the value of the
+      IoT can only be obtained when devices and services from
+      different vendors can be used together. The standards
+      developed by Web of Things (WoT) are intended to address this
+      issue by defining additional building blocks to allow systems
+      from different "ecosystems" to interoperate. The WoT WG will
+      focus on IoT standards for commercial and industrial
+      deployments and ecosystems. As part of its work the WoT WG
+      will aim to build strong liaisons with related
+      organizations.</p>
+
+      <p>As a continuation of the work in <a href=
+      "https://www.w3.org/2023/10/wot-wg-2023.html">the previous
+      charter</a>, this working group is tasked with the
+      standardization or extension of the building blocks to
+      address the use cases and requirements <!--identified by <a href=
+      "https://www.w3.org/groups/ig/wot">the Web of Things Interest
+      Group</a> (IG)--> to advance the Web of Things. The WoT building
+      blocks complement and integrate existing and emerging IoT
+      standards using Web technologies. As a result, the building
+      blocks enable cross-platform and cross-domain
+      interoperability in the IoT.
+      </p>
+      </div>
+
+      <section id="scope" class="scope">
+        <h2>Scope</h2>
+      <!-- What exactly is in scope, and out of scope.
+          For legal review. Be brief. -->
+      <p>During this charter, the Working Group would work on the
+      following:</p>
+      <dl>
+        <dt><strong>Support New Use Cases</strong>:</dt>
+        <dd>Address the requirements of new use cases, such as
+        Digital Twins and integration with edge and cloud
+        systems.</dd>
+        <dt><strong>Update and Refactor Existing
+        Specifications</strong>:</dt>
+        <dd>The WG will add new features, address issues discovered
+        during implementation of the current set of specifications,
+        and reorganize material between documents as appropriate.
+        These are not be limited to backward-compatible updates,
+        however great care will be taken to minimize the impact on
+        existing implementations.</dd>
+        <dt><strong>Support WoT Interoperability</strong>:</dt>
+        <dd>The WG will improve out-of-the-box interoperability and
+        enable the integration of WoT into other ecosystems and
+        communities. Thus, the WG will define core binding and
+        profiling mechanisms, and define additional profiles and
+        bindings, as appropriate.</dd>
+        <dt><strong>Improve Management of TDs</strong>:</dt>
+        <dd>Additional mechanisms around for the management of TDs
+        are needed to improve workflows that use them. Thus, the WG
+        will update the Discovery specification with additional
+        features, including geolocation.</dd>
+        <dt><strong>Increase Descriptiveness of TDs</strong>:</dt>
+        <dd>The WG will work on increasing the descriptive power of
+        TDs to allow using them in additional use cases. This
+        includes describing dynamic resources, historical values
+        (timeseries), better describing payloads, both static and
+        dynamic geolocation information, manageable actions and
+        more precise definitions of data schemas for each type of
+        operation.</dd>
+        <dt><strong>Improve Security and Privacy</strong>:</dt>
+        <dd>Define modular security vocabularies, simplify the use
+        of security schemes, and other work as appropriate.</dd>
+      </dl>
+
+        <section id="section-out-of-scope">
+          <h3 id="out-of-scope">Out of Scope</h3>
+      <p>The following features are out of scope, and will not be
+      addressed by this Working group.</p>
+      <dl class="out-of-scope">
+        <dt><strong>Application- and domain-specific metadata
+        vocabularies:</strong></dt>
+        <dd>The Working Group is restricted to work on cross-domain
+        vocabularies.</dd>
+        <dt><strong>APIs and security frameworks specific to
+        particular platforms external to the W3C:</strong></dt>
+        <dd>The scope of the Working Group is restricted to APIs
+        and security frameworks that are applicable across
+        platforms. We will not define new security mechanisms but
+        will use existing mechanisms and best practices.</dd>
+        <dt><strong>Modification of protocols:</strong></dt>
+        <dd>If during work on bindings, it becomes apparent that
+        changes are needed to protocols, the Web of Things Working
+        Group will rely on the organization responsible for the
+        protocol to make the changes. It is out of scope for the
+        Working Group to standardize such changes itself.</dd>
+      </dl>
+        </section>
+
+      </section>
+
+      <section id="deliverables">
+        <h2>
+          Deliverables
+        </h2>
+
+        <p><i class="todo">Updated document status is available on the <a href="https://www.w3.org/groups/wg/wot/publications/">group publication status page</a>. [or link to a page this group prefers to use]</i></p>
+
+        <p><i>Draft state</i> indicates the state of the deliverable at the time of the charter approval. <span class='todo'>Choose one:</span> <i>Expected completion</i> indicates when the deliverable is projected to become a Recommendation, or otherwise reach a stable state
+          <span class='todo'>The Working Group intends to publish the latest state of their work as Candidate Recommendation (with Snapshots) and does not intend to advance their documents to Recommendation</span>.</p>
+
+        <section id="normative">
+          <h3>
+            Normative Specifications
+          </h3>
+          <p>
+            The Working Group will deliver the following W3C normative specifications:
+          </p>
+          <p class="todo">Consider making a second list for existing specifications that the group will maintain.</p>
+          <dl>
+            <dt id="web-foo" class="spec"><a href="#"><i class="todo">[new spec name]</i></a></dt>
+            <dd>
+              <p>This specification will define <i class="todo">[concrete description]</i>.</p>
+
+              <p class="draft-status"><b>Draft state:</b> <i class="todo">[No draft | <a href="#">Use Cases and Requirements</a> | <a href="#">Editor's Draft</a> | <a href="#">Member Submission</a>]</i></p>
+              <p class="milestone"><b>Expected completion:</b> <i class="todo">[Q1–4 yyyy]</i></p>
+              <p class=todo>If this is a new technical report that will start as a copy of a different TR:</p>
+              <p><b>Initial Text:</b> The <span class="todo">title, stable URL, and publication date of the existing technical report which will serve as the initial text of the deliverable.</span>
+              <p class=todo>Otherwise, if there is an existing <a href='https://www.w3.org/policies/process/#exclusion-draft'>Exclusion Draft</a>, use the [current spec name] template below instead.</p>
+            </dd>
+            <dt id="web-foo" class="spec"><a href="#"><i class="todo">[current spec name]</i></a></dt>
+            <dd>
+              <p>This specification defines <i class="todo">[concrete description]</i>.</p>
+
+              <p class="draft-status"><b>Draft state:</b> <i class="todo">[<a href="#">Adopted from WG/CG Foo</a> | <a href="#">Working Draft</a>]</i></p>
+              <p class="milestone"><b>Expected completion:</b> <i class="todo">[Q1–4 yyyy]</i></p>
+              <p class="todo">Per <a href="https://www.w3.org/policies/process/#WGCharter">5.2.6</a>, for every Recommendation Track deliverable that continues work on a Working Draft (WD) published under any other Charter (including a predecessor group of the same name), for which there is an existing <a href='https://www.w3.org/policies/process/#exclusion-draft'>Exclusion Draft</a>: </p>
+              <p><b>Adopted Draft:</b> The <span class="todo">title, stable URL, and publication date of the <a href="https://www.w3.org/policies/process/#adopted-draft">Adopted Draft</a></span> which will serve to continue the work on the deliverable. If the draft is not a continuation of an existing draft (such as renaming the new draft by using a new version number), the <a href="https://www.w3.org/policies/process/#adopted-draft">Adopted Draft</a> field must not used (as well as "Exclusion Draft" and "Exclusion Draft Charter" below) (see also <a href="https://www.w3.org/2025/04/rdf-star-council-report.html#recommendations">Council recommendation</a> and <a href="https://www.w3.org/2003/12/22-pp-faq#superset">FAQ #41</a>).</p>
+              <p><b>Exclusion Draft:</b> The <span class="todo">title, stable URL, and publication date of the most recent <a href='https://www.w3.org/policies/process/#exclusion-draft'>Exclusion Draft</a></span>.
+              <span class="todo">Exclusion period <b>began</b>; Exclusion period <b>ended</b>.</span> <span class='todo'>(this <a href="https://www.w3.org/2004/01/pp-impl/charter-assistant?wgid=32061">charter assistant</a> helps in producing the list. use the proper <a href='https://www.w3.org/2004/01/pp-impl/'>wgid</a>)</span>
+              <p><b>Exclusion Draft Charter:</b> The  <span class="todo">stable URL of the <a href='https://www.w3.org/policies/process/#exclusion-draft-charter'>Working Group charter</a></span> under which the most recent Exclusion Draft was published.
+            </dd>
+
+          <dt id="wot-arch-update" class="spec">Architecture
+          (Update)</dt>
+          <dd>
+            <p>This specification defines the Web of Things
+            architecture, terminology, fundamental concepts,
+            architecture and deployment patterns, and horizontal
+            security and privacy requirements. It introduces and
+            gives an overview of the family of WoT building block
+            specifications described below.</p>
+            <p class="draft-status"><b>Draft state:</b>No draft</p>
+            <p class="milestone"><b>Expected FPWD:</b>Q1 2024</p>
+            <p class="milestone"><b>Expected CR Transition:</b>Q4
+            2024</p>
+            <p class="milestone"><b>Expected PR Transition:</b>Q2
+            2025</p>
+            <p class="milestone"><b>Expected REC
+            Transition:</b>June 2025</p>
+            <p><b>Adopted Draft:</b> This will be an update of the
+            current <i>Web of Things (WoT) Architecture</i>
+            specification published at <a href=
+            "https://www.w3.org/TR/wot-architecture11/">https://www.w3.org/TR/wot-architecture11/</a>,
+            as a Proposed Recommendation on 11 July 2023.</p>
+          </dd>
+          <dt id="discovery-deliverable" class="spec">Discovery
+          (Update)</dt>
+          <dd>
+            <p>This specification defines a Discovery process for
+            WoT, and would be a backward-compatible update to the
+            existing WoT Discovery Specification.</p>
+            <p class="draft-status"><b>Draft state:</b>No draft</p>
+            <p class="milestone"><b>Expected FPWD:</b>Q1 2024</p>
+            <p class="milestone"><b>Expected CR Transition:</b>Q4
+            2024</p>
+            <p class="milestone"><b>Expected PR Transition:</b>Q2
+            2025</p>
+            <p class="milestone"><b>Expected REC
+            Transition:</b>June 2025</p>
+            <p><b>Adopted Draft:</b> This will be a revision of the
+            current <i>Web of Things (WoT) Discovery</i>
+            specification published at <a href=
+            "https://www.w3.org/TR/wot-discovery/">https://www.w3.org/TR/wot-discovery/</a>,
+            as a Proposed Recommendation on 11 July 2023.</p>
+          </dd>
+          <dt id="thing-description-deliverable" class="spec">Thing
+          Description (Update)</dt>
+          <dd>
+            <p>This specification defines the Web of Things Thing
+            Description information model and its JSON-LD
+            serialization. This deliverable will add new features
+            and address issues discovered during
+            implementation.</p>
+            <p class="draft-status"><b>Draft state:</b>No draft</p>
+            <p class="milestone"><b>Expected FPWD:</b>Q1 2024</p>
+            <p class="milestone"><b>Expected CR Transition:</b>Q4
+            2024</p>
+            <p class="milestone"><b>Expected PR Transition:</b>Q2
+            2025</p>
+            <p class="milestone"><b>Expected REC
+            Transition:</b>June 2025</p>
+            <p><b>Adopted Draft:</b> This will be a further
+            iteration of the current <i>Web of Things (WoT) Thing
+            Description</i> specification published at <a href=
+            "https://www.w3.org/TR/wot-thing-description11/">https://www.w3.org/TR/wot-thing-description11/</a>,
+            as a Proposed Recommendation on 11 July 2023.</p>
+          </dd>
+          <dt id="profiles-deliverable" class="spec">Profile</dt>
+          <dd>
+            <p>This specification defines a profiling mechanism to
+            enable out-of-the-box interoperability between Things
+            and Consumers which conform to a prescriptive set of
+            constraints, and defines at least a first basic
+            HTTP-based profile.</p>
+            <p class="draft-status"><b>Draft state:</b> <a href=
+            "https://www.w3.org/TR/wot-profile/">Working
+            Draft</a></p>
+            <p class="milestone"><b>Expected CR Transition:</b>Q4
+            2023</p>
+            <p class="milestone"><b>Expected PR Transition:</b>Q1
+            2024</p>
+            <p class="milestone"><b>Expected REC Transition:</b>Q3
+            2024</p>
+            <p class="milestone"><b>Exclusion Draft:</b> <a href=
+            "https://www.w3.org/TR/2020/WD-wot-profile-20201124/">https://www.w3.org/TR/2020/WD-wot-profile-20201124/</a><br>
+
+            associated <a href=
+            "https://www.w3.org/mid/cfe-7674-9b112cc6cb00f02c7c746e57df72668e3189a63f@w3.org">
+            Call for Exclusion</a> on 2020-11-24 ended on
+            2021-04-23<br>
+            Produced under Working Group Charter: <a href=
+            "https://www.w3.org/2020/01/wot-wg-charter.html">https://www.w3.org/2020/01/wot-wg-charter.html</a></p>
+          </dd>
+          <dt id="profiles-deliverable-next" class="spec">Profile
+          (Update)</dt>
+          <dd>
+            <p>This specification is an update to the WoT Profile
+            specification, with additional normative profiles as
+            appropriate.</p>
+            <p class="draft-status"><b>Draft state:</b> No
+            draft</p>
+            <p class="milestone"><b>Expected FPWD:</b>Q2 2024</p>
+            <p class="milestone"><b>Expected CR Transition:</b>Q4
+            2024</p>
+            <p class="milestone"><b>Expected PR Transition:</b>Q2
+            2025</p>
+            <p class="milestone"><b>Expected REC
+            Transition:</b>June 2025</p>
+          </dd>
+
+
+
+          </dl>
+
+
+        </section>
+
+        <section id="incubation">
+          <!-- If no incubation or not a Working Group, delete the section. -->
+          <h3>
+            Tentative Deliverables
+          </h3>
+          <p>Depending on the incubation progress, interest from multiple implementers, and the consensus
+            of the Group participants, the Working Group may adopt the following documents
+             as Rec-track specifications:</p>
+          <dl>
+            <dt id="web-incubated-foo" class="spec"><a href="#">Web <i class="todo">[spec name]</i></a></dt>
+            <dd>
+              <p>This specification defines <i class="todo">[concrete description]</i>.</p>
+              <p class="draft-status"><b>Draft state:</b>
+                Proposal in <a href=""><i class="todo">[other name]</i> Community Group</a></p>
+            </dd>
+          </dl>
+        </section>
+
+        <section id="other-deliverables">
+          <h3>
+            Other Deliverables
+          </h3>
+          <p>
+            Other non-normative documents may be created such as:
+          </p>
+          <ul>
+            <li>Use case and requirement documents;</li>
+            <li>Test suite and implementation report for the specification;</li>
+            <li>Primer or Best Practice documents to support web developers when designing applications.</li>
+          <li id="security-deliverable">Security and Privacy Guidelines (to be published as a W3C Note);</li>
+          <li>Test suite and implementation reports for each specification;</li>
+          <li>WoT Scripting API (W3C Note): This document will present a design for a Scripting API that will support
+          exposing and consuming Thing Descriptions while providing
+          a high-level interface to interactions that is
+          independent of protocol. The work will continuously align
+          with the WoT TD specification. Besides these efforts,
+          alignment with the WoT Discovery specification will be
+          the main topic.<br>
+            <!-- Since we plan to publish an update soon the URL might need to change -->
+             Draft state: <a href=
+            "https://www.w3.org/TR/2020/NOTE-wot-scripting-api-20201124/">
+            Group Note</a>
+          </li>
+          <li>Binding Registry to manage specific protocols, Payloads and Ecosystems (W3C Registry): This document specify how
+          protocols and payload formats should be used to allow
+          integration of specific classes of IoT systems and
+          ecosystems. (Protocol-specific subdocuments also?)</li>
+
+          </ul>
+        </section>
+
+        <section id="timeline">
+          <h3>Timeline</h3>
+          <li>September 2023: First teleconference</li>
+          <li>September 2023: First face-to-face meeting (TPAC
+          2023, Sevilla, Spain)</li>
+          <li>Q4 2023: Requirements and Use Cases updated</li>
+          <li>Q4 2023: CR Transition for Profile deliverable</li>
+          <li>Q1 2024: FPWD for updated Discovery, Thing
+          Description, and Architecture deliverables</li>
+          <li>Q1 2024: PR Transition for Profile deliverable</li>
+          <li>Q2 2024: FPWD for updated Profile deliverable</li>
+          <li>Q3 2024: REC Transition for Profile deliverable</li>
+          <li>Q3 2024: Updated publication of WoT Security and
+          Privacy Guidelines as a Note</li>
+          <li>Q4 2024: CR Transition for updated Discovery, Thing
+          Description, Architecture, and Profile deliverables</li>
+          <li>Q4 2024: Updated publication of Bindings as
+          Notes</li>
+          <li>Q1 2025: Updated publication of Scripting API as a
+          Note</li>
+          <li>Q2 2025: PR Transition for updated Discovery, Thing
+          Description, Architecture, and Profile deliverables</li>
+          <li>June 2025: REC Transition for updated Discovery,
+          Thing Description, Architecture, and Profile
+          deliverables</li>
+            </ul>
+        </section>
+      </section>
+
+	<section id="success-criteria">
+	  <h2>Success Criteria</h2>
+
+    <!-- Testing and interop -->
+	  <p>In order to advance beyond
+		  <a href="https://www.w3.org/policies/process/#RecsCR" title="Candidate Recommendation">Candidate Recommendation</a>, each normative specification is expected to have
+		  <a href="https://www.w3.org/policies/process/#implementation-experience">at least two independent interoperable
+			  implementations</a> of every feature defined in the specification, where
+interoperability can be verified by passing open test suites. In order to advance beyond Candidate Recommendation, each normative specification must have an open test suite of every feature defined in the specification.</p>
+	  <p>There should be testing plans for each specification, starting from the earliest drafts.</p>
+    <p>To promote interoperability, all changes made to specifications
+      in Candidate Recommendation
+      or to features that have deployed implementations
+      should have <a href='https://www.w3.org/2019/02/testing-policy.html'>tests</a>.
+      Testing efforts should be conducted via the <a href="https://github.com/web-platform-tests/wpt">Web Platform Tests</a> project.</p>
+
+    <!-- Horizontal review -->
+
+    <p>Each specification should contain separate sections detailing all known security and
+      privacy implications for implementers, Web authors, and end users.</p>
+
+	  <p>Each specification should contain a section on accessibility that describes the benefits and impacts, including ways specification features can be used to address them, and
+		recommendations for maximising accessibility in implementations.</p>
+
+    <!-- W3C Statements and Web Platform Design Principles -->
+    <p>This group is expected to be guided by the following documents:</p>
+    <ul>
+      <li><a href="https://www.w3.org/TR/ethical-web-principles/">Ethical Web Principles</a>,</li>
+      <li><a href="https://www.w3.org/TR/privacy-principles/">Privacy Principles</a>,</li>
+      <li><a href="https://www.w3.org/TR/design-principles/">Web Platform Design Principles</a>.</li>
+    </ul>
+
+	</section>
+
+      <section id="coordination">
+        <h2>Coordination</h2>
+        <p>For all specifications, this Working Group will seek <a href="https://www.w3.org/guide/documentreview/#how-to-get-horizontal-review">horizontal review</a> for
+          accessibility, internationalization, privacy, and security with the relevant Working and
+          Interest Groups, and with the <a href="https://www.w3.org/groups/other/tag/" title="Technical Architecture Group">TAG</a>.
+          Invitation for review must be issued during each major standards-track document transition, including
+          <a href="https://www.w3.org/policies/process/#RecsWD" title="First Public Working Draft">FPWD</a>.  The
+          Working Group is encouraged to engage collaboratively with the horizontal review groups throughout development of
+          each specification.  The Working Group is advised to seek a review at least 3 months before first entering
+          <a href="https://www.w3.org/policies/process/#RecsCR" title="Candidate Recommendation">CR</a> and is encouraged
+          to proactively notify the horizontal review groups when major changes occur in a specification following a review.</p>
+
+        <p>Additional technical coordination with the following Groups will be made, per the <a href="https://www.w3.org/policies/process/#WGCharter">W3C Process Document</a>:</p>
+
+      	<p class="todo">In addition to the above catch-all reference to horizontal review which includes accessibility review, please check with chairs and staff contacts of the <a href="https://www.w3.org/groups/wg/apa/">Accessible Platform Architectures Working Group</a> to determine if an additional liaison statement with more specific information about concrete review issues is needed in the list below.</p>
+
+        <section>
+          <h3 id="w3c-coordination">W3C Groups</h3>
+          <dl>
+              <dt>
+                  <a href="https://www.w3.org/community/wot/">Web of
+                      Things Community Group</a>
+              </dt>
+              <dd>For collaboration on community outreach of the WG
+                  reports to increase adoption and implementation, as well
+                  as collecting feedback from the global community.
+                  Meetings held in English.</dd>
+              <dt>
+                  <a href="https://www.w3.org/community/wot-jp/">Web of
+                      Things Japanese Community Group</a>
+              </dt>
+              <dd>For collaboration on community outreach of the WG
+                  reports to increase adoption and implementation, as well
+                  as collecting feedback from the Japanese community.
+                  Meetings held in Japanese.</dd>
+          <dt>
+            <a href="https://www.w3.org/2018/json-ld-wg/">JSON-LD
+            Working Group</a>
+          </dt>
+          <dd>For collaboration on JSON-LD features and WoT use
+          cases.</dd>
+          <dt>
+            <a href=
+            "https://www.w3.org/community/exi-next/">Efficient
+            Extensible Interchange Community Group</a>
+          </dt>
+          <dd>In relation to efficient interchange for Thing
+          Descriptions.</dd>
+          <dt>
+            <a href="https://www.w3.org/auto/">Web and Automotive
+            Business & Working Groups</a>
+          </dt>
+          <dd>For collaboration on technologies and requirements
+          relating to connected cars and the Web of Things.</dd>
+          <dt>
+            <a href="https://www.w3.org/2009/dap/">Device and
+            Sensors Working Group</a>
+          </dt>
+          <dd>For coordination on APIs for sensors and
+          actuators.</dd>
+          <dt>
+            <a href="">Decentralized Identifier Working Group</a>
+          </dt>
+          <dd>For coordination on identity management and
+          information lifecycle.</dd>
+          <dt>
+            <a href="https://www.w3.org/web-networks/">Web &
+            Networks Interest Group</a>
+          </dt>
+          <dd>For collaboration on networking and computing
+          technologies on the edge and in the cloud when exposing
+          interactions between Things.</dd>
+          <dt>
+            <a href="https://www.w3.org/web-networks/">Spatial Data
+            on the Web Working Group</a>
+          </dt>
+          <dd>For collaboration on geolocation, in conjunction with
+          the Open Geospatial Consortium.</dd>
+          <dt>
+            <a href="https://www.w3.org/WAI/APA/">Accessible
+            Platform Architectures Working Group</a>
+          </dt>
+          <dd>In addition to horizontal review, coordination on
+          impact of WoT technologies on accessibility, and support
+          for new capabilities that help leverage WoT connectivity
+          and sensor networks for accessibility support in public
+          and private spaces is needed.</dd>
+          <dt>
+            <a href="https://www.w3.org/Privacy/">Privacy Interest
+            Group</a>
+          </dt>
+          <dd>In addition to horizontal review, during development
+          of deliverables such as discovery and information
+          lifecycle that require the development of a
+          privacy-preserving architecture, close technical
+          collaboration with the Privacy Interest Group will be
+          needed.</dd>
+          <dt>
+            <a href=
+            "https://www.w3.org/community/iotschema/">Schema
+            Extensions for IoT Community Group</a>
+          </dt>
+          <dd>For collaboration on extensions to Schema.org for IoT
+          use cases.</dd>
+          <dt>
+            <a href=
+            "https://www.w3.org/community/webagents/">Autonomous
+            Agents on the Web Community Group</a>
+          </dt>
+          <dd>For collaboration on application of Web of Things in
+          Agent-based systems in the Web.</dd>
+          </dl>
+
+          <p class="issue"><b>Note:</b> Do not list horizontal groups here, only specific WGs relevant to your work.</p>
+          <p class="issue"><b>Note:</b> Do not bury normative text inside the liaison section.
+            Instead, put it in the scope section.</p>
+        </section>
+
+        <section>
+          <h3 id="external-coordination">External Organizations</h3>
+          <dl>
+          <dt>
+            <a href="https://opcfoundation.org/">OPC Foundation</a>
+          </dt>
+          <dd>For coordination on the development of the OPC UA
+          binding for the W3C Web of Things. A formal agreement
+          between the OPC Foundation and the W3C is being
+          considered to establish an official relationship.</dd>
+          <dt>
+            <a href="https://echonet.jp/english/">ECHONET
+            Consortium</a>
+          </dt>
+          <dd>For collaboration on integrating ECHONET Consortium
+          based platforms within the Web of Things, including
+          platform metadata and approaches for enabling semantic
+          interoperability, and end to end security across
+          platforms.</dd>
+          <dt>
+            <a href=
+            "https://industrialdigitaltwin.org/en/">Industrial
+            Digital Twin Association</a>
+          </dt>
+          <dd>
+            For coordination on the use of TDs and bindings in the
+            Asset Interface Description (AID) submodel for the
+            Asset Administration (AAS) specification. Additionally,
+            the AAS submodels can be used for Digital Nameplate
+            (DNP) and Product Carbon Footprint (PCF) to form the
+            Digital Product Passport (DPP) of products that the
+            European Commission is demanding each product to supply
+            (DPP4.0). Also see <a href=
+            "https://github.com/w3c/wot/issues/978#issuecomment-1359830278">
+            the related GitHub comment</a>.
+          </dd>
+          <dt>
+            <a href="https://www.ashrae.org/">ASHRAE</a>
+          </dt>
+          <dd>For coordination on the development of the BACnet
+          (ASHRAE 135-2020) binding for the W3C Web of Things
+          .</dd>
+          <dt>
+            <a href="https://www.ietf.org/">IETF</a>
+          </dt>
+          <dd>Coordinate common interests related to Internet of
+          Things and Web of Things, e.g., issues such as
+          serialization, security, and trustworthiness.</dd>
+          <dt>
+            <a href=
+            "https://datatracker.ietf.org/doc/charter-irtf-t2trg/">IRTF
+            Thing to Thing Research Group</a>
+          </dt>
+          <dd>For coordination of matters of mutual interest in
+          relation to the Web of Things, such as data modelling,
+          discovery, directory services, and IoT semantics.</dd>
+          <dt>
+            <a href="https://csa-iot.org/">Connectivity Standards
+            Alliance (CSA)</a>
+          </dt>
+          <dd>To coordinate smart home use cases and to develop a
+          potential Matter binding.</dd>
+          <dt>
+            <a href="https://onedm.org/">One Data Model</a>
+          </dt>
+          <dd>For coordination of Semantic Definition Format (SDF)
+          with the Thing Description.</dd>
+          <dt>
+            <a href="https://www.ogc.org/">Open Geospatial
+            Consortium (OGC)</a>
+          </dt>
+          <dd>To coordinate geolocation use cases and potential
+          geo-based definitions for Thing Models and Thing
+          Descriptions.</dd>
+          <dt>
+            <a href="https://www.conexxus.org/">Conexxus</a>
+          </dt>
+          <dd>To coordinate retail use cases and show case in
+          PlugFests.</dd>
+          <dt>
+            <a href="https://www.eclass.eu/en.html">ECLASS</a>
+          </dt>
+          <dd>For collaboration and coordination of the technical
+          realization of the use of ECLASS in the W3C Thing
+          Description.</dd>
+          <dt>
+            <a href="https://www.eclass.eu/en.html">ITU-T</a>
+          </dt>
+          <dd>Coordinating smart city and digital twin use cases
+          and aligning terminology definitions.</dd>
+          </dl>
+        </section>
+      </section>
+
+
+
+      <section class="participation">
+        <h2 id="participation">
+          Participation
+        </h2>
+        <p>
+          To be successful, this Working Group is expected to have 6 or more active participants for its duration, including representatives from the key implementors of this specification, and active Editors and Test Leads for each specification. The Chairs, specification Editors, and Test Leads are expected to contribute half of a working day per week towards the Working Group. There is no minimum requirement for other Participants.
+        </p>
+        <p>
+          The group encourages questions, comments and issues on its public mailing lists and document repositories, as described in <a href='#communication'>Communication</a>. The group also welcomes non-Members to make technical contributions for ongoing work, provided they agree to the terms of the <a href="https://www.w3.org/policies/patent-policy/">W3C Patent Policy</a>.
+        </p>
+        <p>
+          The Chairs should periodically look through the non-Members who have contributed to the Working Group or the Web of Things Community Group and consider whether each one should be invited to participate as an <a href="https://www.w3.org/invited-experts/">Invited Expert</a>. If a non-Member contributor would like to participate in meetings, they are encouraged to <a href="https://www.w3.org/groups/wg/[shortname]/instructions/">apply to be an Invited Expert</a>.
+        </p>
+        <p>Participants in the group are required (by the <a href="https://www.w3.org/policies/process/#ParticipationCriteria">W3C Process</a>) to follow the
+          W3C <a href="https://www.w3.org/policies/code-of-conduct/">Code of Conduct</a>.</p>
+      </section>
+
+
+
+      <section id="communication">
+        <h2>
+          Communication
+        </h2>
+        <p id="public">
+          Technical discussions for this Working Group are conducted in <a href="https://www.w3.org/policies/process/#confidentiality-levels">public</a>: the meeting minutes from teleconference and face-to-face meetings will be archived for public review, and technical discussions and issue tracking will be conducted in a manner that can be both read and written to by the general public. Working Drafts and Editor's Drafts of specifications will be developed in public repositories and may permit direct public contribution requests.
+        The meetings themselves are not open to public participation, however.
+        </p>
+        <p>
+          Information about the group (including details about deliverables, issues, actions, status, participants, and meetings) will be available from the <a href="https://www.w3.org/groups/wg/wot">Web of Things Working Group home page.</a>
+        </p>
+        <p>
+            Most Web of Things Working Group teleconferences will focus on discussion of particular specifications, and will be conducted on an as-needed basis.
+        </p>
+        <p>
+            This group primarily conducts its technical work  on the public mailing list <a id="public-name" href="mailto:public-wot-wg@w3.org">public-wot-wg@w3.org</a> (<a href="https://lists.w3.org/Archives/Public/public-wot-wg/">archive</a>)
+          or on <a id="public-github" href="https://github.com/w3c/wot/issues">GitHub issues</a>.
+          The public is invited to review, discuss and contribute to this work.
+        </p>
+        <p>
+          The group may use a Member-confidential mailing list for administrative purposes and, at the discretion of the Chairs and members of the group, for member-only discussions in special cases when a participant requests such a discussion.
+        </p>
+      </section>
+
+
+
+      <section id="decisions">
+        <h2>
+          Decision Policy
+        </h2>
+        <p>
+          This group will seek to make decisions through consensus and due process, per the <a href="https://www.w3.org/policies/process/#Consensus">W3C Process Document (section 5.2.1, Consensus)</a>. Typically, an editor or other participant makes an initial proposal, which is then refined in discussion with members of the group and other reviewers, and consensus emerges with little formal voting being required.</p>
+        <p>
+           However, if a decision is necessary for timely progress and consensus is not achieved after careful consideration of the range of views presented, the Chairs may call for a group vote and record a decision along with any objections.
+        </p>
+        <p>
+          To afford asynchronous decisions and organizational deliberation, any resolution (including publication decisions) taken in a face-to-face meeting or teleconference will be considered provisional.
+
+          A call for consensus (CfC) will be issued for all resolutions (for example, via email, GitHub issue or web-based survey), with a response period from t to 10 working days</span>, depending on the chair's evaluation of the group consensus on the issue.
+
+          If no objections are raised by the end of the response period, the resolution will be considered to have consensus as a resolution of the Working Group.
+        </p>
+        <p>
+          All decisions made by the group should be considered resolved unless and until new information becomes available or unless reopened at the discretion of the Chairs.
+        </p>
+        <p>
+          This charter is written in accordance with the <a href="https://www.w3.org/policies/process/#Votes">W3C Process Document (Section 5.2.3, Deciding by Vote)</a> and includes no voting procedures beyond what the Process Document requires.
+        </p>
+      </section>
+
+
+
+      <section id="patentpolicy">
+        <h2>
+          Patent Policy
+        </h2>
+        <p>
+          This Working Group operates under the <a href="https://www.w3.org/policies/patent-policy/">W3C Patent Policy</a> (Version of 15 May 2025). To promote the widest adoption of Web standards, W3C seeks to issue Web specifications that can be implemented, according to this policy, on a Royalty-Free basis.
+
+          For more information about disclosure obligations for this group, please see the <a href="https://www.w3.org/groups/wg/[shortname]/ipr/">licensing information</a>.
+        </p>
+
+      </section>
+
+
+
+      <section id="licensing">
+        <h2>Licensing</h2>
+        <p>This Working Group will use the <a href="https://www.w3.org/copyright/software-license/">W3C Software and Document license</a> for all its deliverables.</p>
+      </section>
+
+
+
+      <section id="about">
+        <h2>
+          About this Charter
+        </h2>
+        <p>
+          This charter has been created according to <a href="https://www.w3.org/policies/process/#GAGeneral">section 3.4</a> of the <a href="https://www.w3.org/policies/process/">Process Document</a>. In the event of a conflict between this document or the provisions of any charter and the W3C Process, the W3C Process shall take precedence.
+        </p>
+
+        <section id="history">
+          <h3>
+            Charter History
+          </h3>
+          <p class="issue"><b>Note:</b>Display this table and update it when appropriate. Requirements for charter extension history are documented in the <a href="https://www.w3.org/Guide/process/charter.html#extension">Charter Guidebook (section 4)</a>.</p>
+
+          <p>The following table lists details of all changes from the initial charter, per the <a href="https://www.w3.org/policies/process/#CharterReview">W3C Process Document (section 4.3, Advisory Committee Review of a Charter)</a>:</p>
+
+          <table class="history">
+            <tbody>
+              <tr>
+                <th>
+                  Charter Period
+                </th>
+                <th>
+                  Start Date
+                </th>
+                <th>
+                  End Date
+                </th>
+                <th>
+                  Changes
+                </th>
+              </tr>
+            <tr>
+              <th>
+                <a href=
+                "https://lists.w3.org/Archives/Member/w3c-ac-members/2016OctDec/0074.html">
+                Initial Charter</a>
+              </th>
+              <td>27 December 2016</td>
+              <td>31 December 2018</td>
+              <td></td>
+            </tr>
+            <tr>
+              <th>
+                <a href=
+                "https://lists.w3.org/Archives/Member/w3c-ac-members/2018OctDec/0066.html">
+                Charter Extension</a>
+              </th>
+              <td></td>
+              <td>30 June 2019</td>
+              <td>Removed staff contact Yingyong Chen</td>
+            </tr>
+            <tr>
+              <th>
+                <a href=
+                "https://lists.w3.org/Archives/Member/w3c-ac-members/2019JanMar/0018.html">
+                Chair update</a>
+              </th>
+              <td></td>
+              <td></td>
+              <td>Matthias Kovatsch changed his affiliation and
+              re-appointed as co-Chair on 13 February
+              2019.</td>
+            </tr>
+            <tr>
+              <th>
+                <a href=
+                "https://lists.w3.org/Archives/Member/w3c-ac-members/2019AprJun/0002.html">
+                Chair update</a>
+              </th>
+              <td></td>
+              <td></td>
+              <td>Kazuo Kajimoto stepped down as co-Chair on 4
+              April 2019.</td>
+            </tr>
+            <tr>
+              <th>
+                <a href=
+                "https://lists.w3.org/Archives/Member/w3c-ac-members/2019JulSep/0006.html">
+                Charter Extension</a>
+              </th>
+              <td></td>
+              <td>31 December 2019</td>
+              <td>Charter period extended till 31 December
+              2019</td>
+            </tr>
+            <tr>
+              <th>
+                <a href=
+                "https://lists.w3.org/Archives/Member/w3c-ac-members/2019OctDec/0065.html">
+                Charter Extension</a>
+              </th>
+              <td></td>
+              <td>31 January 2020</td>
+              <td>Charter period extended till 31 January
+              2020</td>
+            </tr>
+            <tr>
+              <th>
+                <a href=
+                "https://lists.w3.org/Archives/Member/w3c-ac-members/2020JanMar/0011.html">
+                Rechartered</a>
+              </th>
+              <td>31 January 2020</td>
+              <td>31 January 2022</td>
+              <td>
+                <p>New charter. Deliverables include updates to
+                existing documents (<a href=
+                "#wot-thing-description-updates">Thing Description
+                1.1</a> and <a href=
+                "#wot-architecture-updates">Architecture 1.1</a>),
+                extensions to existing documents (<a href=
+                "#wot-thing-description-next">Thing Description
+                2.0</a>) and new deliverables (<a href=
+                "#wot-profiles">Interoperability Profiles</a> and
+                <a href="#wot-discovery">Discovery</a>)</p>
+              </td>
+            </tr>
+            <tr>
+              <th>
+                <a href=
+                "https://lists.w3.org/Archives/Member/w3c-ac-members/2022JanMar/0017.html">
+                Charter Extension</a>
+              </th>
+              <td></td>
+              <td>31 May 2022</td>
+              <td>Charter period extended till 31 May
+              2022</td>
+            </tr>
+            <tr>
+              <th>
+                <a href=
+                "https://lists.w3.org/Archives/Member/w3c-ac-members/2022AprJun/0041.html">
+                Charter Extension</a>
+              </th>
+              <td></td>
+              <td>31 July 2022</td>
+              <td>Charter period extended till 31 July
+              2022</td>
+            </tr>
+            <tr>
+              <th>
+                <a href=
+                "https://lists.w3.org/Archives/Member/w3c-ac-members/2022JulSep/0024.html">
+                Rechartered</a>
+              </th>
+              <td>28 July 2022</td>
+              <td>31 January 2023</td>
+              <td>
+                <p>New charter: Charter period extended until 31
+                January 2023; Switch to the Patent Policy 2020.</p>
+              </td>
+            </tr>
+            <tr>
+              <th>
+                <a href=
+                "https://lists.w3.org/Archives/Member/w3c-ac-members/2023JanMar/0021.html">
+                Charter Extension</a>
+              </th>
+              <td></td>
+              <td>31 July 2023</td>
+              <td>Charter period extended until 31 July
+              2023</td>
+            </tr>
+            <tr>
+              <th>
+                <a href=
+                "https://lists.w3.org/Archives/Member/w3c-ac-members/2023JulSep/0015.html">
+                Charter Extension</a>
+              </th>
+              <td></td>
+              <td>30 Sepbember 2023</td>
+              <td>Charter period extended until 30 September 2023</td>
+            </tr>
+            <tr>
+              <th>
+                <a class="todo" href=
+                "https://w3c.github.io/charter-drafts/charter-template.html">
+                Rechartered</a>
+              </th>
+              <td>3 October 2023</td>
+              <td>2 October 2025</td>
+              <td>
+                <ul>
+                  <li>New charter.</li>
+                  <li>Added Michael Koster to the co-Chairs.</li>
+                  <li>Removed Team Contact, Dave Raggett.</li>
+                  <li>Added further clarification on the motivation
+                  and background.</li>
+                  <li>Simplified the description on the scope.</li>
+                  <li>Updated the descriptions on the normative
+                  deliverables: <a href=
+                  "#wot-arch-update">Architecture (Update)</a>,
+                  <a href="#discovery-deliverable">Discovery
+                  (Update)</a>, <a href=
+                  "#thing-description-deliverable">Thing
+                  Description (Update)</a>, <a href=
+                  "#profiles-deliverable">Profile</a> and
+                    <a href="#profiles-deliverable-next">Profile
+                    (Update)</a>.
+                  </li>
+                  <li>Updated the list of the coordination on W3C
+                  groups and external standardization organizations
+                  based on the recent situation.</li>
+                </ul>
+              </td>
+            </tr>
+            <tr>
+              <th>
+                <a href=
+                "https://lists.w3.org/Archives/Member/w3c-ac-members/2025AprJun/0032.html">
+                Chair update</a>
+              </th>
+              <td></td>
+              <td></td>
+              <td>Michael McCool stepped down as co-Chair on 8 May 2025.</td>
+            </tr>
+              <tr>
+                <th>
+                  <a class="todo" href="">Rechartered</a>
+                </th>
+                <td>
+                  <i class="todo">[dd monthname yyyy]</i>
+                </td>
+                <td>
+                  <i class="todo">[dd monthname yyyy]</i>
+                </td>
+                <td>
+                  <p class="todo">[description of change to charter, with link to new deliverable item in charter] <b>Note:</b> use the class <code>new</code> for all new deliverables, for ease of recognition.</p>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </section>
+
+        <section id="changelog">
+          <h3>Change log</h3>
+
+          <!-- Use this section for changes _after_ the charter was approved by the Director. -->
+          <p>Changes to this document are documented in this section.</p>
+          <!--
+          <dl id='changes'>
+            <dt>YYYY-MM-DD</dt>
+            <dd>[changes]]</dd>
+          </dl>
+          -->
+        </section>
+      </section>
+    </main>
+
+    <hr>
+
+    <footer>
+      <address>
+        <i class="todo"><a href="mailto:ashimura@w3.org">Kaz Ashimura</a></i>
+      </address>
+
+<p class="copyright">Copyright © 2025 <a href="https://www.w3.org/">World Wide Web Consortium</a>.<br>
+  <abbr title="World Wide Web Consortium">W3C</abbr><sup>®</sup>
+  <a href="https://www.w3.org/policies/#disclaimers">liability</a>,
+  <a href="https://www.w3.org/policies/#trademarks">trademark</a> and
+      <a rel="license" href="https://www.w3.org/copyright/software-license/" title="W3C Software and Document Notice and License">permissive document license</a> rules apply.</p>
+
+      <hr>
+      <p><span class='todo'><a href="https://github.com/w3c/charter-drafts">Yes, it's on GitHub!</a>.</span></p>
+    </footer>
+
+  </body>
+</html>


### PR DESCRIPTION
based on the [latest Charter template](https://github.com/w3c/charter-drafts/blob/gh-pages/charter-template.html) and the [current WoT WG Charter](https://www.w3.org/2023/10/wot-wg-2023.html).