### PR TITLE
style: minor charter wg 2026 style issues

### DIFF
--- a/charters/wot-wg-2026.html
+++ b/charters/wot-wg-2026.html
@@ -434,7 +434,7 @@
 
 		  <dt id="wot-primer-deliverable" class="spec">WoT Primer and Best Practice</dt>
           <dd>
-            <p>Document supporting developers in designing WoT‑based applications, including the combination of AI techniques and tooling (e.g, AI Agents and MCP).</p>
+            <p>Document supporting developers in designing WoT‑based applications, including the combination of AI techniques and tooling (e.g., AI Agents and MCP).</p>
             <p class="draft-status"><b>Draft state: </b>No draft</p>
             <p class="milestone"><b>Expected completion:</b> Q4 2027</p>
 			</p>
@@ -573,7 +573,7 @@ interoperability can be verified by passing open test suites. In order to advanc
 
 	  <p id="a11y-section">
 		Each specification should contain a section on accessibility that describes the benefits and impacts, including ways specification features can be used to address them, and
-		recommendations for maximising accessibility in implementations.</p>
+		recommendations for maximizing accessibility in implementations.</p>
 
     <!-- W3C Statements and Web Platform Design Principles -->
     <p>This group is expected to be guided by the following documents:</p>

--- a/charters/wot-wg-2026.html
+++ b/charters/wot-wg-2026.html
@@ -294,10 +294,10 @@
             implementation.</p>
             <p class="draft-status"><b>Draft state: </b> <a href=
             "https://www.w3.org/TR/wot-thing-description-2.0/">FPWD</a></p>
-            <p class="milestone"><b>Expected CR Transition:</b>Q4 2027</p>
-            <p class="milestone"><b>Expected PR Transition:</b>Q2 2028</p>
+            <p class="milestone"><b>Expected CR Transition: </b>Q4 2027</p>
+            <p class="milestone"><b>Expected PR Transition: </b>Q2 2028</p>
             <p class="milestone"><b>Expected REC
-            Transition:</b>June 2028</p>
+            Transition:</b> June 2028</p>
             <p><b>Adopted Draft:</b> This will be a further
             iteration of the current <i>Web of Things (WoT) Thing
             Description</i> specification published at <a href=
@@ -367,7 +367,7 @@
 				of use for the developers. </p>
             <p class="draft-status"><b>Draft state: </b> <a href=
             "https://w3c.github.io/wot-binding-registry/">Draft Registry</a></p>
-            <p class="milestone"><b>Expected completion:</b>Q1 2027</p>
+            <p class="milestone"><b>Expected completion:</b> Q1 2027</p>
 			</p>
           </dd>
         </section>
@@ -409,7 +409,7 @@
           the main topic.</p>
             <p class="draft-status"><b>Draft state: </b> <a href=
             "https://www.w3.org/TR/wot-scripting-api/">Group Note</a></p>
-            <p class="milestone"><b>Expected completion:</b>Q3 2027</p>
+            <p class="milestone"><b>Expected completion:</b> Q3 2027</p>
 			</p>
           </dd>
 
@@ -419,7 +419,7 @@
 				with the WoT Thing Description 2.0 specification. </p>
             <p class="draft-status"><b>Draft state: </b> <a href=
             "https://www.w3.org/TR/wot-usecases/">Group Note</a></p>
-            <p class="milestone"><b>Expected completion:</b>Q3 2027</p>
+            <p class="milestone"><b>Expected completion:</b> Q3 2027</p>
 			</p>
           </dd>
 
@@ -428,7 +428,7 @@
             <p>The group will continuously maintain the WoT Security and Privacy Guidelines and maintain alignment with other deliverables, including the WoT Thing Description 2.0 specification.</p>
             <p class="draft-status"><b>Draft state: </b> <a href=
             "https://www.w3.org/TR/wot-security/">Group Note</a></p>
-            <p class="milestone"><b>Expected completion:</b>Q1 2028</p>
+            <p class="milestone"><b>Expected completion:</b> Q1 2028</p>
 			</p>
           </dd>
 
@@ -436,7 +436,7 @@
           <dd>
             <p>Document supporting developers in designing WoT‑based applications, including the combination of AI techniques and tooling (e.g, AI Agents and MCP).</p>
             <p class="draft-status"><b>Draft state: </b>No draft</p>
-            <p class="milestone"><b>Expected completion:</b>Q4 2027</p>
+            <p class="milestone"><b>Expected completion:</b> Q4 2027</p>
 			</p>
           </dd>
  
@@ -445,7 +445,7 @@
             <p>Official WoT binding for HTTP</p>
             <p class="draft-status"><b>Draft state: </b> <a href=
             "https://w3c.github.io/wot-binding-templates/bindings/protocols/http/">Editors Draft</a></p>
-            <p class="milestone"><b>Expected completion:</b>Q4 2026</p>
+            <p class="milestone"><b>Expected completion:</b> Q4 2026</p>
 			</p>
           </dd>
 
@@ -454,7 +454,7 @@
             <p>Official WoT binding for MQTT</p>
             <p class="draft-status"><b>Draft state: </b> <a href=
             "https://w3c.github.io/wot-binding-templates/bindings/protocols/mqtt/index.html">Editors Draft</a></p>
-            <p class="milestone"><b>Expected completion:</b>Q4 2026</p>
+            <p class="milestone"><b>Expected completion:</b> Q4 2026</p>
 			</p>
           </dd>
 
@@ -463,7 +463,7 @@
             <p>Official WoT binding for Modbus</p>
             <p class="draft-status"><b>Draft state: </b> <a href=
             "https://w3c.github.io/wot-binding-templates/bindings/protocols/modbus/">Editors Draft</a></p>
-            <p class="milestone"><b>Expected completion:</b>Q4 2026</p>
+            <p class="milestone"><b>Expected completion:</b> Q4 2026</p>
 			</p>
           </dd>
 
@@ -472,7 +472,7 @@
             <p>Official WoT binding for BACnet</p>
             <p class="draft-status"><b>Draft state: </b> <a href=
             "https://w3c.github.io/wot-binding-templates/bindings/protocols/bacnet/index.html">Editors Draft</a></p>
-            <p class="milestone"><b>Expected completion:</b>Q4 2026</p>
+            <p class="milestone"><b>Expected completion:</b> Q4 2026</p>
 			</p>
           </dd>
 
@@ -481,7 +481,7 @@
             <p>Official WoT binding for CoAP</p>
             <p class="draft-status"><b>Draft state: </b> <a href=
             "https://w3c.github.io/wot-binding-templates/bindings/protocols/coap/index.html">Editors Draft</a></p>
-            <p class="milestone"><b>Expected completion:</b>Q4 2026</p>
+            <p class="milestone"><b>Expected completion:</b> Q4 2026</p>
 			</p>
           </dd>
 
@@ -490,7 +490,7 @@
             <p>Official WoT binding for PROFINET</p>
             <p class="draft-status"><b>Draft state: </b> <a href=
             "https://w3c.github.io/wot-binding-templates/bindings/protocols/profinet/">Editors Draft</a></p>
-            <p class="milestone"><b>Expected completion:</b>Q4 2026</p>
+            <p class="milestone"><b>Expected completion:</b> Q4 2026</p>
 			</p>
           </dd>
 
@@ -498,7 +498,7 @@
           <dd>
             <p>Official WoT binding for LoRaWAN</p>
             <p class="draft-status"><b>Draft state: </b>No Draft</p>
-            <p class="milestone"><b>Expected completion:</b>Q4 2026</p>
+            <p class="milestone"><b>Expected completion:</b> Q4 2026</p>
 			</p>
           </dd>				
 


### PR DESCRIPTION
Fixes some style issues like

* minor typos w.r.t. American English
* no space after the colon (which looks strange in the rendered version)
