### PR TITLE
Update list of groups for coordination to address review feedback

### DIFF
--- a/charters/wot-wg-2025-draft.html
+++ b/charters/wot-wg-2025-draft.html
@@ -627,17 +627,11 @@ interoperability can be verified by passing open test suites. In order to advanc
               <dd>For the incubation of a common protocol for communicating with connected devices over the web, and
                 handing off specifications to the WoT Working Group for formal recommendation track standardization.</dd>
           <dt>
-            <a href="https://www.w3.org/2018/json-ld-wg/">JSON-LD
+            <a href="https://www.w3.org/groups/wg/json-ld/">JSON-LD
             Working Group</a>
           </dt>
           <dd>For collaboration on JSON-LD features and WoT use
           cases.</dd>
-          <dt>
-            <a href=
-            "https://www.w3.org/community/exi-next/">Efficient
-            Extensible Interchange Community Group</a>
-          </dt>
-          <dd>Toward efficient interchange of Thing Descriptions.</dd>
           <dt><a href="https://www.w3.org/2009/dap/">Device and
             Sensors Working Group</a></dt>
           <dd>For coordination on APIs for sensors and actuators.</dd>
@@ -650,15 +644,8 @@ interoperability can be verified by passing open test suites. In order to advanc
 		    Working Group</a></dt>
           <dd>For coordinating use of Decentralized Identifiers in Verifiable
           Credential ecosystems with the Web of Things.</dd>
-          
-          <dt><a href="https://www.w3.org/web-networks/">Web &
-            Networks Interest Group</a>
-          </dt>
-          <dd>For collaboration on networking and computing
-          technologies on the edge and in the cloud when exposing
-          interactions between Things.</dd>
           <dt>
-            <a href="https://www.w3.org/web-networks/">Spatial Data
+            <a href="https://www.w3.org/2021/sdw/">Spatial Data
             on the Web Working Group</a>
           </dt>
           <dd>For collaboration on geolocation, in conjunction with
@@ -673,14 +660,14 @@ interoperability can be verified by passing open test suites. In order to advanc
           and sensor networks for accessibility support in public
           and private spaces is needed.</dd>
           <dt>
-            <a href="https://www.w3.org/Privacy/">Privacy Interest
+            <a href="https://www.w3.org/groups/wg/privacy/">Privacy Working
             Group</a>
           </dt>
           <dd>In addition to horizontal review, during development
           of deliverables such as discovery and information
           lifecycle that require the development of a
           privacy-preserving architecture, close technical
-          collaboration with the Privacy Interest Group will be
+          collaboration with the Privacy Working Group will be
           needed.</dd>
           <dt>
             <a href=
@@ -689,13 +676,6 @@ interoperability can be verified by passing open test suites. In order to advanc
           </dt>
           <dd>For collaboration on extensions to Schema.org for IoT
           use cases.</dd>
-          <dt>
-            <a href=
-            "https://www.w3.org/community/webagents/">Autonomous
-            Agents on the Web Community Group</a>
-          </dt>
-          <dd>For collaboration on application of Web of Things in
-          Agent-based systems in the Web.</dd>
 		  <dt>
             <a href="https://www.w3.org/groups/ig/smart-cities/">Web-based Digital Twins for Smart Cities Interest Group</a>
           </dt>
@@ -776,13 +756,13 @@ interoperability can be verified by passing open test suites. In order to advanc
           <dd>To coordinate retail use cases and show case in
           PlugFests.</dd>
           <dt>
-            <a href="https://www.eclass.eu/en.html">ECLASS</a>
+            <a href="https://eclass.eu/en/">ECLASS</a>
           </dt>
           <dd>For collaboration and coordination of the technical
           realization of the use of ECLASS in the W3C Thing
           Description.</dd>
           <dt>
-            <a href="https://www.eclass.eu/en.html">ITU-T</a>
+            <a href="https://www.itu.int/en/ITU-T/">ITU-T</a>
           </dt>
           <dd>Coordinating smart city and digital twin use cases
           and aligning terminology definitions.</dd>

--- a/charters/wot-wg-2025-draft.html
+++ b/charters/wot-wg-2025-draft.html
@@ -645,7 +645,7 @@ interoperability can be verified by passing open test suites. In order to advanc
           <dd>For coordinating use of Decentralized Identifiers in Verifiable
           Credential ecosystems with the Web of Things.</dd>
           <dt>
-            <a href="https://www.w3.org/2021/sdw/">Spatial Data
+            <a href="https://www.w3.org/groups/wg/sdw/">Spatial Data
             on the Web Working Group</a>
           </dt>
           <dd>For collaboration on geolocation, in conjunction with


### PR DESCRIPTION
Updated list of groups for coordination to address feedback from @dontcallmedom in https://github.com/w3c/strategy/issues/509#issuecomment-4197504588

- JSON-LD Working Group has a new homepage
- Efficient Extensible Interchange Community Group has closed
- Web & Networks Interest Group has closed
- URL for Spatial Data on the Web Working Group was incorrect
- Privacy Interest Group is now Privacy Working Group
- Autonomous Agents on the Web Community Group was duplicated (kept the newer one)
- ECLASS link was broken
- ITU-T link was incorrect