### PR TITLE
Meeting minutes for WoT Outreach

### DIFF
--- a/minutes/marketing/20260211/Readme.md
+++ b/minutes/marketing/20260211/Readme.md
@@ -1,0 +1,122 @@
+# WoT Outreach
+
+## Attendees
+
+- Ege Korkan
+- Daniel Peintner
+- Dave Raggett
+- Amy van der Hiel
+- Marie-Claire Forgue
+- Coralie Mercier
+- Michael Koster
+- Kaz Ashimura
+- Kunihiko Toumura
+- Tomoaki Mizushima
+- Victor Lu
+
+Scribe: Dave Raggett
+
+## Minutes
+
+### Introduction
+
+Ege introduces the aims for this call. We want to find ways to attract new people and organizations to the WoT WG as we recharter, and to ask for advice on alternatives to X/Twitter.
+
+Ege has been managing the outreach accounts for WoT, see below:
+
+https://w3c.social/home  
+https://www.youtube.com/@WoTCG  
+https://x.com/W3C_WoT
+
+Amy introduces herself and her roles for W3C.
+
+Coralie does likewise.
+
+Marie-Claire has been using Mastodon plus YouTube for videos of W3C talks.
+
+Amy: We can repost what you provide as a way to reach a broader community. We are on LinkedIn, Mastodon, YouTube, but not Discord. We are happy to help give you greater visibility.
+
+We can help with W3C News and our event calendar.
+
+Marie-Claire: Let us know when you are posting, maybe tag us. I scan the channels daily.
+
+W3C has a lot of followers. Don’t hesitate to involve me.
+
+Amy: The dev account is active and often highlights individuals, e.g., their talks. W3C News is less personal and more about releases of new RECs, etc.
+
+The W3C CEO Newsletter is another channel of interest.
+
+Ege summarizes what the WoT activity has been doing with respect to outreach.
+
+Amy: The blog is for more of an individual voice and for sharing W3C technologies.
+
+Ege: Can I post?
+
+Amy: Right now, you would need to send it to us.
+
+Ege: What platforms should WoT have accounts on? I guess that doesn’t include X, right?
+
+Amy: X/Twitter has changed since it was taken over and is now more exposed to trolling. Our experience is that we get much better interaction on Mastodon.
+
+Here are the links:  
+W3C News: https://www.w3.org/news/  
+W3C Blog: https://www.w3.org/news-events/about-w3c-blog/  
+Events: https://www.w3.org/events/
+
+Amy: LinkedIn brings in CEOs and high-level people, so we now view channels in terms of the audiences they offer. LinkedIn allows us to ping companies. YouTube is more of a younger, technology-oriented audience. Mastodon is stronger for technology audiences.
+
+Ege: We can’t have a W3C WoT account on LinkedIn, but we can create groups, though they can get hijacked, unfortunately.
+
+Amy: We want to work with you. We could use a specific hashtag or subpost. We need to find a consistent way to manage this.
+
+Ege: Mastodon allows groups to have their own accounts. For WoT we want to reach a broader industry audience beyond W3C, covering different IoT technologies.
+
+Amy: I could go back to LinkedIn for advice.
+
+### X/Twitter
+
+Ege: Do I have to close our X account?
+
+Coralie: Yes.
+
+Amy: You would need to show us why it would be positive to remain there. You could redirect people on X to the Mastodon channel. On X, I had to keep removing W3C from posts by scammers to avoid reputational damage.
+
+Marie-Claire: It is painful to post on multiple channels and probably better to focus on a few effective ones.
+
+### Strategy
+
+Amy: I searched for WoT on different channels. LinkedIn seems better for reaching business people.
+
+Coralie: I would lean toward not giving permission to retain the X account. Please also give us the keys to your Mastodon account.
+
+Ege: I think I already sent you our Mastodon info. What is your take on other platforms?
+
+Amy: TikTok is similar to YouTube. I am keeping an eye on Bluesky. We’re concerned about the lack of long-term commitments from W3C groups for social outreach.
+
+Amy: We are trying to be aware of potential issues like political or business capture of channels.
+
+Coralie: Mastodon uses W3C technologies and has higher ethical standards.
+
+Ege: One takeaway for us is to put more effort into Mastodon and LinkedIn, where Sylvia’s advice would be valuable. Another is to ask for help with reposts to reach a broader W3C audience.
+
+Dave: What kind of help can we get? Videos (interviews and demos) aren't something I have experience with. Can you point us to someone on staff who has experience?
+
+Amy: Marie-Claire is our video expert; not offering her as the default person, but she can advise on timing.
+
+Marie-Claire: Videos at specific times (around AC meetings, for example), or interviews in a W3C Blog post.
+
+Dave: We may be able to arrange interviews and demos during WoT face-to-face meetings.
+
+Coralie: I think Ege mentioned copying events. Can you tell us more about that?
+
+Ege: I’ve copied event info to LinkedIn.
+
+Coralie: Keep W3T Comms in the loop. Give us a heads-up so Amy can repost to W3C Events:  
+https://www.w3.org/events/happenings/
+
+Amy: See https://www.w3.org/news-events/, e.g., TAG meetup: https://www.w3.org/events/happenings/2026/meet-the-w3c-technical-architecture-group/  
+There’s a way to subscribe to the calendar, and some groups provide signup links.
+
+Coralie: We need at least a couple of days’ advance notice. Note that additional info can be added after the event, e.g., links to videos.
+
+Dave thanks the Comms Team and looks forward to working with them.


### PR DESCRIPTION
From https://pad.w3.org/p/2026-02-11-wot-outreach

Documented the minutes of the WoT Outreach meeting, including attendees, discussion points, and strategies for social media engagement.