### PR TITLE
Remove PR transition step from TD Schedule

### DIFF
--- a/charters/wot-wg-2025-draft.html
+++ b/charters/wot-wg-2025-draft.html
@@ -295,9 +295,7 @@
             <p class="draft-status"><b>Draft state: </b> <a href=
             "https://www.w3.org/TR/wot-thing-description-2.0/">FPWD</a></p>
             <p class="milestone"><b>Expected CR Transition:</b>Q4 2027</p>
-            <p class="milestone"><b>Expected PR Transition:</b>Q2 2028</p>
-            <p class="milestone"><b>Expected REC
-            Transition:</b>June 2028</p>
+            <p class="milestone"><b>Expected REC Transition:</b>June 2028</p>
             <p><b>Adopted Draft:</b> This will be a further
             iteration of the current <i>Web of Things (WoT) Thing
             Description</i> specification published at <a href=


### PR DESCRIPTION
Done during the TD call. However, the final date can change as the charter's start date is expected to move a bit (~august 2026)