### PR TITLE
Add minutes for WoT Scripting API meeting on 2026-03-04

### DIFF
--- a/minutes/scripting-api/2026-03-04.md
+++ b/minutes/scripting-api/2026-03-04.md
@@ -1,0 +1,154 @@
+# WoT Scripting API Call
+
+## 04 March 2026
+
+### Meeting Information
+
+#### Attendees
+
+* Tomoaki Mizushima
+* Daniel Peintner
+* Cristiano Aguzzi
+* Ege Korkan
+
+#### Scribe
+
+* Daniel Peintner
+
+#### Agenda
+
+[https://www.w3.org/WoT/IG/wiki/WG_WoT_Scripting_API_WebConf#March_4,_2026](https://www.w3.org/WoT/IG/wiki/WG_WoT_Scripting_API_WebConf#March_4,_2026)
+
+### Minutes
+
+#### [Previous minutes](https://pad.w3.org/p/2026-02-04-wot-scripting-api-minutes)
+
+See [https://github.com/w3c/wot/pull/1264](https://github.com/w3c/wot/pull/1264), okay with merging.
+
+### PRs
+
+#### [Move Zoltan to former editor #584](https://github.com/w3c/wot-scripting-api/pull/584)
+
+Cris: Updates editor list
+
+... PR looks good
+
+Daniel: +1
+
+Cris: <merging>
+
+### Issues
+
+Cris: 2–3 issues to discuss with Ege
+
+#### [Support profile mechanism #531](https://github.com/w3c/wot-scripting-api/issues/531)
+
+Cris: Not introducing specific terms
+
+... "won't fix" essentially
+
+... can be done on top of the Scripting API
+
+Ege: Would be supported through TD
+
+... nothing on the Scripting API side
+
+... error terms could be introduced (not compliant with profile X)
+
+... impossible to say in Scripting that profile X is supported (mechanism is too open)
+
+Cris: Profile is somewhat fuzzy
+
+... no extra mechanism is applied when seeing the term "profile"
+
+... Scripting API does not support xxxAll terms like queryAll
+
+Ege: Theoretically it could be mapped to MQTT
+
+... queryAll would need to relax dataSchema
+
+Cris: There is no data schema... that's a problem
+
+... we could do the same as we did for async actions
+
+Daniel: We did that for a purpose... would not do that
+
+Ege: We can just give examples... on top of node-wot... but not as part of node-wot
+
+Cris: Not sure what would happen with HTTP polling... very open
+
+Ege: Yes, it would be very open... we don't define the payload
+
+Cris: Could go with the stream approach
+
+... it is just an interface... the application needs to do the rest
+
+Ege/Cris: Proper support in TD is missing and should come first
+
+Ege: Currently, the profile term is totally ignored
+
+Daniel: Experimenting with node-wot on top of the Scripting API is fine, but I would stop there
+
+Ege: Could also mark calls in the Scripting API as "experimental"
+
+... anyhow, would close the issue
+
+Cris: Okay, but we need a note first in the Scripting API saying "we do not support profile"
+
+See also [comments taken on GitHub](https://github.com/w3c/wot-scripting-api/issues/531#issuecomment-3996664940)
+
+#### [TD common definition and effects on formIndex #582](https://github.com/w3c/wot-scripting-api/issues/582)
+
+Ege: Criticism applies to using numbers for formIndex
+
+... developers need to understand forms
+
+... the intention "use this protocol" might be limited... but makes more sense
+
+Cris: Agree
+
+... preferring contentType would be better
+
+... anyhow... it should not matter... you should not look into forms
+
+... that would break the abstraction
+
+Daniel: formIndex gives the full power, which "prefer this or that contentType" does not provide
+
+Ege: e.g., use case: prefer CoAP and only if there are problems, HTTP
+
+Cris: Nice experiments... but formIndex can do all that
+
+Ege: Helper functions
+
+Cris: Correct, it could be easy like this
+
+... should not be baked into the Scripting API
+
+Ege: In the case of "TD common definition," no one should see the expanded TD
+
+Daniel: Isn't it the same as before? People don't need it... but it is there
+
+Ege: We can keep formIndex, but preferences are also needed
+
+Cris: Is determinism given?
+
+Ege: Yes
+
+Cris: Let's create an issue for "support form preferences" on the node-wot side --> [https://github.com/eclipse-thingweb/node-wot/issues/1501](https://github.com/eclipse-thingweb/node-wot/issues/1501)
+
+Daniel: I still question the need... since formIndex can do it
+
+Cris: It could be part of "td-tools"
+
+Daniel: Or clean up the TD before consuming
+
+Ege: I think developers should not need to see the expanded TD
+
+Cris: The runtime will use the expanded TD
+
+Ege: Is formIndex usable with an expanded TD?
+
+Cris: Yes
+
+[adjourned]


### PR DESCRIPTION
Documented the minutes of the WoT Scripting API meeting held on March 4, 2026, including attendee list, agenda, discussions on PRs and issues, and key points raised during the meeting.

see https://pad.w3.org/p/2026-03-04-wot-scripting-api-minutes