### PR TITLE
Update documentation link in charter to address feedback

### DIFF
--- a/charters/wot-wg-2025-draft.html
+++ b/charters/wot-wg-2025-draft.html
@@ -168,8 +168,8 @@
 		  </p>
 		<p>
 			Newcomers are encouraged to read the <a
-			href="https://www.w3.org/WoT/"
-			>Web of Things in a Nutshell</a> documentation where they will find a
+			href="https://www.w3.org/WoT/documentation/"
+			>Web of Things documentation</a> where they will find a
 			technical overview of how the various existing deliverables relate to
 			one another.
 		</p>

--- a/charters/wot-wg-2025-draft.html
+++ b/charters/wot-wg-2025-draft.html
@@ -168,8 +168,8 @@
 		  </p>
 		<p>
 			Newcomers are encouraged to read the <a
-			href="https://www.w3.org/WoT/documentation/"
-			>Web of Things documentation</a> where they will find a
+			href="https://www.w3.org/WoT/"
+			>Web of Things website</a> where they will find a
 			technical overview of how the various existing deliverables relate to
 			one another.
 		</p>


### PR DESCRIPTION
To address feedback by @dontcallmedom in https://github.com/w3c/strategy/issues/509#issuecomment-4197504588.

I think @sebastiankb probably changed this to https://www.w3.org/WoT/ because there is a [draft](https://deploy-preview-572--wot-marketing.netlify.app/) of a new version of the W3C WoT website where the "WoT in a Nutshell" content is moved to the homepage, but that has not yet been finalised.

I suggest changing this link back to https://www.w3.org/WoT/documentation/ and just calling it "Web of Things documentation", which is likely to be relevant in either case.

~~Separately I suggest the content of the "Web of Things in a Nutshell" content should also be revisited because it's a bit outdated now.~~ (I see this is already being done as part of the website update).