### PR TITLE
Timeline for Binding Registry

### DIFF
--- a/charters/wot-wg-2025-draft.html
+++ b/charters/wot-wg-2025-draft.html
@@ -532,7 +532,9 @@
           <li>Q4 2026: Publication of PROFINET Binding as a Note</li>
           <li>Q4 2026: Publication of LoRaWAN Binding as a Note</li>
           <li>Q1 2027: WD of Thing Description 2.0</li>
-          <li>Q1 2027: Publication of Binding Registry as a Note</li>
+          <li>Q1 2027: Publication of Binding Registry as a Registry Draft</li>
+		  <li>Q2 2027: Candidate Registry Transition of Binding Registry</li>
+		  <li>Q3 2027: W3C Registry Transition of Binding Registry</li>
           <li>Q3 2027: Updated publication of Scripting API as a Note</li>
           <li>Q3 2027: Updated publication of Use Cases and Requirements as a Note</li>
           <li>Q4 2027: Publication of Primer and Best Practice as a Note</li>


### PR DESCRIPTION
Based https://www.w3.org/policies/process/#reg-pub , we should also have a publication timeline of the binding registry.